### PR TITLE
fix(tests): repair four failures a real-host validation run exposed

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -53,6 +53,14 @@ DB2_TEST_BACKEND_STAMP = \
 $(DB2_TEST_BACKEND_STAMP):
 	@mkdir -p $(dir $@) && rm -f $(OBJDIR)/tests/.db2-test-backend-* && touch $@
 $(OBJDIR)/db2/db2_test_shim.o: $(DB2_TEST_BACKEND_STAMP)
+# db_postgres.o carries a mode-dependent define too (AIMEE_PG_STMT_COUNTER above),
+# and seven recipes name it explicitly, so a sqlite run builds it WITHOUT the
+# counter. Flipping to pg then rebuilds nothing -- the source is untouched -- and
+# every batching test fails to link with an undefined reference to
+# aimee_pg_test_stmt_count. CI never sees this because it builds one backend in a
+# fresh tree; running both modes in one OBJDIR is what finds it. Same stamp, same
+# reason as the shim above.
+$(OBJDIR)/db2/db_postgres.o: $(DB2_TEST_BACKEND_STAMP)
 
 # Test output prefix: defaults to $(OBJDIR)/tests so any `make unit-tests`
 # invocation with a non-default OBJDIR (sanitizers, coverage, build-integrity,

--- a/src/tests/test_audit_worm.c
+++ b/src/tests/test_audit_worm.c
@@ -1,7 +1,10 @@
 /* test_audit_worm.c: S0 WORM audit store — chain integrity, gap-free seq,
  * WORM triggers, cross-store determinism, and crypto tamper detection. */
 #include <assert.h>
+#include <dirent.h>
 #include <fcntl.h>
+#include <linux/fs.h> /* FS_IOC_GETFLAGS/SETFLAGS, FS_IMMUTABLE_FL */
+#include <sys/ioctl.h>
 #include <sqlite3.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,6 +21,74 @@ static void mk_tmpdir(void)
 {
    snprintf(g_dir, sizeof g_dir, "%s/worm_test_XXXXXX", platform_tmpdir());
    assert(mkdtemp(g_dir) != NULL);
+}
+
+/* audit_worm_seal() makes each sealed snapshot OS-immutable, which is the point
+ * of a WORM store -- and it means this test cannot simply leave its directory
+ * behind. Where the process holds CAP_LINUX_IMMUTABLE the seal really takes, and
+ * nothing (not even root) can unlink the file until FS_IMMUTABLE_FL is cleared:
+ * the suite's own tmpdir cleanup then fails with "Operation not permitted" and
+ * takes the whole run down with it. CI containers usually lack the capability,
+ * so the seal degrades to crypto-only there and the leak stays invisible until
+ * the suite runs somewhere privileged.
+ *
+ * Unseal what we sealed, then remove the directory. Best-effort throughout: a
+ * filesystem without the flag, or a process without the capability, never sealed
+ * anything in the first place. */
+static void unseal(const char *path)
+{
+   int fd = open(path, O_RDONLY);
+   if (fd < 0)
+      return;
+   int flags = 0;
+   if (ioctl(fd, FS_IOC_GETFLAGS, &flags) == 0 && (flags & FS_IMMUTABLE_FL))
+   {
+      flags &= ~FS_IMMUTABLE_FL;
+      (void)ioctl(fd, FS_IOC_SETFLAGS, &flags);
+   }
+   close(fd);
+}
+
+static void rm_tmpdir(void)
+{
+   if (!g_dir[0])
+      return;
+   DIR *d = opendir(g_dir);
+   if (d)
+   {
+      struct dirent *e;
+      while ((e = readdir(d)) != NULL)
+      {
+         if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
+            continue;
+         char child[512];
+         snprintf(child, sizeof child, "%s/%s", g_dir, e->d_name);
+         unseal(child);
+         if (remove(child) != 0)
+         {
+            /* A nested directory: the audit/ subdir the sealed snapshots live in. */
+            DIR *sub = opendir(child);
+            if (sub)
+            {
+               struct dirent *se;
+               while ((se = readdir(sub)) != NULL)
+               {
+                  if (strcmp(se->d_name, ".") == 0 || strcmp(se->d_name, "..") == 0)
+                     continue;
+                  char leaf[1024];
+                  snprintf(leaf, sizeof leaf, "%s/%s", child, se->d_name);
+                  unseal(leaf);
+                  (void)remove(leaf);
+               }
+               closedir(sub);
+               (void)rmdir(child);
+            }
+         }
+      }
+      closedir(d);
+   }
+   (void)rmdir(g_dir);
+   g_dir[0] = '\0';
 }
 
 static void db_path(char *out, size_t n)
@@ -392,6 +463,7 @@ static void test_cross_engine_vector(void)
 int main(void)
 {
    mk_tmpdir();
+   assert(atexit(rm_tmpdir) == 0);
    test_cross_engine_vector();
    test_metric_snapshot();
    test_detail_capped();

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -12,6 +12,10 @@
 
 /* --- stubs for agent exec functions --- */
 
+/* Deadline for test_roundtable_deadline_returns_best_so_far. Paired with the
+ * g_parallel_mode == 4 sleep below, which must be comfortably longer. */
+#define ROUNDTABLE_DEADLINE_TEST_MS 200
+
 static int g_parallel_mode = 0; /* 0=all, 1=only-first, 9=last-fails, 10=first-fails,
                                  * 11=first seat fails only on the first fan-out */
 static int g_aggregator_mode = 0;
@@ -114,7 +118,10 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
    }
    if (g_parallel_mode == 4)
    {
-      struct timespec ts = {0, 3000000};
+      /* Must outlast ROUNDTABLE_DEADLINE_TEST_MS by enough that the post-panel
+       * deadline check cannot miss, however the scheduler behaves. See the
+       * comment on that constant. */
+      struct timespec ts = {0, 400000000};
       nanosleep(&ts, NULL);
    }
    for (int i = 0; i < count; i++)
@@ -1909,9 +1916,19 @@ static void test_roundtable_deadline_returns_best_so_far(void)
    opts.mode = ROUNDTABLE_DRAFT;
    opts.turns = ROUNDTABLE_PARALLEL;
    /* One round exercises the post-panel deadline capture: there is no next
-    * loop-top check to set deadline_hit for us. */
+    * loop-top check to set deadline_hit for us.
+    *
+    * The deadline has to sit in a window: ABOVE whatever wall clock passes
+    * between the run starting and the loop-top check (delegate_ensemble.c
+    * breaks there with rounds_run still 0 if the deadline has already gone),
+    * and BELOW the panel's duration, so the check after the panel does fire.
+    * At deadline_ms=1 the lower bound was a scheduling accident -- on a loaded
+    * box the loop-top check lost the race and this asserted rounds_run == 1
+    * against a run that never got to round one. 200ms tolerates any plausible
+    * scheduling delay; the mock panel sleeps twice that, so the upper bound
+    * holds by construction rather than by timing luck. */
    opts.max_rounds = 1;
-   opts.deadline_ms = 1;
+   opts.deadline_ms = ROUNDTABLE_DEADLINE_TEST_MS;
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, "draft until deadline", &opts, &result);
    assert(rc == 0);

--- a/src/tests/test_kb_metrics_listener.c
+++ b/src/tests/test_kb_metrics_listener.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
@@ -177,6 +178,18 @@ static void test_unix_lifecycle(void)
 
 int main(void)
 {
+   /* kb_metrics_listener writes responses with plain write(2), which raises
+    * SIGPIPE when a scrape client hangs up mid-response. That is safe in the
+    * real service because kb_main.c ignores SIGPIPE process-wide before any
+    * listener starts (see the comment at its signal(SIGPIPE, SIG_IGN)), and the
+    * listener is written against that contract.
+    *
+    * This binary links the listener WITHOUT kb_main, so it inherited the default
+    * disposition and died of SIGPIPE instead of failing an assertion: under
+    * parallel load the suite saw a bare exit 141, no message, roughly one run in
+    * five. Reproduce the process contract the component depends on. */
+   signal(SIGPIPE, SIG_IGN);
+
    test_disabled_and_fail_closed();
    test_loopback_bearer();
    test_unix_lifecycle();


### PR DESCRIPTION
Found by building and running the suite on a loaded 8-core box against a real **PostgreSQL 18.6**, rather than on a CI runner. Each of these is invisible to CI for a structural reason — which is why they survived.

## 1. `db_postgres.o` kept a stale backend across a mode flip

`unit-tests-pg` failed to link every batching test: `undefined reference to aimee_pg_test_stmt_count`.

The counter is compiled into `$(OBJDIR)/db2/db_postgres.o` by a target-specific `-DAIMEE_PG_STMT_COUNTER=1` under `AIMEE_TEST_PG=1`. That object had **no dependency on the backend stamp**, and seven recipes name it explicitly — so a sqlite run builds it *without* the counter, and flipping to pg rebuilds nothing, because the source and headers are untouched. The flag change is invisible to make.

That is exactly the hazard the stamp already existed for: `db2_test_shim.o` had the dependency, `db_postgres.o` did not. It cuts both ways — a pg-built object leaking into a sqlite run is the same bug mirrored — and the stamp catches both, since flipping modes deletes one stamp and creates the other.

**CI builds one backend in a fresh tree and never flips, so it cannot see this.** Verified red/green in a single tree:

| | counter symbols |
|---|---|
| sqlite build | 0 |
| flip to pg, **without** fix | 0 ← bug |
| flip to pg, **with** fix | 2 |

## 2. The WORM test sealed files it could not delete

`audit_worm_seal()` sets `FS_IMMUTABLE_FL` — the point of a WORM store. The test never cleared it and never removed its directory, so the suite's own tmpdir cleanup died with `Operation not permitted` and took the whole run down **after every test had already passed**.

CI containers usually lack `CAP_LINUX_IMMUTABLE`, so the seal degrades to crypto-only and the leak stays invisible; running as root is what finds it. Added a teardown that unseals what it sealed. Verified as root where the seal really takes: `immutable=1`, directories before 0 → after 0.

## 3. The metrics listener test died of SIGPIPE

Bare **exit 141**, no assertion, no message — roughly one run in five under parallel load, which reads as an unexplained crash.

`kb_metrics_listener` writes responses with plain `write(2)`, raising SIGPIPE when a scrape client hangs up mid-response. That is safe in the real service: `kb/kb_main.c` ignores SIGPIPE process-wide before any listener starts, and the listener is written against that contract. This binary links the listener **without** `kb_main`, so it inherited the default disposition and was killed. The test now reproduces the contract the component depends on.

**11/60 failures under contention → 0/60.**

## 4. The ensemble deadline test raced the scheduler

`test_roundtable_deadline_returns_best_so_far` asserts `rounds_run == 1` against `deadline_ms = 1`. `delegate_ensemble.c` checks the deadline at the **top** of the round loop and breaks with `rounds_run` still 0 — so under load the deadline expired before round one began, and the assert fired against a run that never started.

The test wants the *post*-panel capture, which needs the deadline above whatever wall clock precedes the loop-top check and below the panel's duration. That window was 1 ms wide by accident. 200 ms tolerates any plausible scheduling delay, and the mock panel sleeps twice that, so both bounds hold by construction rather than by timing luck.

**0/24 under contention.**

## Not included

A fifth suspect turned out to be the harness, not the code: `kb-workload-helper-posix` failed only because the fixtures were installed under `/run`, which is `noexec` on that host (and the helper additionally requires every ancestor directory to be root-owned and non-world-writable, so `/var/tmp` fails too). Moved them to `/opt` and the **unmodified** test passes 10/10 — so no change to it here.

## Verification

Tests only — no production code changes. Full `make lint` (69 checks) passes, and `audit-worm`, `kb-metrics-listener`, `delegate-ensemble` and `graph-scoring` all pass on this base.