### PR TITLE
perf: rank a candidate set in one statement instead of one per candidate

### DIFF
--- a/src/modules/db2/c/db_postgres.c
+++ b/src/modules/db2/c/db_postgres.c
@@ -1151,6 +1151,26 @@ int db2_pg_conninfo_with_bounds(const char *conninfo, char *out, size_t out_sz)
    return 0;
 }
 
+/* Statement counter for the test-only $(OBJDIR)/db2/ object namespace, so the
+ * SAME test can assert round-trip count against real libpq as against the
+ * sqlite shim. Never defined for a production build: tests/Rules.mk sets
+ * AIMEE_PG_STMT_COUNTER on that object alone, the way it already sets
+ * AIMEE_TEST_PG_BACKEND on db2_test_shim.o. */
+#ifdef AIMEE_PG_STMT_COUNTER
+static long s_pg_stmt_count = 0;
+void aimee_pg_test_stmt_count_reset(void)
+{
+   s_pg_stmt_count = 0;
+}
+long aimee_pg_test_stmt_count(void)
+{
+   return s_pg_stmt_count;
+}
+#define AIMEE_PG_STMT_TICK() (s_pg_stmt_count++)
+#else
+#define AIMEE_PG_STMT_TICK() ((void)0)
+#endif
+
 #ifdef AIMEE_DISABLE_POSTGRES
 
 /* Build-time opt-out for platforms where libpq isn't available (mostly
@@ -1213,6 +1233,7 @@ aimee_pg_stmt_t *aimee_pg_prepare(void *c, const char *s, char *e, size_t n)
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *c, const char *s, aimee_pg_prepare_error_t *kind,
                                      char *e, size_t n)
 {
+   AIMEE_PG_STMT_TICK();
    (void)c;
    (void)s;
    if (kind)
@@ -1582,6 +1603,7 @@ aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, 
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *pg_conn, const char *sql, aimee_pg_prepare_error_t *kind,
                                      char *errbuf, size_t errlen)
 {
+   AIMEE_PG_STMT_TICK();
    if (kind)
       *kind = AIMEE_PG_PREPARE_INVALID;
    if (!pg_conn || !sql)

--- a/src/modules/db2/c/memory_scope_query.c
+++ b/src/modules/db2/c/memory_scope_query.c
@@ -13,6 +13,10 @@
 
 #define MSQ_ERRBUF 256
 
+/* Ids per IN(...) statement. Bounds the placeholder buffer; a longer candidate
+ * list is split across statements rather than truncated. */
+#define MSQ_RANK_BATCH_CHUNK 128
+
 static __thread db2_memory_scope_context_t s_memory_scope_context;
 
 /* Keep PostgreSQL RLS in lockstep with the in-process filter.  These values are
@@ -86,6 +90,29 @@ void db2_memory_scope_context_get(db2_memory_scope_context_t *out)
       *out = s_memory_scope_context;
 }
 
+/* The visibility rank, expressed once. The single-id and batch readers below
+ * both call this: two copies of a four-level visibility ladder is how a store
+ * starts disagreeing with itself about who can see what. */
+static int msq_rank_for(const char *type, const char *value)
+{
+   if (!type || !value)
+      return 0;
+   if (s_memory_scope_context.scope_type[0] && s_memory_scope_context.scope_value[0] &&
+       strcmp(type, s_memory_scope_context.scope_type) == 0 &&
+       strcmp(value, s_memory_scope_context.scope_value) == 0)
+      return 4;
+   if (strcmp(type, "project") == 0 && s_memory_scope_context.project[0] &&
+       strcmp(value, s_memory_scope_context.project) == 0)
+      return 3;
+   if (strcmp(type, "workspace") == 0 && s_memory_scope_context.workspace[0] &&
+       strcmp(value, s_memory_scope_context.workspace) == 0)
+      return 2;
+   if ((strcmp(type, "global") == 0 && strcmp(value, "_global") == 0) ||
+       (strcmp(type, "workspace") == 0 && strcmp(value, "_shared") == 0))
+      return 1;
+   return 0;
+}
+
 int db2_memory_scope_context_rank(int64_t memory_id)
 {
    if (memory_id <= 0)
@@ -101,28 +128,67 @@ int db2_memory_scope_context_rank(int64_t memory_id)
    aimee_pg_bind_int64(st, "?1", memory_id);
    int rank = 0;
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
-   {
-      const char *type = aimee_pg_column_text(st, 0);
-      const char *value = aimee_pg_column_text(st, 1);
-      if (type && value && s_memory_scope_context.scope_type[0] &&
-          s_memory_scope_context.scope_value[0] &&
-          strcmp(type, s_memory_scope_context.scope_type) == 0 &&
-          strcmp(value, s_memory_scope_context.scope_value) == 0)
-         rank = 4;
-      else if (type && value && strcmp(type, "project") == 0 && s_memory_scope_context.project[0] &&
-               strcmp(value, s_memory_scope_context.project) == 0)
-         rank = 3;
-      else if (type && value && strcmp(type, "workspace") == 0 &&
-               s_memory_scope_context.workspace[0] &&
-               strcmp(value, s_memory_scope_context.workspace) == 0)
-         rank = 2;
-      else if (type && value &&
-               ((strcmp(type, "global") == 0 && strcmp(value, "_global") == 0) ||
-                (strcmp(type, "workspace") == 0 && strcmp(value, "_shared") == 0)))
-         rank = 1;
-   }
+      rank = msq_rank_for(aimee_pg_column_text(st, 0), aimee_pg_column_text(st, 1));
    aimee_pg_finalize(st);
    return rank;
+}
+
+/* Batch form of the above: ONE statement for the whole candidate set instead of
+ * one per candidate. The ranking is thread-local scope context plus two strings
+ * per row, so the per-id work was never the cost -- the round trip was, and a
+ * recall ranks every candidate it is about to sort.
+ *
+ * Chunked so an arbitrarily long candidate list cannot overflow the placeholder
+ * buffer. Ids absent from `memories` keep rank 0, matching the single-id reader
+ * when its query returns no row. */
+int db2_memory_scope_context_rank_batch(const int64_t *ids, int n, int *out_ranks)
+{
+   if (!ids || n <= 0 || !out_ranks)
+      return 0;
+   for (int i = 0; i < n; i++)
+      out_ranks[i] = 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+
+   int ranked = 0;
+   for (int base = 0; base < n; base += MSQ_RANK_BATCH_CHUNK)
+   {
+      int chunk = n - base < MSQ_RANK_BATCH_CHUNK ? n - base : MSQ_RANK_BATCH_CHUNK;
+      char placeholders[MSQ_RANK_BATCH_CHUNK * 8];
+      int pos = 0;
+      for (int i = 0; i < chunk; i++)
+         pos += snprintf(placeholders + pos, sizeof(placeholders) - (size_t)pos,
+                         i == 0 ? "?%d" : ",?%d", i + 1);
+      char sql[sizeof(placeholders) + 128];
+      snprintf(sql, sizeof(sql), "SELECT id,scope_type,scope_value FROM memories WHERE id IN (%s)",
+               placeholders);
+
+      char err[MSQ_ERRBUF] = "";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+      if (!st)
+         return ranked;
+      for (int i = 0; i < chunk; i++)
+      {
+         char name[16];
+         snprintf(name, sizeof(name), "?%d", i + 1);
+         aimee_pg_bind_int64(st, name, ids[base + i]);
+      }
+      while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         int64_t row_id = aimee_pg_column_int64(st, 0);
+         int rank = msq_rank_for(aimee_pg_column_text(st, 1), aimee_pg_column_text(st, 2));
+         /* A candidate list may repeat an id; rank every position holding it. */
+         for (int i = 0; i < chunk; i++)
+            if (ids[base + i] == row_id)
+            {
+               out_ranks[base + i] = rank;
+               ranked++;
+            }
+      }
+      aimee_pg_finalize(st);
+   }
+   return ranked;
 }
 
 int db2_memory_scope_context_allows(int64_t memory_id)

--- a/src/modules/db2/c/memory_scope_query.h
+++ b/src/modules/db2/c/memory_scope_query.h
@@ -55,6 +55,11 @@ void db2_memory_scope_context_restore(const db2_memory_scope_context_t *context)
 void db2_memory_scope_context_clear(void);
 void db2_memory_scope_context_get(db2_memory_scope_context_t *out);
 int db2_memory_scope_context_rank(int64_t memory_id);
+
+/* Rank every id in one statement instead of one per id. out_ranks must hold n
+ * ints; an id with no row keeps rank 0. Returns the number of positions
+ * ranked. Prefer this wherever a whole candidate set is being ranked. */
+int db2_memory_scope_context_rank_batch(const int64_t *ids, int n, int *out_ranks);
 int db2_memory_scope_context_allows(int64_t memory_id);
 void db2_memory_scope_bind_current(aimee_pg_stmt_t *st);
 

--- a/src/modules/memory/memory_core_search_c.c
+++ b/src/modules/memory/memory_core_search_c.c
@@ -41,6 +41,11 @@
 #include <unistd.h>
 #include <pthread.h>
 
+/* Stack bound for id arrays handed to the batched rank reader. Sized to the
+ * rerank buffer; a wider set falls back to the single-id reader for the tail
+ * rather than growing the frame. */
+#define MEMORY_SCOPE_RANK_PROBE_MAX 96
+
 static int memory_collect_graph_candidates(const char *raw_query, const char *norm_query,
                                            int fetch_limit, memory_t *out, int count, int max,
                                            memory_candidate_source_t *source_stats,
@@ -980,8 +985,18 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
 
 static void memory_sort_scope_buckets(memory_t *matches, int count, int *scope_rank)
 {
-   for (int i = 0; i < count; i++)
-      scope_rank[i] = db2_memory_scope_context_rank(matches[i].id);
+   /* One statement for the whole set: this ranks every candidate about to be
+    * sorted, so a per-candidate reader made the round trips scale with recall
+    * width. */
+   {
+      int64_t rank_ids[MEMORY_SCOPE_RANK_PROBE_MAX];
+      int probe = count < MEMORY_SCOPE_RANK_PROBE_MAX ? count : MEMORY_SCOPE_RANK_PROBE_MAX;
+      for (int i = 0; i < probe; i++)
+         rank_ids[i] = matches[i].id;
+      db2_memory_scope_context_rank_batch(rank_ids, probe, scope_rank);
+      for (int i = probe; i < count; i++)
+         scope_rank[i] = db2_memory_scope_context_rank(matches[i].id);
+   }
    /* Stable insertion sort: relevance ordering from the reranker is retained
     * inside each hard visibility bucket. */
    for (int i = 1; i < count; i++)
@@ -1093,10 +1108,22 @@ int memory_find_facts_visible_ex(const char *query, const char *workspace, const
          db2_memory_scope_context_clear();
       return -1;
    }
+   /* Rank the pool in one statement before the filter loop: this runs on every
+    * scoped recall, over the full candidate pool, and a per-candidate reader
+    * made its round trips scale with pool width. */
+   int pool_ranks[MEMORY_RERANK_BUFFER];
+   {
+      int64_t rank_ids[MEMORY_RERANK_BUFFER];
+      int probe = count < MEMORY_RERANK_BUFFER ? count : MEMORY_RERANK_BUFFER;
+      for (int i = 0; i < probe; i++)
+         rank_ids[i] = candidates[i].id;
+      db2_memory_scope_context_rank_batch(rank_ids, probe, pool_ranks);
+   }
    int kept = 0;
    for (int i = 0; i < count; i++)
    {
-      int rank = db2_memory_scope_context_rank(candidates[i].id);
+      int rank = i < MEMORY_RERANK_BUFFER ? pool_ranks[i]
+                                          : db2_memory_scope_context_rank(candidates[i].id);
       if (rank <= 0 && !include_all)
       {
          memory_recall_trace_reject(candidates[i].id, "candidate", "scope_boundary");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -33,6 +33,10 @@ DB2_TEST_BACKEND_LIB = $(PQ_LIB)
 # wanted sqlite", which are otherwise the same code path and abort identically.
 # Target-specific so only the shim sees it, rather than redefining every object.
 $(OBJDIR)/db2/db2_test_shim.o: C_FLAGS += -DAIMEE_TEST_PG_BACKEND=1
+# The round-trip counter the batching tests assert on. The sqlite shim carries it
+# unconditionally (it is test-only); the libpq layer is also production code, so
+# it compiles the counter only for this test-only object.
+$(OBJDIR)/db2/db_postgres.o: C_FLAGS += -DAIMEE_PG_STMT_COUNTER=1
 endif
 
 

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -768,6 +768,19 @@ int aimee_pg_exec_with_changes(void *pg_conn, const char *sql, char *errbuf, siz
 
 /* --- Statements --- */
 
+/* Statement counter, test-only. Round-trip COUNT is what a batching regression
+ * changes, and unlike a timing assertion it is deterministic: no clock, no load
+ * sensitivity, and it fails the same way on every machine. */
+static long s_stmt_count = 0;
+void aimee_pg_test_stmt_count_reset(void)
+{
+   s_stmt_count = 0;
+}
+long aimee_pg_test_stmt_count(void)
+{
+   return s_stmt_count;
+}
+
 aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
 {
    return aimee_pg_prepare_ex(pg_conn, sql, NULL, errbuf, errlen);
@@ -776,6 +789,7 @@ aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, 
 aimee_pg_stmt_t *aimee_pg_prepare_ex(void *pg_conn, const char *sql, aimee_pg_prepare_error_t *kind,
                                      char *errbuf, size_t errlen)
 {
+   s_stmt_count++;
    if (kind)
       *kind = AIMEE_PG_PREPARE_INVALID;
    sqlite3 *db = (sqlite3 *)pg_conn;

--- a/src/tests/test_workspace_memory.c
+++ b/src/tests/test_workspace_memory.c
@@ -788,8 +788,77 @@ static void test_api_memory_stats_includes_functional_tiers(void)
    teardown();
 }
 
+/* ---------------------------------------------------------------------------
+ * Ranking a candidate set must cost ONE statement, not one per candidate.
+ *
+ * Two assertions, and the first matters more: the batch reader must agree with
+ * the single-id reader on every id. This is a visibility ladder -- a batch form
+ * that ranks even one row differently silently changes who can see what, and
+ * that would be a far worse bug than the latency it set out to fix.
+ *
+ * The second asserts round-trip COUNT rather than elapsed time: deterministic,
+ * no clock, no load sensitivity, and it fails identically on every machine.
+ */
+void aimee_pg_test_stmt_count_reset(void);
+long aimee_pg_test_stmt_count(void);
+
+static void test_scope_rank_batch_matches_single_and_costs_one_statement(void)
+{
+   setup();
+   db2_memory_scope_context_set("active-workspace", "active-project", 0);
+
+   /* One memory per rank tier, plus an unscoped row and an id that does not
+    * exist -- the two cases a naive IN(...) batch gets wrong. */
+   memory_t proj, ws, shared, plain;
+   memory_insert(TIER_L2, KIND_FACT, "rb-proj", "batch rank project row", 0.9, "s", &proj);
+   memory_insert(TIER_L2, KIND_FACT, "rb-ws", "batch rank workspace row", 0.9, "s", &ws);
+   memory_insert(TIER_L2, KIND_FACT, "rb-shared", "batch rank shared row", 0.9, "s", &shared);
+   memory_insert(TIER_L2, KIND_FACT, "rb-plain", "batch rank unscoped row", 0.9, "s", &plain);
+   assert(memory_tag_project(proj.id, "active-project") == 0);
+   assert(memory_tag_workspace(ws.id, "active-workspace") == 0);
+   assert(memory_tag_workspace(shared.id, SHARED_WORKSPACE) == 0);
+
+   int64_t ids[6];
+   ids[0] = proj.id;
+   ids[1] = ws.id;
+   ids[2] = shared.id;
+   ids[3] = plain.id;
+   ids[4] = proj.id;         /* a repeated id must rank at BOTH positions */
+   ids[5] = plain.id + 9999; /* absent from `memories` -> rank 0 */
+
+   int single[6];
+   for (int i = 0; i < 6; i++)
+      single[i] = db2_memory_scope_context_rank(ids[i]);
+
+   int batch[6];
+   aimee_pg_test_stmt_count_reset();
+   db2_memory_scope_context_rank_batch(ids, 6, batch);
+   long batch_stmts = aimee_pg_test_stmt_count();
+
+   /* Equivalence: identical verdict for every position, repeats and misses too. */
+   for (int i = 0; i < 6; i++)
+      assert(batch[i] == single[i]);
+   assert(batch[5] == 0);        /* absent id */
+   assert(batch[0] == batch[4]); /* repeated id ranked twice */
+
+   /* Cost: one statement for six ids, not six. */
+   assert(batch_stmts == 1);
+
+   /* And the single-id reader really is the per-id shape being replaced, so the
+    * saving is proportional to the candidate set rather than a constant. */
+   aimee_pg_test_stmt_count_reset();
+   for (int i = 0; i < 6; i++)
+      (void)db2_memory_scope_context_rank(ids[i]);
+   assert(aimee_pg_test_stmt_count() == 6);
+
+   db2_memory_scope_context_clear();
+   teardown();
+   printf("  PASS: test_scope_rank_batch_matches_single_and_costs_one_statement\n");
+}
+
 int main(void)
 {
+   test_scope_rank_batch_matches_single_and_costs_one_statement();
    test_tag_workspace();
    test_tag_generic_scope();
    test_tag_multiple_workspaces();

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -19042,7 +19042,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_scope_query.h",
-          "line": 59
+          "line": 64
         }
       ],
       "signature": "void db2_memory_scope_bind_current ( aimee_pg_stmt_t * st )",
@@ -19055,7 +19055,7 @@
       "locations": [
         {
           "header": "src/modules/db2/c/memory_scope_query.h",
-          "line": 58
+          "line": 63
         }
       ],
       "signature": "int db2_memory_scope_context_allows ( int64_t memory_id )",
@@ -19134,6 +19134,22 @@
       "signature_sha256": "284878b4cdc500db2a5e7288465e3522ff5481857669ffec3f8ddaf7c0de5845",
       "status": "reviewed",
       "symbol": "db2_memory_scope_context_rank"
+    },
+    {
+      "consumers": [
+        "src/modules/memory/memory_core_search_c.c",
+        "src/tests/test_workspace_memory.c"
+      ],
+      "locations": [
+        {
+          "header": "src/modules/db2/c/memory_scope_query.h",
+          "line": 62
+        }
+      ],
+      "signature": "int db2_memory_scope_context_rank_batch ( const int64_t * ids , int n , int * out_ranks )",
+      "signature_sha256": "869d561d1b609e2cd140ab99a45f58cb08ab768e957bac3787c253d2e73679aa",
+      "status": "audit-pending",
+      "symbol": "db2_memory_scope_context_rank_batch"
     },
     {
       "consumers": [
@@ -26977,12 +26993,12 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "e98dead41d00ccefb2abf9f926e62d8aee02651f942d5509c7b3cded7138cb9d",
+  "fingerprint": "bf6745c02bf34dd024aad373402089d4db6b14b1c4e2bfea8866d9779fc13f02",
   "module": "db2",
   "schema_version": 1,
   "summary": {
-    "audit_pending": 737,
-    "declarations": 1487,
+    "audit_pending": 738,
+    "declarations": 1488,
     "headers": 143,
     "internal_unconsumed": 172,
     "private_test_only": 284,


### PR DESCRIPTION
For 0.4.0. One confirmed N+1 in the recall path, fixed and covered by a local test. No production data involved anywhere.

## What was wrong

The four-level visibility ladder was read **one memory at a time**. Both recall paths that use it — `memory_sort_scope_buckets` and the scoped-recall filter loop — called `db2_memory_scope_context_rank()` inside a loop over the candidate pool, so **a recall's round trips scaled with its own width**.

The ranking itself is thread-local scope context compared against two strings per row. The per-id work was never the cost; the round trip was.

## The fix

`db2_memory_scope_context_rank_batch()` reads the whole set in one statement, following the `IN(?1,?2,...)` placeholder shape `db2_memory_filter_archived_ids` already uses. Chunked at 128 ids so a long candidate list is split across statements rather than truncated or overflowing the buffer.

The ladder is now expressed **once**, in `msq_rank_for()`, called by both readers. Two copies of a visibility ladder is how a store starts disagreeing with itself about who can see what.

## The test — local, deterministic, no production data

Two assertions, and the first matters more:

- **Equivalence.** Batch and single must return the identical verdict for every position, including a repeated id and an id that doesn't exist. A batch form that ranks one row differently silently changes who can see what — worse than the latency it set out to fix.
- **Cost.** Six ids cost one statement; the single-id reader costs six. So the saving is proportional to the candidate set, not a constant.

It asserts **round-trip count, not elapsed time**: deterministic, no clock, no load sensitivity, fails identically on every machine. The counter is a test-only facility on the sqlite shim.

Verified red/green — regressing the batch reader to an internal per-id loop fails the count assertion.

## What I deliberately did NOT do

**The graph frontier N+1.** `memory_graph_expand_from_seeds` issues one `db2_entity_edge_neighbors_weighted()` call per frontier node, inside the hop loop — the larger of the two pathologies.

`db2_entity_edge_two_hop_neighbors()` already does two-hop expansion in one round trip and **has no production callers**. But it doesn't return `utility_score`, and `memory_fusion_utility_scoring()` defaults on — so it is not a drop-in, and swapping it would change ranking inputs.

Closing it properly needs either the CTE extended to carry utility, or a batched neighbour reader keyed by several sources — plus recall-quality evidence that ranking is unchanged. That's a real piece of work on a retrieval-quality path, not something to rush in alongside this.

## Verification

Full build of all binaries and the server. **All 69 lint checks pass.** `workspace-memory`, `memory-lanes`, `memory-filter`, `graph-scoring` and `harness-memory-scope` all pass. `tests/baselines/db2/declarations-v1.json` regenerated via its own generator, since the new reader changes the surface it tracks.