### PR TITLE
fix(release): unblock testing upgrades and artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,6 +1415,9 @@ jobs:
       - name: Init/migrate service routing smoke test
         run: cd src && make -j$(nproc) init-migrate-service-test
 
+      - name: Historical store volume upgrades in place
+        run: cd src && make postgres-store-upgrade-test
+
       # Cheap and image-free: the gate that decides whether a kb may start without an
       # embedder. Getting it wrong in either direction ships a broken deploy — too
       # loose and an unconfigured kb serves nothing usable, too tight and the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,13 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_compile_options(-D_FORTIFY_SOURCE=3 -fstack-protector-strong
-                        -fstack-clash-protection -fPIE -fcf-protection=full)
+                        -fstack-clash-protection -fPIE)
+    # -fcf-protection enables Intel CET and is rejected by GCC on AArch64.
+    # Gate it on the target processor (not the build host, so cross-compiles
+    # select the same flags as native builds).
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64|i[3-6]86)$")
+        add_compile_options(-fcf-protection=full)
+    endif()
     add_link_options(-pie -Wl,-z,relro,-z,now -Wl,-z,noexecstack)
 endif()
 

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -119,7 +119,14 @@ from sentence_transformers import SentenceTransformer
 spec = table[sel]
 local_dir = snapshot_download(spec["repo"], revision=spec["revision"],
                               local_files_only=True)
-m = SentenceTransformer(local_dir, trust_remote_code=True)
+code_revisions = set((spec.get("code_revisions") or {}).values())
+if len(code_revisions) > 1:
+    sys.exit(f"{sel}: multiple external code revisions cannot be loaded safely")
+code_revision = next(iter(code_revisions), None)
+config_kwargs = {"code_revision": code_revision} if code_revision else None
+model_kwargs = {"code_revision": code_revision} if code_revision else None
+m = SentenceTransformer(local_dir, trust_remote_code=True,
+                        config_kwargs=config_kwargs, model_kwargs=model_kwargs)
 dim = m.get_sentence_embedding_dimension()
 if dim != spec["dim"]:
     sys.exit(f"{sel}: registry says dim={spec['dim']}, model serves {dim}")

--- a/compose.server-managed.yaml
+++ b/compose.server-managed.yaml
@@ -87,7 +87,8 @@ services:
       - ./scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -220,7 +221,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -71,7 +71,8 @@ services:
       - ./scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -118,11 +119,11 @@ services:
     ports:
       # /v1 over native TLS on 8743 (plaintext 8740 is loopback-only, not published).
       - "8743:8743"
-    # An unauthenticated probe gets 401, which still proves the listener is up;
-    # treat 200/401 as healthy so this stays correct if the bearer is overridden.
+    # Probe the privileged local socket so credentials are unnecessary, but
+    # require the core store and module graph to be ready before admitting work.
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -59,7 +59,7 @@ services:
     ports:
       - "127.0.0.1:8741:8741"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -154,7 +154,8 @@ services:
       - ./scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -225,7 +226,7 @@ services:
     ports:
       # Remote /v1 is served over native TLS on 8743 (the server refuses to expose
       # plaintext /v1 off-loopback). Plaintext 8740 stays bound to 127.0.0.1 inside
-      # the container (the healthcheck below still uses it) and is NOT published.
+      # the container and is NOT published.
       - "8743:8743"
       # webchat UI — on by default; gated off only by AIMEE_RUNTIME_WEB_ENABLED=0 above.
       - "8443:8443"
@@ -234,11 +235,11 @@ services:
         condition: service_healthy
       aimee-kb:
         condition: service_healthy
-    # An unauthenticated probe gets 401, which still proves the listener is up;
-    # treat 200/401 as healthy so this stays correct if the bearer is overridden.
+    # Probe the privileged local socket so credentials are unnecessary, but
+    # require the core store and module graph to be ready before admitting work.
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,7 +41,7 @@ services:
     ports:
       - "127.0.0.1:8741:8741"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -53,7 +53,7 @@ services:
     ports:
       - "8741:8741"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -119,7 +119,11 @@ services:
       - ../../scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      # pg_isready only proves that a postmaster is listening; it exits zero
+      # even when the requested role is absent. Authenticate both identities so
+      # an old volume cannot be declared healthy before role reconciliation.
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -158,7 +162,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -98,7 +98,7 @@ services:
       AIMEE_WORKSPACES_DIR: /var/lib/aimee-workspaces
     command: ["--http-port=8741"]
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/smoothnas/aimee-kb.compose.yaml
+++ b/deploy/smoothnas/aimee-kb.compose.yaml
@@ -26,7 +26,7 @@ services:
     ports:
       - "8741:8741"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -87,7 +87,7 @@ services:
         expose: false
         hostExpose: true
     health:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/deploy/smoothnas/aimee-server.compose.yaml
+++ b/deploy/smoothnas/aimee-server.compose.yaml
@@ -57,7 +57,10 @@ services:
       - ../../scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      # pg_isready does not authenticate the requested role. Exercise both
+      # split identities so an unreconciled legacy volume stays unhealthy.
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -92,7 +95,7 @@ services:
       - "8443:8443"
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -59,7 +59,7 @@ services:
     ports:
       - "8741:8741"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -125,7 +125,10 @@ services:
       - ../../scripts/postgres-store-init.sh:/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro
       - aimee-store-tls:/var/lib/postgresql/secure
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "aimee_store"]
+      # pg_isready does not authenticate the requested role. Exercise both
+      # split identities so an unreconciled legacy volume stays unhealthy.
+      test: ["CMD-SHELL",
+             "PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_MIGRATOR_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_migrator -d aimee_store -Atqc 'SELECT 1' | grep -qx 1 && PGSSLMODE=require PGPASSWORD=\"$${AIMEE_STORE_RUNTIME_PASSWORD}\" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' | grep -qx 1"]
       interval: 2s
       timeout: 2s
       retries: 30
@@ -159,7 +162,7 @@ services:
       aimee-kb: { condition: service_healthy }
     healthcheck:
       test: ["CMD-SHELL",
-             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+             "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -290,7 +290,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 255 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
+The binaries read 257 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests, plus the generic first-boot credential inputs). Depending on the setting, these variables either override config-store values or provide fallbacks when no explicit config value is present. Module-activation variables use fallback semantics; deployment and runtime wiring variables commonly override stored values. A credential may enter through an environment variable only as first-boot transport (for example, a Kubernetes Secret): startup seals it into Vault, scrubs the environment, verifies custody, and fails closed before any long-lived service starts. Credentials are never runtime environment or config-file storage.
 
 ### Paths & assets
 
@@ -344,6 +344,8 @@ The binaries read 255 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_MGMT_STATUS_KEY_ID` | Identifier of the management-status verification key. |
 | `AIMEE_MGMT_STATUS_PUBLIC_KEY` | Hex-encoded Ed25519 key used to verify management-status staples. |
 | `AIMEE_MODULE_ROUNDTABLE` | Enable the optional roundtable module; invalid values fail closed to off. |
+| `AIMEE_MODULE_RUNTIME_WEB` | Explicit runtime-web process intent. `1`, `true`, `on`, or `yes` enables it; `0`, `false`, `off`, or `no` disables it. When valid, this takes precedence over `AIMEE_RUNTIME_WEB_ENABLED`; unset or malformed preserves the shipped module default. |
+| `AIMEE_RUNTIME_WEB_ENABLED` | Enable the browser runtime and its optional runtime-web process. The shipped container default is on; `0`, `false`, `off`, or `no` disables both unless `AIMEE_MODULE_RUNTIME_WEB` explicitly enables the process. |
 | `AIMEE_SEARCH_ALLOW_PRIVATE_ENDPOINT` | Permit the operator-configured search backend (`search.searxng_url`) to resolve to a private, loopback, or link-local address. Off by default: every outbound fetch is validated and pinned, so a self-hosted SearXNG on a LAN address is refused unless this is set. Deliberately an environment variable rather than a config key, because `config.set` is reachable from inside the running system and pointing the search backend at a cloud metadata address would exfiltrate instance credentials through a tool that looks like search. Set to exactly `1`; any other value is off. Never widens fetches of model-supplied or search-result URLs, which stay denied. |
 | `AIMEE_SERVER_HTTP_BIND` | TCP bind address for the server `/v1` HTTP listener (else UDS-only). |
 | `AIMEE_SERVER_MGMT_BIND` | Bind address that enables the server management listener when its full TLS configuration is present. |

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -35,6 +35,8 @@
 #                 list several to layer an override, e.g. to remap host ports
 #                 on a host where 8740/8741 are already taken
 #   WAIT_SECONDS  health wait budget on --up      (default 300)
+#   AIMEE_STORE_{ADMIN,MIGRATOR,RUNTIME}_PASSWORD may be supplied; --up
+#                 generates independent values when they are absent
 #
 # Exit code: 0 = all checks passed, non-zero otherwise.
 
@@ -88,6 +90,10 @@ if [[ "$DO_UP" == 1 ]]; then
   export AIMEE_API_BEARER_TOKEN="$BEARER"
   export AIMEE_KB_API_BEARER_TOKEN="$KB_BEARER"
   export AIMEE_KB_SERVICE_IDENTITY_TOKEN="scope:service:aimee-server:$(openssl rand -hex 32)"
+  : "${AIMEE_STORE_ADMIN_PASSWORD:=$(openssl rand -hex 32)}"
+  : "${AIMEE_STORE_MIGRATOR_PASSWORD:=$(openssl rand -hex 32)}"
+  : "${AIMEE_STORE_RUNTIME_PASSWORD:=$(openssl rand -hex 32)}"
+  export AIMEE_STORE_ADMIN_PASSWORD AIMEE_STORE_MIGRATOR_PASSWORD AIMEE_STORE_RUNTIME_PASSWORD
 fi
 : "${KB_BEARER:=$BEARER}"
 
@@ -263,7 +269,11 @@ check "GET /v1/rules -> kb" '"rules"' "${SERVER_URL}/v1/rules"
 # No `-f`: an HTTP error must leave the body readable so a failure here is
 # diagnosable, and the assignment is guarded so a non-zero curl cannot trip
 # `set -e` and kill the run between checks with no message.
-as_of_seed="$(curl -sS -k --max-time 20 "${KB_AUTH[@]}" -X POST -H 'content-type: application/json' \
+# The first write can overlap the fresh KB's initial reflection/index pass. Its
+# production request budget is longer than the generic 20-second read probe, so
+# give this write enough time to return its committed id instead of reporting a
+# false failure after the KB has accepted it.
+as_of_seed="$(curl -sS -k --max-time 60 "${KB_AUTH[@]}" -X POST -H 'content-type: application/json' \
   -d '{"key":"e2e-as-of","content":"as-of smoke value","tier":"L0","kind":"fact"}' \
   "${KB_URL}/v1/actions/memory.store" 2>&1 || true)"
 mem_id="$(printf '%s' "$as_of_seed" | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
@@ -288,6 +298,9 @@ check_status "GET /v1/health (no bearer) rejected" 401 "${SERVER_URL}/v1/health"
 
 bold "==> Sanity: kb container is directly healthy at ${KB_URL}"
 check_kb "GET /v1/health (kb direct)" '"status"' "${KB_URL}/v1/health"
+check_kb "GET /v1/health reports DB2 schema ready" '"db2_ok":true' "${KB_URL}/v1/health"
+check_kb "GET /v1/health reports KB tables ready" '"db2_kb_tables_ok":true' \
+         "${KB_URL}/v1/health"
 
 echo
 bold "==> Summary: ${PASS} passed, ${FAIL} failed"

--- a/scripts/aimee-server-standalone-docker-smoke.sh
+++ b/scripts/aimee-server-standalone-docker-smoke.sh
@@ -19,7 +19,8 @@
 #
 # Env: SERVER_URL (default https://localhost:8743), BEARER (required for an
 #      existing stack; generated as a first-boot secret with --up), COMPOSE_FILE
-#      (default compose.server-standalone.yaml), WAIT_SECONDS (300).
+#      (default compose.server-standalone.yaml), WAIT_SECONDS (300). Store
+#      passwords may be supplied explicitly; --up generates isolated values.
 #
 # Exit code: 0 = all checks passed.
 
@@ -57,6 +58,10 @@ if [[ -z "$BEARER" ]]; then
 fi
 if [[ "$DO_UP" == 1 ]]; then
   export AIMEE_API_BEARER_TOKEN="$BEARER"
+  : "${AIMEE_STORE_ADMIN_PASSWORD:=$(openssl rand -hex 32)}"
+  : "${AIMEE_STORE_MIGRATOR_PASSWORD:=$(openssl rand -hex 32)}"
+  : "${AIMEE_STORE_RUNTIME_PASSWORD:=$(openssl rand -hex 32)}"
+  export AIMEE_STORE_ADMIN_PASSWORD AIMEE_STORE_MIGRATOR_PASSWORD AIMEE_STORE_RUNTIME_PASSWORD
 fi
 
 cd "$(dirname "$0")/.."

--- a/scripts/bake-embedder.py
+++ b/scripts/bake-embedder.py
@@ -111,12 +111,16 @@ def main():
     repo, revision = spec["repo"], spec.get("revision") or "main"
     print(f"baking {selected}: {repo}@{revision}", flush=True)
     local = fetch(repo, revision=revision, ignore_patterns=SKIP)
-    # Code repos are referenced by name only -- auto_map carries no revision -- so these
-    # take the default branch. A looser pin than the weights get; a model whose code must
-    # be pinned needs its auto_map repo added to the registry explicitly.
+    # auto_map carries no revision. Refuse external code unless the registry binds
+    # every referenced repository to an immutable commit, matching the Docker bake.
+    code_revisions = spec.get("code_revisions") or {}
     for code_repo in sorted(code_repos(local)):
-        print(f"  + code: {code_repo}", flush=True)
-        fetch(code_repo, allow_patterns=["*.py", "*.json", "*.txt"])
+        code_revision = code_revisions.get(code_repo)
+        if not code_revision or len(code_revision) != 40:
+            raise RuntimeError(f"{selected}: unpinned auto_map code repository {code_repo}")
+        print(f"  + code: {code_repo}@{code_revision}", flush=True)
+        fetch(code_repo, revision=code_revision,
+              allow_patterns=["*.py", "*.json", "*.txt"])
 
 
 if __name__ == "__main__":

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -138,6 +138,27 @@ MODEL_NAME = str(SPEC["repo"]) if SPEC else ""
 MODEL_REVISION = str(SPEC.get("revision") or "main") if SPEC else "main"
 
 
+def model_code_revision(spec):
+    """Return the immutable revision used for external ``auto_map`` code.
+
+    Transformers accepts one ``code_revision`` for a model load.  Refuse an
+    ambiguous registry entry instead of silently loading one of several custom-code
+    repositories at a floating ref.
+    """
+    revisions = set((spec.get("code_revisions") or {}).values()) if spec else set()
+    if len(revisions) > 1:
+        raise RegistryError("an embedder cannot declare multiple external code revisions")
+    revision = next(iter(revisions), None)
+    if revision is not None and (
+            not isinstance(revision, str) or len(revision) != 40
+            or any(char not in "0123456789abcdef" for char in revision)):
+        raise RegistryError("external embedder code must use an immutable commit revision")
+    return revision
+
+
+MODEL_CODE_REVISION = model_code_revision(SPEC)
+
+
 def prefix_for(input_type):
     """The prefix for `input_type` under the configured embedder."""
     return SPEC["prefixes"][input_type] if SPEC else ""
@@ -291,6 +312,8 @@ def load_model():
     # one?" is answerable without reading logs.
     global _runtime
     _model = None
+    config_kwargs = ({"code_revision": MODEL_CODE_REVISION}
+                     if MODEL_CODE_REVISION else None)
     if EMBEDDER_BACKEND in ("onnx", "auto"):
         try:
             # Load from the LOCAL SNAPSHOT DIRECTORY, not the repo id.
@@ -307,9 +330,12 @@ def load_model():
             # nothing to enumerate. Loading through ST rather than driving
             # onnxruntime directly keeps its pooling and normalisation exactly as
             # the torch path had them, so the vector space does not move.
+            model_kwargs = {"file_name": "onnx/model.onnx"}
+            if MODEL_CODE_REVISION:
+                model_kwargs["code_revision"] = MODEL_CODE_REVISION
             _model = SentenceTransformer(
                 model_source, revision=model_revision, trust_remote_code=True, backend="onnx",
-                model_kwargs={"file_name": "onnx/model.onnx"})
+                model_kwargs=model_kwargs, config_kwargs=config_kwargs)
             _runtime = "onnx"
         except Exception as exc:  # missing optimum/onnxruntime, or no baked graph
             if EMBEDDER_BACKEND == "onnx":
@@ -317,8 +343,11 @@ def load_model():
             sys.stderr.write(f"embedder-server: onnx unavailable ({exc}); using torch\n")
             _model = None
     if _model is None:
+        model_kwargs = ({"code_revision": MODEL_CODE_REVISION}
+                        if MODEL_CODE_REVISION else None)
         _model = SentenceTransformer(
-            model_source, revision=model_revision, trust_remote_code=True)
+            model_source, revision=model_revision, trust_remote_code=True,
+            model_kwargs=model_kwargs, config_kwargs=config_kwargs)
         _runtime = "torch"
     _dim = _model.get_sentence_embedding_dimension() or 0  # read before quantizing
     if EMBEDDER_QUANTIZE == "int8":

--- a/scripts/embedders.json
+++ b/scripts/embedders.json
@@ -70,6 +70,9 @@
     "nomic-embed-text-v2-moe": {
       "repo": "nomic-ai/nomic-embed-text-v2-moe",
       "revision": "1066b6599d099fbb93dfcb64f9c37a7c9e503e85",
+      "code_revisions": {
+        "nomic-ai/nomic-bert-2048": "e5042dce39060cc34bc223455f25cf1d26db4655"
+      },
       "pooling": "mean",
       "dim": 768,
       "context": 2048,

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -717,6 +717,8 @@ ENV_DESC = {
     # Server runtime
     "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
     "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),
+    "AIMEE_RUNTIME_WEB_ENABLED": ("Server runtime", "Enable the browser runtime and its optional runtime-web process. The shipped container default is on; `0`, `false`, `off`, or `no` disables both unless `AIMEE_MODULE_RUNTIME_WEB` explicitly enables the process."),
+    "AIMEE_MODULE_RUNTIME_WEB": ("Server runtime", "Explicit runtime-web process intent. `1`, `true`, `on`, or `yes` enables it; `0`, `false`, `off`, or `no` disables it. When valid, this takes precedence over `AIMEE_RUNTIME_WEB_ENABLED`; unset or malformed preserves the shipped module default."),
     "AIMEE_API_REMOTE_WRITES": ("Server runtime", "Legacy value: `off`, `data`, or `full`. Still parsed, but no longer authorizes user writes; non-off values warn and feed `remote_writes.global_ignored`."),
     "AIMEE_API_MTLS": ("Server runtime", "Client-certificate mode: `off`, `optional`, or `required`. The managed server image defaults to `optional` so enrollment works before the durable roster promotes the listener to required."),
     "AIMEE_SEARCH_ALLOW_PRIVATE_ENDPOINT": (

--- a/scripts/postgres-secure-entrypoint.sh
+++ b/scripts/postgres-secure-entrypoint.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 : "${AIMEE_STORE_DB_HOSTNAME:=aimee-store-db}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${PGDATA:?PGDATA is required}"
+: "${AIMEE_STORE_MIGRATOR_PASSWORD:?AIMEE_STORE_MIGRATOR_PASSWORD is required}"
+: "${AIMEE_STORE_RUNTIME_PASSWORD:?AIMEE_STORE_RUNTIME_PASSWORD is required}"
 secure_dir=/var/lib/postgresql/secure
 # The server mounts this volume read-only and must traverse the directory to
 # read server.crt as its TLS trust root.  The certificate is public (0644);
@@ -34,6 +40,75 @@ hostnossl all all ::/0        reject
 EOF
 chown postgres:postgres "$secure_dir/pg_hba.conf"
 chmod 0600 "$secure_dir/pg_hba.conf"
+
+# The upstream image runs /docker-entrypoint-initdb.d only for an empty PGDATA.
+# Releases before the store role split therefore keep their `aimee` superuser
+# and never create the migrator/runtime roles when Compose replaces the image.
+# Reconcile an existing cluster through a Unix-socket-only temporary postmaster;
+# no TCP listener exists until the role split and password rotation have
+# completed successfully.
+if [[ -s "$PGDATA/PG_VERSION" ]]; then
+  migration_socket="$secure_dir/reconcile-socket"
+  migration_hba="$secure_dir/reconcile-pg_hba.conf"
+  migration_log="$secure_dir/reconcile.log"
+  install -d -o postgres -g postgres -m 0700 "$migration_socket"
+  printf '%s\n' 'local all all trust' >"$migration_hba"
+  chown postgres:postgres "$migration_hba"
+  chmod 0600 "$migration_hba"
+  touch "$migration_log"
+  chown postgres:postgres "$migration_log"
+  chmod 0600 "$migration_log"
+
+  migration_started=0
+  stop_migration_cluster() {
+    if [[ "$migration_started" == 1 ]]; then
+      gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop >/dev/null 2>&1 || true
+      migration_started=0
+    fi
+  }
+  trap stop_migration_cluster EXIT INT TERM
+  gosu postgres pg_ctl -D "$PGDATA" -w -l "$migration_log" \
+    -o "-c listen_addresses='' -c unix_socket_directories='$migration_socket' -c hba_file='$migration_hba' -c ssl=off" start
+  migration_started=1
+
+  existing_admin=""
+  for candidate in postgres aimee; do
+    if gosu postgres psql --host "$migration_socket" --username "$candidate" \
+         --dbname "$POSTGRES_DB" --tuples-only --no-align \
+         --command "SELECT 1 FROM pg_roles WHERE rolname = current_user AND rolsuper" \
+         2>/dev/null | grep -qx 1; then
+      existing_admin="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$existing_admin" ]]; then
+    echo "aimee store: existing cluster has no supported administrative role (postgres or aimee)" >&2
+    exit 1
+  fi
+
+  AIMEE_STORE_ADMIN_USER="$existing_admin" PGHOST="$migration_socket" \
+    /docker-entrypoint-initdb.d/10-aimee-store-roles.sh
+
+  # Historical releases shipped the network-reachable `aimee:aimee`
+  # superuser. Once its objects and ownership have moved, remove login and erase
+  # its verifier so enabling TLS does not preserve that known credential.
+  # Do this on every existing-cluster reconciliation, not only when `aimee`
+  # was the role used above. A prior interrupted reconciliation may already
+  # have created `postgres` but failed before revoking the legacy credential;
+  # the next boot must finish the security transition rather than treating the
+  # new role as proof that every later step committed.
+  gosu postgres psql --host "$migration_socket" --username postgres \
+    --dbname "$POSTGRES_DB" --set=ON_ERROR_STOP=1 <<'SQL'
+-- PostgreSQL 18 does not allow the original bootstrap superuser to lose its
+-- SUPERUSER attribute. NOLOGIN plus a NULL password is the supported durable
+-- revocation: no HBA authentication method can use the historical identity.
+SELECT 'ALTER ROLE aimee NOLOGIN PASSWORD NULL'
+WHERE EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aimee') \gexec
+SQL
+
+  stop_migration_cluster
+  trap - EXIT INT TERM
+fi
 
 exec /usr/local/bin/docker-entrypoint.sh postgres \
   -c ssl=on \

--- a/scripts/postgres-store-init.sh
+++ b/scripts/postgres-store-init.sh
@@ -3,20 +3,76 @@ set -euo pipefail
 
 : "${AIMEE_STORE_MIGRATOR_PASSWORD:?AIMEE_STORE_MIGRATOR_PASSWORD is required}"
 : "${AIMEE_STORE_RUNTIME_PASSWORD:?AIMEE_STORE_RUNTIME_PASSWORD is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
 
-psql --set=ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+# docker-entrypoint invokes this as POSTGRES_USER on a fresh cluster. The secure
+# wrapper also invokes it against an existing pre-role-split cluster, where the
+# historical superuser is `aimee`; in that case it supplies the discovered role
+# explicitly. Keeping one idempotent reconciliation prevents fresh installs and
+# upgrades from acquiring subtly different grants.
+admin_user="${AIMEE_STORE_ADMIN_USER:-$POSTGRES_USER}"
+
+psql --set=ON_ERROR_STOP=1 --username "$admin_user" --dbname "$POSTGRES_DB" \
+  --set=admin_password="$POSTGRES_PASSWORD" \
   --set=migrator_password="$AIMEE_STORE_MIGRATOR_PASSWORD" \
   --set=runtime_password="$AIMEE_STORE_RUNTIME_PASSWORD" <<'SQL'
+SELECT format('CREATE ROLE postgres LOGIN SUPERUSER PASSWORD %L', :'admin_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'postgres') \gexec
+SELECT format('ALTER ROLE postgres WITH LOGIN SUPERUSER PASSWORD %L', :'admin_password') \gexec
 SELECT format('CREATE ROLE aimee_store_migrator LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION', :'migrator_password')
 WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aimee_store_migrator') \gexec
 SELECT format('CREATE ROLE aimee_store_runtime LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION', :'runtime_password')
 WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'aimee_store_runtime') \gexec
+SELECT format('ALTER ROLE aimee_store_migrator WITH LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION', :'migrator_password') \gexec
+SELECT format('ALTER ROLE aimee_store_runtime WITH LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION', :'runtime_password') \gexec
 
 ALTER DATABASE aimee_store OWNER TO aimee_store_migrator;
 ALTER SCHEMA public OWNER TO aimee_store_migrator;
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE CONNECT ON DATABASE aimee_store FROM PUBLIC;
 GRANT CONNECT ON DATABASE aimee_store TO aimee_store_runtime;
 GRANT USAGE ON SCHEMA public TO aimee_store_runtime;
+
+-- A fresh cluster has no application objects yet; an upgraded one does. Default
+-- privileges only affect future migrations, so transfer and grant every
+-- existing object before the old known-password owner is disabled.
+DO $reconcile$
+DECLARE
+  object record;
+  object_kind text;
+BEGIN
+  FOR object IN
+    SELECT c.relkind, n.nspname, c.relname
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public'
+       AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+       -- ALTER TABLE transfers its SERIAL/IDENTITY sequences atomically. A
+       -- second ALTER SEQUENCE is rejected because an owned sequence may not
+       -- have a different owner from its table; only standalone sequences
+       -- need their own pass here.
+       AND (c.relkind <> 'S' OR NOT EXISTS (
+         SELECT 1 FROM pg_depend d
+          WHERE d.objid = c.oid AND d.deptype IN ('a', 'i')
+       ))
+  LOOP
+    object_kind := CASE object.relkind
+      WHEN 'r' THEN 'TABLE'
+      WHEN 'p' THEN 'TABLE'
+      WHEN 'v' THEN 'VIEW'
+      WHEN 'm' THEN 'MATERIALIZED VIEW'
+      WHEN 'S' THEN 'SEQUENCE'
+      WHEN 'f' THEN 'FOREIGN TABLE'
+    END;
+    EXECUTE format('ALTER %s %I.%I OWNER TO aimee_store_migrator',
+                   object_kind, object.nspname, object.relname);
+  END LOOP;
+END
+$reconcile$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO aimee_store_runtime;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO aimee_store_runtime;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO aimee_store_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE aimee_store_migrator IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO aimee_store_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE aimee_store_migrator IN SCHEMA public

--- a/scripts/tests/test_bake_embedder.py
+++ b/scripts/tests/test_bake_embedder.py
@@ -6,6 +6,7 @@ in a CI log.
 """
 import importlib.util
 import json
+import os
 import pathlib
 import sys
 import tempfile
@@ -127,10 +128,64 @@ def test_auto_map_code_repos_are_followed():
     print("  auto_map code repos are followed, missing config.json is not an error")
 
 
+def test_nomic_external_code_is_immutably_pinned():
+    registry = json.loads((ROOT / "scripts" / "embedders.json").read_text())
+    nomic = registry["embedders"]["nomic-embed-text-v2-moe"]
+    code_revision = (nomic.get("code_revisions") or {}).get("nomic-ai/nomic-bert-2048")
+    assert code_revision == "e5042dce39060cc34bc223455f25cf1d26db4655", code_revision
+    assert len(code_revision) == 40 and all(c in "0123456789abcdef" for c in code_revision)
+    print("  nomic external auto_map code is bound to its compatible immutable commit")
+
+
+def test_external_code_fetch_uses_registry_revision():
+    m = load()
+    revision = "1" * 40
+    code_revision = "2" * 40
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        snapshot = root / "snapshot"
+        snapshot.mkdir()
+        (snapshot / "config.json").write_text(json.dumps({"auto_map": {
+            "AutoModel": "example/code--modeling.Example",
+        }}))
+        registry = root / "embedders.json"
+        registry.write_text(json.dumps({"embedders": {"example": {
+            "repo": "example/model",
+            "revision": revision,
+            "code_revisions": {"example/code": code_revision},
+        }}}))
+        calls = []
+
+        def fake_fetch(repo, **kwargs):
+            calls.append((repo, kwargs))
+            return str(snapshot)
+
+        m.REGISTRY = str(registry)
+        m.fetch = fake_fetch
+        os.environ["AIMEE_EMBEDDER"] = "example"
+        m.main()
+        assert calls[1][0] == "example/code", calls
+        assert calls[1][1]["revision"] == code_revision, calls
+
+        registry.write_text(json.dumps({"embedders": {"example": {
+            "repo": "example/model", "revision": revision,
+        }}}))
+        calls.clear()
+        try:
+            m.main()
+        except RuntimeError as exc:
+            assert "unpinned auto_map code repository example/code" in str(exc), exc
+        else:
+            raise AssertionError("external auto_map code without a revision was accepted")
+    print("  external auto_map code fetches use immutable registry revisions")
+
+
 if __name__ == "__main__":
     test_transient_is_retried()
     test_permanent_is_not_retried()
     test_exhaustion_is_bounded()
     test_unknown_embedder_is_a_build_failure()
     test_auto_map_code_repos_are_followed()
+    test_nomic_external_code_is_immutably_pinned()
+    test_external_code_fetch_uses_registry_revision()
     print("test_bake_embedder: ok")

--- a/scripts/tests/test_embedder_env_parsing.py
+++ b/scripts/tests/test_embedder_env_parsing.py
@@ -37,6 +37,16 @@ def load_env_int():
     return ns["_env_int"]
 
 
+def load_model_code_revision():
+    """Import the registry helper without importing torch or loading a model."""
+    src = MODULE.read_text(encoding="utf-8")
+    start = src.index("def model_code_revision(")
+    end = src.index("MODEL_CODE_REVISION = ")
+    ns = {"RegistryError": RuntimeError}
+    exec(compile(src[start:end], str(MODULE), "exec"), ns)
+    return ns["model_code_revision"]
+
+
 class TestEnvInt(unittest.TestCase):
     def setUp(self):
         self._env_int = load_env_int()
@@ -90,6 +100,24 @@ class TestEnvInt(unittest.TestCase):
         os.environ["T_PROBE"] = ""
         self.assertEqual(self._env_int("T_PROBE", expensive), 99)
         self.assertEqual(len(calls), 1)
+
+
+class TestCodeRevision(unittest.TestCase):
+    def setUp(self):
+        self.revision = load_model_code_revision()
+
+    def test_pinned_external_code_revision_is_forwarded(self):
+        commit = "e5042dce39060cc34bc223455f25cf1d26db4655"
+        self.assertEqual(self.revision({"code_revisions": {"repo": commit}}), commit)
+
+    def test_missing_external_code_needs_no_loader_argument(self):
+        self.assertIsNone(self.revision({}))
+
+    def test_floating_or_ambiguous_external_code_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "immutable commit"):
+            self.revision({"code_revisions": {"repo": "main"}})
+        with self.assertRaisesRegex(RuntimeError, "multiple"):
+            self.revision({"code_revisions": {"one": "1" * 40, "two": "2" * 40}})
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_postgres_store_upgrade.sh
+++ b/scripts/tests/test_postgres_store_upgrade.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Reproduce the published pre-role-split store and prove an in-place upgrade is
+# data-preserving, fail-closed, and idempotent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+suffix="$$"
+legacy_container="aimee-store-upgrade-legacy-${suffix}"
+repaired_container="aimee-store-upgrade-repaired-${suffix}"
+data_volume="aimee-store-upgrade-data-${suffix}"
+tls_volume="aimee-store-upgrade-tls-${suffix}"
+
+cleanup() {
+  docker rm -f "$legacy_container" "$repaired_container" >/dev/null 2>&1 || true
+  docker volume rm "$data_volume" "$tls_volume" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_sql() {
+  local container="$1" user="$2" password="$3"
+  for _ in $(seq 1 90); do
+    if docker exec -e PGPASSWORD="$password" -e PGSSLMODE=require "$container" \
+         psql -h 127.0.0.1 -U "$user" -d aimee_store -Atqc 'SELECT 1' \
+         2>/dev/null | grep -qx 1; then
+      return 0
+    fi
+    if ! docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null | grep -qx true; then
+      docker logs "$container" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+  docker logs "$container" >&2 || true
+  return 1
+}
+
+docker volume create "$data_volume" >/dev/null
+docker volume create "$tls_volume" >/dev/null
+
+# The last fully published pre-split manifest used this exact owner/password.
+docker run -d --name "$legacy_container" \
+  -e POSTGRES_USER=aimee -e POSTGRES_PASSWORD=aimee -e POSTGRES_DB=aimee_store \
+  -e PGDATA=/var/lib/postgresql/data/pgdata \
+  -v "$data_volume":/var/lib/postgresql/data postgres:18 >/dev/null
+legacy_ready=0
+for _ in $(seq 1 90); do
+  if docker exec "$legacy_container" psql -U aimee -d aimee_store -Atqc 'SELECT 1' \
+       2>/dev/null | grep -qx 1; then
+    legacy_ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$legacy_ready" != 1 ]]; then
+  docker logs "$legacy_container" >&2 || true
+  exit 1
+fi
+docker exec -i "$legacy_container" psql -U aimee -d aimee_store -v ON_ERROR_STOP=1 <<'SQL'
+CREATE TABLE release_upgrade_probe(
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  payload text NOT NULL
+);
+INSERT INTO release_upgrade_probe(payload) VALUES ('preserved-before-upgrade');
+SQL
+docker stop "$legacy_container" >/dev/null
+docker rm "$legacy_container" >/dev/null
+
+start_repaired() {
+  docker run -d --name "$repaired_container" \
+    -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=repair-admin-secret \
+    -e AIMEE_STORE_MIGRATOR_PASSWORD=repair-migrator-secret \
+    -e AIMEE_STORE_RUNTIME_PASSWORD=repair-runtime-secret \
+    -e POSTGRES_DB=aimee_store -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$data_volume":/var/lib/postgresql/data \
+    -v "$tls_volume":/var/lib/postgresql/secure \
+    -v "$REPO_ROOT/scripts/postgres-secure-entrypoint.sh":/opt/aimee/postgres-secure-entrypoint.sh:ro \
+    -v "$REPO_ROOT/scripts/postgres-store-init.sh":/docker-entrypoint-initdb.d/10-aimee-store-roles.sh:ro \
+    --entrypoint /opt/aimee/postgres-secure-entrypoint.sh postgres:18 >/dev/null
+  wait_for_sql "$repaired_container" aimee_store_runtime repair-runtime-secret
+}
+
+start_repaired
+
+test "$(docker exec -e PGPASSWORD=repair-runtime-secret -e PGSSLMODE=require \
+  "$repaired_container" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store \
+  -Atqc 'SELECT payload FROM release_upgrade_probe')" = preserved-before-upgrade
+test "$(docker exec "$repaired_container" psql -U postgres -d aimee_store -Atqc \
+  "SELECT tableowner FROM pg_tables WHERE schemaname='public' AND tablename='release_upgrade_probe'")" \
+  = aimee_store_migrator
+test "$(docker exec "$repaired_container" psql -U postgres -d aimee_store -Atqc \
+  "SELECT sequenceowner FROM pg_sequences WHERE schemaname='public' AND sequencename='release_upgrade_probe_id_seq'")" \
+  = aimee_store_migrator
+test "$(docker exec "$repaired_container" psql -U postgres -d aimee_store -Atqc \
+  "SELECT rolsuper || ':' || rolcanlogin || ':' || (rolpassword IS NULL) FROM pg_authid WHERE rolname='aimee'")" \
+  = true:false:true
+
+# A listening postmaster is insufficient: wrong credentials and plaintext TCP
+# must both fail even though pg_isready would return success.
+if docker exec -e PGPASSWORD=wrong -e PGSSLMODE=require "$repaired_container" \
+     psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store -Atqc 'SELECT 1' \
+     >/dev/null 2>&1; then
+  echo "store upgrade accepted the wrong runtime password" >&2
+  exit 1
+fi
+if docker exec "$repaired_container" psql -h 127.0.0.1 -U aimee_store_runtime \
+     -d aimee_store -Atqc 'SELECT 1' >/dev/null 2>&1; then
+  echo "store upgrade accepted plaintext/passwordless TCP" >&2
+  exit 1
+fi
+
+# Recreate the container over the same volumes. Every reconciliation step must
+# be safe after it has already committed, including revocation of the bootstrap
+# identity.
+docker stop "$repaired_container" >/dev/null
+docker rm "$repaired_container" >/dev/null
+start_repaired
+test "$(docker exec -e PGPASSWORD=repair-runtime-secret -e PGSSLMODE=require \
+  "$repaired_container" psql -h 127.0.0.1 -U aimee_store_runtime -d aimee_store \
+  -Atqc 'SELECT payload FROM release_upgrade_probe')" = preserved-before-upgrade
+
+echo "postgres-store-upgrade: ok"

--- a/src/Makefile
+++ b/src/Makefile
@@ -124,11 +124,18 @@ ifeq ($(OS),Windows_NT)
 endif
 
 UNAME_S := $(shell uname -s)
+CC_MACHINE := $(shell $(CC) -dumpmachine 2>$(NULLDEV))
 
 # Shipping Linux binaries carry an explicit, repository-owned hardening contract;
 # their exploit resistance must not vary with the runner distribution defaults.
 ifeq ($(UNAME_S),Linux)
-    HARDEN_C_FLAGS = -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fstack-clash-protection -fPIE -fcf-protection=full
+    HARDEN_C_FLAGS = -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fstack-clash-protection -fPIE
+    # Intel CET is an x86 hardening facility. GCC rejects -fcf-protection on
+    # AArch64, so keeping it in the unconditional Linux set made the published
+    # arm64 thin client unbuildable even though the source is portable.
+    ifneq ($(filter x86_64% amd64% i386% i486% i586% i686%,$(CC_MACHINE)),)
+        HARDEN_C_FLAGS += -fcf-protection=full
+    endif
     HARDEN_L_FLAGS = -pie -Wl,-z,relro,-z,now -Wl,-z,noexecstack
     C_FLAGS += $(HARDEN_C_FLAGS)
 endif
@@ -956,7 +963,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB1_CLIENT_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS
 # nothing is stale when nothing exists.
 DEPS = $(ALL_OBJS:.o=.d) $(shell find $(OBJDIR) -name '*.d' 2>/dev/null)
 
-.PHONY: optional-tool-ownership-check refactor-baseline-check module-source-ownership-check go-package-ownership-check module-bus-boundary-check module-egress-check cleanup-ledger-check repository-lock-check db2-contract-check db2-declaration-ledger-check db2-activation-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check memory-store-degradation-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check manifest-emitter-linkage-check argspec-numeric-parity-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests configure-hooks-matrix-test go-unit-tests go-vulncheck verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check learning-loop-evidence self-learning-efficacy virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb provider-seams-check provider-registration-check changeset-worm-seal-check worm-worker-boundary-check module-placement-check
+.PHONY: optional-tool-ownership-check refactor-baseline-check module-source-ownership-check go-package-ownership-check module-bus-boundary-check module-egress-check cleanup-ledger-check repository-lock-check db2-contract-check db2-declaration-ledger-check db2-activation-check all clean install inc-check forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check memory-store-degradation-check config-schema-drift-check config-uninitialized-check cmd-srcs-compile-check charter-tables-check tier-deps-check module-boundary-check module-inventory-check background-skill-curator-absence-check guidance-tool-parity-check capability-ownership-check panel-contract-boundary-check published-compose-images-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check deploy-env-consumed-check sidecar-clients-check docs-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check manifest-emitter-linkage-check argspec-numeric-parity-check async-op-handlers-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check pending-audit-manifest-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check models-dev-snapshot-check test-tmpdir-check tests-are-run-check model-fallback-shadow-check p1-tenant-guard-check p1-rls-gate-check bus-blast-radius-check entrypoint-exit-report-check webchat-bootstrap-login-check deployed-image-check gen-sdks sdk-parity-check v1-ws-test format unit-tests configure-hooks-matrix-test go-unit-tests go-vulncheck verify-local integration-tests wizard-bootstrap-e2e v1-third-party-test v1-sdk-smoke init-migrate-service-test postgres-store-upgrade-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check learning-loop-evidence self-learning-efficacy virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries kb provider-seams-check provider-registration-check changeset-worm-seal-check worm-worker-boundary-check module-placement-check
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_RUNTIME_WEB) $(DELEGATE_EGRESS) $(SERVER) $(KB) $(KB_WORM) $(KB_RESOLVER) $(GATEWAY) $(FORWARDER)
 
@@ -1316,6 +1323,9 @@ integration-tests: $(BINARY) $(SERVER) $(OBJDIR)/aimee-module $(CONFIG_MODULE)
 
 init-migrate-service-test: $(BINARY) $(SERVER) $(CONFIG_MODULE)
 	./tests/test_init_migrate_service.sh
+
+postgres-store-upgrade-test:
+	../scripts/tests/test_postgres_store_upgrade.sh
 
 # The kb entrypoint's embedder gate. Needs no binary, no cluster and no image: it
 # sources the entrypoint's definitions and calls them directly.

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -389,8 +389,14 @@ static cJSON *kb_service_health_object(void)
 
    /* DB2: generic schema + KB-specific tables */
    int schema_ok = 0, have_pg_trgm = 0, kb_tables_ok = 0;
-   int db2_ok = (kb_module_postgres_health_probe(&schema_ok, &have_pg_trgm, &kb_tables_ok) == 0 &&
-                 schema_ok);
+   /* DB2 still runs in-process in the KB owner. The generic PostgreSQL process
+    * module reads AIMEE_STORE_URL (the server-store DSN), while the staged DB2
+    * bus adapter is not attached until that ownership migration completes.
+    * Probing either one here returns capability_absent on a healthy managed KB.
+    * Use the same thread-safe DB2 probes as startup readiness. */
+   int db2_ok = (db2_health_probe(&schema_ok, &have_pg_trgm) == 0 && schema_ok && have_pg_trgm);
+   if (db2_kb_health_probe(&kb_tables_ok) != 0)
+      kb_tables_ok = 0;
    cJSON_AddBoolToObject(resp, "db2_ok", db2_ok);
    cJSON_AddBoolToObject(resp, "db2_kb_tables_ok", kb_tables_ok);
 

--- a/src/modules/kb_client/kb_client_mtls.c
+++ b/src/modules/kb_client/kb_client_mtls.c
@@ -986,6 +986,28 @@ char *kb_client_mtls_request_timeout_with_type(const char *method, const char *p
                       content_type, 0, resp, cap, &status, &reusable)
                 : -1;
    pool_return(entry, rc == 0 && reusable);
+
+   /* A pooled keep-alive can outlive a KB container restart. The first write
+    * then discovers the dead socket even though a fresh handshake would work,
+    * which previously made an already-recovered KB look unavailable until the
+    * next breaker probe (or a server restart). Retry a response-free read once
+    * on a newly borrowed connection. Writes are deliberately excluded: the
+    * peer may have committed a POST before the connection disappeared. */
+   if (rc != 0 && status < 0 && (strcasecmp(method, "GET") == 0 || strcasecmp(method, "HEAD") == 0))
+   {
+      entry = pool_borrow(&pool_error);
+      if (entry)
+      {
+         status = -1;
+         reusable = 0;
+         rc = kb_tls_client_conn_set_timeout(entry->conn, timeout_ms) == 0
+                  ? kb_tls_client_conn_request_with_type(
+                        entry->conn, method, path, (body && body[0]) ? body : NULL, authorization,
+                        content_type, 0, resp, cap, &status, &reusable)
+                  : -1;
+         pool_return(entry, rc == 0 && reusable);
+      }
+   }
    if (status_out)
       *status_out = status;
    /* Body preserved on non-2xx as above; *status_out distinguishes. */

--- a/src/server/server_ready.c
+++ b/src/server/server_ready.c
@@ -55,6 +55,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -118,6 +119,30 @@ static int ready_interval_secs(void)
 static int ready_stale_secs(void)
 {
    return env_int("AIMEE_READY_STALE_SECS", READY_STALE_DEFAULT, ready_interval_secs(), 86400);
+}
+
+static int env_switch_is(const char *value, int enabled)
+{
+   if (!value || !value[0])
+      return 0;
+   if (enabled)
+      return strcasecmp(value, "1") == 0 || strcasecmp(value, "true") == 0 ||
+             strcasecmp(value, "on") == 0 || strcasecmp(value, "yes") == 0;
+   return strcasecmp(value, "0") == 0 || strcasecmp(value, "false") == 0 ||
+          strcasecmp(value, "off") == 0 || strcasecmp(value, "no") == 0;
+}
+
+/* Keep readiness aligned with optional-modules-lib.sh. An explicit module
+ * switch wins; otherwise runtime-web follows the browser UI switch. Invalid or
+ * absent values preserve the image's default-on manifest entry. */
+static int runtime_web_required(void)
+{
+   const char *module_intent = getenv("AIMEE_MODULE_RUNTIME_WEB");
+   if (env_switch_is(module_intent, 1))
+      return 1;
+   if (env_switch_is(module_intent, 0))
+      return 0;
+   return !env_switch_is(getenv("AIMEE_RUNTIME_WEB_ENABLED"), 0);
 }
 
 static const char *dep_name(dep_state_t s)
@@ -222,6 +247,8 @@ void server_ready_sample_now(void)
    s.modules = DEP_OK;
    for (size_t i = 0; i < sizeof(required_modules) / sizeof(required_modules[0]); ++i)
    {
+      if (required_modules[i].kind == AIMEE_RUNTIME_WEB_EVENT_CLASSIFY && !runtime_web_required())
+         continue;
       if (obs_bus_module_available(required_modules[i].kind))
          continue;
       s.modules = DEP_FAIL;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -3981,6 +3981,24 @@ static void test_mtls_listener(void)
       assert(pool_total == 1 && pool_idle == 1 && pool_busy == 0 && pool_waiters == 0);
       assert(pool_exhausted == 0);
 
+      /* A managed KB restart leaves an apparently reusable socket in the
+       * server pool. The first read must discard that dead connection and
+       * reconnect immediately; waiting for a process restart or idle reaper
+       * turns a recovered KB into a prolonged user-visible outage. */
+      unsigned long handshakes_before_listener_restart = 0, resumed_before_listener_restart = 0;
+      kb_client_mtls_tls_stats(&handshakes_before_listener_restart,
+                               &resumed_before_listener_restart);
+      kb_mtls_stop();
+      assert(kb_mtls_start(port, cfg, "localhost") == 0);
+      assert(kb_mtls_bound_port() == port);
+      r = kb_client_mtls_request_timeout("GET", "/v1/health", NULL, 600000, &st2);
+      assert(st2 == 200 && r && strstr(r, "\"status\":\"ok\""));
+      free(r);
+      unsigned long handshakes_after_listener_restart = 0, resumed_after_listener_restart = 0;
+      kb_client_mtls_tls_stats(&handshakes_after_listener_restart, &resumed_after_listener_restart);
+      assert(handshakes_after_listener_restart == handshakes_before_listener_restart + 1);
+      assert(resumed_after_listener_restart >= resumed_before_listener_restart);
+
       unsigned long caller_handshakes = 0, caller_resumed = 0;
       kb_client_mtls_tls_stats(&caller_handshakes, &caller_resumed);
       snprintf(g_test_outbound_caller, sizeof(g_test_outbound_caller), "%s", "alice");

--- a/src/tests/test_server_ready.c
+++ b/src/tests/test_server_ready.c
@@ -13,6 +13,7 @@
 #include <aimee/skills/module_api.h>
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* --- stubs for the sampler's dependency closure (link-only) --- */
@@ -59,10 +60,35 @@ int obs_bus_module_available(uint32_t event_kind)
 int main(void)
 {
    char resp[2048];
+
+   unsetenv("AIMEE_RUNTIME_WEB_ENABLED");
+   unsetenv("AIMEE_MODULE_RUNTIME_WEB");
    server_ready_sample_now();
    assert(g_runtime_web_checked == 1);
    assert(g_skills_trigger_checked == 1);
    assert(g_git_ref_checked == 1);
+
+   /* runtime-web is optional. Readiness must follow the same operator intent
+    * as the entrypoint instead of waiting forever for an intentionally
+    * disabled module. An explicit module switch wins over the UI switch. */
+   g_runtime_web_checked = 0;
+   setenv("AIMEE_RUNTIME_WEB_ENABLED", "0", 1);
+   server_ready_sample_now();
+   assert(g_runtime_web_checked == 0);
+
+   g_runtime_web_checked = 0;
+   setenv("AIMEE_MODULE_RUNTIME_WEB", "yes", 1);
+   server_ready_sample_now();
+   assert(g_runtime_web_checked == 1);
+
+   g_runtime_web_checked = 0;
+   setenv("AIMEE_RUNTIME_WEB_ENABLED", "true", 1);
+   setenv("AIMEE_MODULE_RUNTIME_WEB", "off", 1);
+   server_ready_sample_now();
+   assert(g_runtime_web_checked == 0);
+
+   unsetenv("AIMEE_RUNTIME_WEB_ENABLED");
+   unsetenv("AIMEE_MODULE_RUNTIME_WEB");
    server_ready_diagnostics_t ok = {.retrieval_ok = 1,
                                     .modules_ok = 1,
                                     .failed_boundary = "",

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -9325,6 +9325,7 @@
         "src/cmd_core.c",
         "src/cmd_doctor.c",
         "src/kb/kb_main.c",
+        "src/kb/kb_service_kb.c",
         "src/tests/test_db2.c",
         "src/tests/test_witness_checkpoint_produce_pg.c"
       ],
@@ -10262,6 +10263,7 @@
     },
     {
       "consumers": [
+        "src/kb/kb_service_kb.c",
         "src/tests/test_db2.c",
         "src/tests/test_witness_checkpoint_produce_pg.c"
       ],
@@ -27069,7 +27071,7 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "8c9cc91927e85e39d4d1f4366c649355135a22d1089018669b580e8a9a247932",
+  "fingerprint": "3076780eb9b2cb35df5fec13223e3cc13b71ba95ffbcdf94cefa82d9042f6e29",
   "module": "db2",
   "schema_version": 1,
   "summary": {


### PR DESCRIPTION
## Summary

Fixes the release blockers found while validating `:testing` on the release host:

- make Linux hardening architecture-aware so arm64 builds do not receive x86 CET flags
- pin Nomic's external `auto_map` code repository in both embedder bake paths
- reconcile historical `aimee:aimee` PostgreSQL 18 store volumes into split admin/migrator/runtime roles without losing data
- authenticate both store roles in health checks instead of accepting `pg_isready` false positives
- make server health require core readiness and make KB health require the real DB2 schema/tables
- recover pooled idempotent reads immediately after a managed KB restart without retrying ambiguous writes
- generate all three independent store passwords in the Docker smoke harnesses
- add a CI regression that upgrades the exact historical store shape in place and repeats the reconciliation to prove idempotency

## Validation

On `root@192.168.1.252`:

- full Nomic image build completed and fetched `nomic-ai/nomic-bert-2048@e5042dce39060cc34bc223455f25cf1d26db4655`
- real AArch64 compiler accepted the hardened flags and produced an AArch64 ELF object without `-fcf-protection`
- historical PostgreSQL 18 volume upgrade preserved its identity-backed row and object ownership, rejected the old/wrong/plaintext credentials, and passed a second boot (`postgres-store-upgrade: ok`)
- all eight shipping Compose manifests parsed successfully
- split server + A25M + PostgreSQL stack passed 10/10 probes, including strict `db2_ok` and KB-table readiness
- standalone server + PostgreSQL stack passed 4/4 probes
- restarting the live KB under an unchanged server restored `/v1/rules` with HTTP 200 in 64 ms; the stale pooled socket did not require a server restart
- every test container and volume was removed afterward; only the two pre-existing unrelated containers remain

Local gates:

- `make -C src -j4 unit-tests` — all tests passed
- `make -C src -j4 integration-tests` — 70/70 plus thin-client/argspec E2E passed
- `make -C src -j4 go-unit-tests` — passed
- `python3 -I scripts/tests/test_bake_embedder.py` — passed
- packaging, managed-authority, deploy-env, shell syntax, formatting, and diff checks — passed
