### PR TITLE
fix: finish the split stack, and name the credentials every profile requires

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,21 @@
 # enrollment material or credentials.
 COMPOSE_PROFILES=
 
+# The store's three PostgreSQL roles. Every Compose profile that runs
+# aimee-store-db REQUIRES all three -- there is deliberately no default, so a
+# deployment cannot inherit a shipped password. Compose reads this file
+# automatically, so generating them once here is enough:
+#
+#   for v in ADMIN MIGRATOR RUNTIME; do
+#     echo "AIMEE_STORE_${v}_PASSWORD=$(openssl rand -hex 32)" >> .env
+#   done
+#
+# Keep them: they are the credentials for the existing data directory, and
+# changing one after first boot does not re-run initdb.
+# AIMEE_STORE_ADMIN_PASSWORD=
+# AIMEE_STORE_MIGRATOR_PASSWORD=
+# AIMEE_STORE_RUNTIME_PASSWORD=
+
 # Optional split/external authority enrollment values. Leave blank for the
 # managed wizard path; see docs/QUICKSTART.md before setting these.
 # AIMEE_SERVER_ID=YOUR_ENROLLED_SERVER_ID

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -36,7 +36,17 @@ services:
       # MUST receive both: `aimee config deploy-env` emits them, and without them
       # reaching the container the entrypoint sees no selection, starts nothing, and
       # the builtin serves forever — the wizard's embedder silently never runs.
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}
+      #
+      # DEFAULTED, and it must stay PAIRED with the image default above. There is
+      # no wizard on this topology to write embedder_model into the kb's config,
+      # so on a fresh volume read_cfg_embedding_model finds nothing and the
+      # entrypoint exits 1 with "no embedder selected, and there is no fallback".
+      # Pointing the image default at the bundled-embedder variant was necessary
+      # but not sufficient: the weights are in the image and it still refuses,
+      # because nothing selected them. Pinning AIMEE_KB_IMAGE to another variant
+      # means setting this to match it (nomic-embed-text-v2-moe for aimee-kb-nomic);
+      # EMBEDDER_URL still wins outright, so the external case is unaffected.
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-bekko-a25m}
       EMBEDDER_URL: ${EMBEDDER_URL:-}
       # Embedding dim. Leave EMPTY so the kb uses the dimension of the embedder it
       # actually serves (the bundled bekko-a25m is 384). This carried the retired

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,14 +14,62 @@ boundary.
 
 ## Split stack
 
+> **This profile does not currently complete the server-to-KB link.** Everything below brings both
+> halves up healthy, and then every server call to the KB fails. Use the managed profile until this
+> is resolved; the detail is in [What is broken](#what-is-broken-in-this-profile) so a deployment is
+> not attempted on the assumption that it merely needs more configuration.
+
 ```bash
-docker compose -f deploy/compose/aimee.yaml up -d
+cp -n .env.example .env
+for v in ADMIN MIGRATOR RUNTIME; do
+  echo "AIMEE_STORE_${v}_PASSWORD=$(openssl rand -hex 32)" >> .env
+done
+export AIMEE_KB_API_BEARER_TOKEN=$(openssl rand -hex 32)
+./scripts/aimee-compose-vault-bootstrap.sh -f deploy/compose/aimee.yaml all
+unset AIMEE_KB_API_BEARER_TOKEN
+docker compose --env-file .env -f deploy/compose/aimee.yaml up -d
 ```
 
 Server and one KB are declared together, and no browser action needs to create them. The KB owns its
 embedding and synthesis role placements. Each role can run inside the KB container or use a remote
-endpoint supported by the selected profile. There is no separate inference service. This is the
-safer default when the server must not control Docker.
+endpoint supported by the selected profile. There is no separate inference service. This is intended
+as the safer default when the server must not control Docker.
+
+`all`, not `kb`: the same token is the KB's inbound credential and the server's outbound one, so
+sealing it into only the KB leaves the halves unable to talk at all.
+
+**`--env-file .env` is not optional on this path.** Compose takes its project directory from the
+first `-f` file, so for `deploy/compose/aimee.yaml` it looks for `deploy/compose/.env` and never
+reads the one at the repository root. Without the flag the command fails on the store passwords even
+though the file exists. The root-level profiles need no flag, because their project directory
+already is the repository root.
+
+### What is broken in this profile
+
+The three requirements below cannot all be satisfied at once, so no value of
+`AIMEE_KB_API_BEARER_TOKEN` makes this profile work:
+
+1. The profile sets `AIMEE_KB_HTTP_BIND=1`, and it has to: the server reaches the KB across the
+   Compose network by name, and a loopback-only listener is unreachable from another container.
+2. Binding `0.0.0.0` with no bearer is a hard refusal, not a warning. The KB logs
+   `refusing to bind 0.0.0.0:8741 with no bearer configured` and exits, and because the container is
+   `restart: unless-stopped` that presents as a KB restarting every thirty seconds while
+   `aimee-server` sits in `Created` behind its `service_healthy` gate.
+3. Once a bearer exists, the server refuses to present it over the profile's own
+   `AIMEE_KB_API_URL: http://aimee-kb:8741`, because that is cleartext to a non-loopback host:
+
+   ```text
+   kb_client: refusing to send the kb bearer in cleartext to non-loopback host 'aimee-kb';
+   use the mTLS endpoint or terminate TLS in front of the kb
+   ```
+
+   The request is never sent, so `/v1/kb/status` reports `did not respond` and the circuit opens.
+   That line goes to `/var/lib/aimee/server.log` inside the container and not to `docker logs`, so
+   the visible symptom carries none of the cause.
+
+Resolving it needs the server to reach the KB over mTLS or through a TLS terminator, which this
+profile does not yet configure. Both halves report healthy throughout, so container health is not a
+signal that the link works.
 
 The one-KB Compose files are deployment profiles, not the fleet limit. The target architecture can
 route among several KB containers with explicit corpus, authority, and capability identity. Fleet
@@ -43,6 +91,11 @@ unused:
 export AIMEE_STORE_URL='postgres://user:password@host:5432/aimee_store'
 docker compose -f compose.server.yaml up -d
 ```
+
+The bundled service still needs `AIMEE_STORE_ADMIN_PASSWORD`,
+`AIMEE_STORE_MIGRATOR_PASSWORD` and `AIMEE_STORE_RUNTIME_PASSWORD` to be set even when
+`AIMEE_STORE_URL` points elsewhere, because Compose interpolates every service it parses before it
+decides which to start. Generate them into `.env` as above.
 
 Create that database `ENCODING UTF8 TEMPLATE template0`. This is load-bearing
 rather than tidiness: the store bounds text with `octet_length`, and in a

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,9 +15,27 @@ can start the KB container.
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
+cp -n .env.example .env
+for v in ADMIN MIGRATOR RUNTIME; do
+  echo "AIMEE_STORE_${v}_PASSWORD=$(openssl rand -hex 32)" >> .env
+done
 docker compose -f compose.server-managed.yaml up -d
 docker compose -f compose.server-managed.yaml logs aimee-server
 ```
+
+The store runs three separate PostgreSQL roles (an admin, a migrator and a runtime), and every
+Compose profile that starts `aimee-store-db` requires a password for each. There is deliberately no
+default, so no deployment can inherit a password that ships in the repository; without them Compose
+stops before it creates anything:
+
+```text
+error while interpolating services.aimee-store-db.environment.POSTGRES_PASSWORD:
+required variable AIMEE_STORE_ADMIN_PASSWORD is missing a value
+```
+
+Compose reads `.env` on its own, so generating them once as above is all that is needed. Keep the
+file: those are the credentials for the data directory that now exists, and changing one later does
+not re-run `initdb`.
 
 When you do not supply a dashboard login, the server generates one on first boot and prints it once
 in that log. The values below show the format. Your values will be different:

--- a/scripts/aimee-compose-vault-bootstrap.sh
+++ b/scripts/aimee-compose-vault-bootstrap.sh
@@ -4,12 +4,20 @@
 set -eu
 
 usage() {
-    printf 'usage: %s [-p PROJECT] -f COMPOSE_FILE {server|kb|all}\n' "$0" >&2
+    printf 'usage: %s [-p PROJECT] [-e ENV_FILE] -f COMPOSE_FILE {server|kb|all}\n' "$0" >&2
     exit 2
 }
 
 compose_file=
 project=
+# Compose reads `.env` from the PROJECT directory, which is the directory holding
+# the first -f file -- so `-f deploy/compose/aimee.yaml` looks in deploy/compose/
+# and never sees the repository-root .env. Once a profile declares a required
+# variable with no default, every compose call here fails at interpolation before
+# it can seal anything. -e forwards the same --env-file the operator used for
+# `up`; the repo-root .env is picked up automatically when it exists, so the
+# common case needs no flag.
+env_file=
 while [ "$#" -gt 0 ]; do
     case "$1" in
         -f|--file)
@@ -26,11 +34,24 @@ while [ "$#" -gt 0 ]; do
             project=$2
             shift 2
             ;;
+        -e|--env-file)
+            [ "$#" -ge 2 ] || usage
+            env_file=$2
+            shift 2
+            ;;
         -*) usage ;;
         *) break ;;
     esac
 done
 [ -n "$compose_file" ] && [ -r "$compose_file" ] || usage
+if [ -z "$env_file" ]; then
+    repo_env=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)/.env
+    [ -r "$repo_env" ] && env_file=$repo_env
+fi
+[ -z "$env_file" ] || [ -r "$env_file" ] || {
+    printf '%s: cannot read env file %s\n' "$0" "$env_file" >&2
+    exit 2
+}
 [ "$#" -eq 1 ] || usage
 target=$1
 
@@ -60,11 +81,10 @@ if [ -z "$project" ] && [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
 fi
 
 compose() {
-    if [ -n "$project" ]; then
-        docker compose -p "$project" -f "$compose_file" "$@"
-    else
-        docker compose -f "$compose_file" "$@"
-    fi
+    set -- -f "$compose_file" "$@"
+    [ -z "$env_file" ] || set -- --env-file "$env_file" "$@"
+    [ -z "$project" ] || set -- -p "$project" "$@"
+    docker compose "$@"
 }
 
 announce_project() {


### PR DESCRIPTION
Rebuilt on top of #2882, which independently landed most of what this branch
originally carried: the dot-file ingest rule, the synthesis-sidecar release tags,
the compose-image checker, and the two message fixes. Ten of the thirteen changes
here are now upstream, so they have been dropped rather than re-proposed. What is
left is three things #2882 did not cover, all found by running the documented
commands rather than reading them.

## The split stack still cannot start

`EMBEDDER_MODEL` is empty in `deploy/compose/aimee.yaml`. Pointing the image default at
the bundled-embedder variant was necessary but not sufficient: there is no wizard on this
topology to write `embedder_model` into the KB's config, so on a fresh volume
`read_cfg_embedding_model` finds nothing and the entrypoint exits 1 with
`no embedder selected, and there is no fallback`. Verified straight against
`aimee-kb-a25m:testing`: the weights are in the image and it still refuses, because
nothing selected them.

## The Vault bootstrap script cannot run against the split stack

`aimee-compose-vault-bootstrap.sh` called `docker compose` with no `--env-file`. Compose
reads `.env` from the *project directory*, which is the directory holding the first `-f`
file, so `-f deploy/compose/aimee.yaml` looks in `deploy/compose/` and never sees the
repository-root `.env`. Now that the store passwords are required with no default, every
compose call in the script died at interpolation before it could seal anything. It now
takes `-e/--env-file`, defaults to the repo-root `.env` when one exists, and forwards it
to every call.

## The store passwords are named in no document

They appear only in two smoke-test scripts, so QUICKSTART's first command stops before it
creates anything:

```text
error while interpolating services.aimee-store-db.environment.POSTGRES_PASSWORD:
required variable AIMEE_STORE_ADMIN_PASSWORD is missing a value
```

Documented in QUICKSTART section 1 and in DEPLOYMENT's split-stack and store sections,
listed in `.env.example` with the same `openssl` one-liner the smoke scripts already use,
and noted that the bundled service still needs them even when `AIMEE_STORE_URL` points
elsewhere, because Compose interpolates every service it parses before deciding which to
start. Verified: with the three generated into `.env`, the managed profile comes up
healthy end to end.

## And one thing this cannot fix

DEPLOYMENT's split-stack section now says plainly that the profile does not complete its
server-to-KB link, because three requirements cannot all hold at once:

1. it must set `AIMEE_KB_HTTP_BIND=1`, since the server reaches the KB across the Compose
   network by name and a loopback listener is unreachable from another container;
2. binding `0.0.0.0` with no bearer is a hard refusal, so without one the KB restart-loops
   while `aimee-server` waits in `Created`; and
3. with a bearer, the server refuses to present it over the profile's own
   `AIMEE_KB_API_URL=http://aimee-kb:8741`, because that is cleartext to a non-loopback host.

Measured rather than inferred: with the sealed token a direct call from inside the server
container to that URL returns 200, while the server's own `/v1/kb/status` reports
`did not respond` and opens the circuit, and `/var/lib/aimee/server.log` carries

```text
kb_client: refusing to send the kb bearer in cleartext to non-loopback host 'aimee-kb';
use the mTLS endpoint or terminate TLS in front of the kb
```

That line never reaches `docker logs`, and both containers report healthy throughout, so
the visible symptom carries none of the cause. The managed profile avoids this by enrolling
an mTLS identity during Deploy, and its KB starts an mTLS listener; the split profile does
neither. Fixing it is a topology change rather than a document, so this marks the profile
as not usable instead of shipping a recipe that fails.

## Also worth an owner

On the listener-refusal path the KB aborts with `double free or corruption (out)` while
tearing down, on every one of nine observed cycles. It is reachable from a plain
misconfiguration and is what turns that refusal into a restart loop. Sealing a bearer stops
it being triggered, but the memory-safety bug is still there and wants someone who can run
that teardown under ASan.