### PR TITLE
Fix KB startup teardown and split-stack mTLS

### DIFF
--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -56,14 +56,19 @@ services:
       # Set it ONLY for an external EMBEDDER_URL, whose width the kb cannot
       # know.
       EMBEDDER_DIMS: ${EMBEDDER_DIMS:-}
-      AIMEE_KB_HTTP_BIND: "1"
+      # Keep plain HTTP process-local for the healthcheck. Server traffic uses
+      # the independently authenticated mTLS lane below; a bearer must never
+      # cross the Compose network in cleartext.
+      AIMEE_KB_HTTP_BIND: ""
+      AIMEE_KB_MTLS_HOST: aimee-kb
+      AIMEE_KB_MTLS_PORT: "8745"
       # The curator adapter reads the same SYNTHESIS_ENDPOINT above. It used to need
       # its own LLM_ENDPOINT, defaulted to a container this file never defined, so a
       # fresh deployment aimed the adapter at a dead host while the KB used
       # AIMEE_LLM_URL. One endpoint, one spelling.
     command: ["--http-port=8741"]
-    ports:
-      - "8741:8741"
+    expose:
+      - "8745"
     healthcheck:
       test: ["CMD-SHELL", "body=$$(curl -fsS http://127.0.0.1:8741/v1/health) && printf '%s' \"$$body\" | grep -q '\"status\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"db2_ok\":true' && printf '%s' \"$$body\" | grep -q '\"db2_kb_tables_ok\":true'"]
       interval: 10s
@@ -156,7 +161,6 @@ services:
       # was telling operators the server kept a database it does not keep.
       AIMEE_STORE_URL: "host=aimee-store-db port=5432 dbname=aimee_store user=aimee_store_runtime password=${AIMEE_STORE_RUNTIME_PASSWORD:?AIMEE_STORE_RUNTIME_PASSWORD is required} sslmode=verify-full sslrootcert=/run/aimee-store-tls/server.crt"
       AIMEE_STORE_MIGRATION_URL: "host=aimee-store-db port=5432 dbname=aimee_store user=aimee_store_migrator password=${AIMEE_STORE_MIGRATOR_PASSWORD:?AIMEE_STORE_MIGRATOR_PASSWORD is required} sslmode=verify-full sslrootcert=/run/aimee-store-tls/server.crt"
-      AIMEE_KB_API_URL: http://aimee-kb:8741
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_RUNTIME_WEB_ENABLED: ${AIMEE_RUNTIME_WEB_ENABLED:-1}
       # First-boot credentials are streamed into Vault before `up`; this
@@ -172,6 +176,8 @@ services:
         condition: service_healthy
       aimee-kb:
         condition: service_healthy
+      aimee-server-identity:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL",
              "body=$$(curl -sS --max-time 4 --unix-socket /var/lib/aimee/aimee-http.sock http://localhost/v1/ready) && printf '%s' \"$$body\" | grep -q '\"db1\":\"ok\"' && printf '%s' \"$$body\" | grep -q '\"modules\":\"ok\"'"]
@@ -183,6 +189,31 @@ services:
       - aimee-server-home:/var/lib/aimee
       - aimee-store-tls:/run/aimee-store-tls:ro
       - aimee-server-workspaces:/var/lib/aimee-workspaces
+
+  # Issue the server's dedicated KB client identity before its long-lived
+  # process starts. The helper owns no durable state: it writes the client
+  # identity to the server home while the KB keeps its CA and DB2 private.
+  aimee-server-identity:
+    restart: "no"
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-a25m:${AIMEE_IMAGE_TAG:-latest}}
+    user: "0:0"
+    environment:
+      AIMEE_HOME: /var/lib/aimee
+      AIMEE_DB2_URL: postgresql:///aimee_shared?host=/var/lib/aimee/run&user=aimee
+    command:
+      - managed-server-identity
+      - install
+      - --server-home=/var/lib/aimee-server
+      - --host=aimee-kb
+      - --port=8745
+      - --endpoint=https://aimee-server:8743
+      - --uid=1000
+    depends_on:
+      aimee-kb:
+        condition: service_healthy
+    volumes:
+      - aimee-kb-home:/var/lib/aimee
+      - aimee-server-home:/var/lib/aimee-server
 
 volumes:
   aimee-store-db:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,19 +14,15 @@ boundary.
 
 ## Split stack
 
-> **This profile does not currently complete the server-to-KB link.** Everything below brings both
-> halves up healthy, and then every server call to the KB fails. Use the managed profile until this
-> is resolved; the detail is in [What is broken](#what-is-broken-in-this-profile) so a deployment is
-> not attempted on the assumption that it merely needs more configuration.
-
 ```bash
 cp -n .env.example .env
 for v in ADMIN MIGRATOR RUNTIME; do
   echo "AIMEE_STORE_${v}_PASSWORD=$(openssl rand -hex 32)" >> .env
 done
-export AIMEE_KB_API_BEARER_TOKEN=$(openssl rand -hex 32)
+export AIMEE_KB_API_BEARER_TOKEN="scope:service:aimee-server:$(openssl rand -hex 32)"
+export AIMEE_KB_SERVICE_IDENTITY_TOKEN="scope:service:aimee-server:$(openssl rand -hex 32)"
 ./scripts/aimee-compose-vault-bootstrap.sh -f deploy/compose/aimee.yaml all
-unset AIMEE_KB_API_BEARER_TOKEN
+unset AIMEE_KB_API_BEARER_TOKEN AIMEE_KB_SERVICE_IDENTITY_TOKEN
 docker compose --env-file .env -f deploy/compose/aimee.yaml up -d
 ```
 
@@ -35,41 +31,17 @@ embedding and synthesis role placements. Each role can run inside the KB contain
 endpoint supported by the selected profile. There is no separate inference service. This is intended
 as the safer default when the server must not control Docker.
 
-`all`, not `kb`: the same token is the KB's inbound credential and the server's outbound one, so
-sealing it into only the KB leaves the halves unable to talk at all.
+`all`, not `kb`: the connection bearer and application-identity token must be sealed into both
+Vaults. The one-shot `aimee-server-identity` service then issues the server's separate client
+certificate before the long-lived server starts. Server-to-KB requests use all three checks over
+mTLS on the private Compose network. The KB's plain HTTP listener remains loopback-only for its
+container healthcheck and is not published on the host.
 
 **`--env-file .env` is not optional on this path.** Compose takes its project directory from the
 first `-f` file, so for `deploy/compose/aimee.yaml` it looks for `deploy/compose/.env` and never
 reads the one at the repository root. Without the flag the command fails on the store passwords even
 though the file exists. The root-level profiles need no flag, because their project directory
 already is the repository root.
-
-### What is broken in this profile
-
-The three requirements below cannot all be satisfied at once, so no value of
-`AIMEE_KB_API_BEARER_TOKEN` makes this profile work:
-
-1. The profile sets `AIMEE_KB_HTTP_BIND=1`, and it has to: the server reaches the KB across the
-   Compose network by name, and a loopback-only listener is unreachable from another container.
-2. Binding `0.0.0.0` with no bearer is a hard refusal, not a warning. The KB logs
-   `refusing to bind 0.0.0.0:8741 with no bearer configured` and exits, and because the container is
-   `restart: unless-stopped` that presents as a KB restarting every thirty seconds while
-   `aimee-server` sits in `Created` behind its `service_healthy` gate.
-3. Once a bearer exists, the server refuses to present it over the profile's own
-   `AIMEE_KB_API_URL: http://aimee-kb:8741`, because that is cleartext to a non-loopback host:
-
-   ```text
-   kb_client: refusing to send the kb bearer in cleartext to non-loopback host 'aimee-kb';
-   use the mTLS endpoint or terminate TLS in front of the kb
-   ```
-
-   The request is never sent, so `/v1/kb/status` reports `did not respond` and the circuit opens.
-   That line goes to `/var/lib/aimee/server.log` inside the container and not to `docker logs`, so
-   the visible symptom carries none of the cause.
-
-Resolving it needs the server to reach the KB over mTLS or through a TLS terminator, which this
-profile does not yet configure. Both halves report healthy throughout, so container health is not a
-signal that the link works.
 
 The one-KB Compose files are deployment profiles, not the fleet limit. The target architecture can
 route among several KB containers with explicit corpus, authority, and capability identity. Fleet
@@ -146,7 +118,7 @@ Use the compose files and generated configuration as the source of truth. Typica
 | --- | ---: | --- |
 | browser | 8443 | user network, HTTPS |
 | server `/v1` | 8743 | enrolled clients only |
-| KB `/v1` | 8741 | deployment network only |
+| KB service mTLS | 8745 | deployment network only |
 | remote model endpoint | provider-defined | deployment network only |
 
 Do not publish PostgreSQL or a remote model endpoint unless a separate host needs it. Apply TLS and

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -349,8 +349,19 @@ docker compose -f compose.server-managed.yaml logs --tail=100 aimee-server
 If the server must not control Docker, use the split stack instead:
 
 ```bash
-docker compose -f deploy/compose/aimee.yaml up -d
+cp -n .env.example .env
+for v in ADMIN MIGRATOR RUNTIME; do
+  echo "AIMEE_STORE_${v}_PASSWORD=$(openssl rand -hex 32)" >> .env
+done
+export AIMEE_KB_API_BEARER_TOKEN="scope:service:aimee-server:$(openssl rand -hex 32)"
+export AIMEE_KB_SERVICE_IDENTITY_TOKEN="scope:service:aimee-server:$(openssl rand -hex 32)"
+scripts/aimee-compose-vault-bootstrap.sh -f deploy/compose/aimee.yaml all
+unset AIMEE_KB_API_BEARER_TOKEN AIMEE_KB_SERVICE_IDENTITY_TOKEN
+docker compose --env-file .env -f deploy/compose/aimee.yaml up -d
 ```
+
+This profile installs a dedicated server-to-KB client certificate and uses mTLS; it does not expose
+the KB's plain HTTP listener. See [Deployment](DEPLOYMENT.md#split-stack) for the trust boundaries.
 
 The old combined image is gone.
 

--- a/scripts/check-kb-container-packaging.py
+++ b/scripts/check-kb-container-packaging.py
@@ -378,6 +378,57 @@ def kb_mtls_failures(text: str) -> list[str]:
     ]
 
 
+def split_kb_identity_failures(text: str) -> list[str]:
+    """Keep the no-Docker-socket profile on the authenticated mTLS path."""
+    if yaml is None:
+        return ["PyYAML is required to validate the effective Compose model"]
+    try:
+        model = yaml.load(text, Loader=UniqueKeySafeLoader)
+    except yaml.YAMLError as exc:
+        return [f"invalid Compose YAML: {exc.__class__.__name__}"]
+    services = model.get("services") if isinstance(model, dict) else None
+    if not isinstance(services, dict):
+        return ["missing services mapping"]
+    kb = services.get("aimee-kb")
+    server = services.get("aimee-server")
+    identity = services.get("aimee-server-identity")
+    if not all(isinstance(service, dict) for service in (kb, server, identity)):
+        return ["split stack requires KB, server, and server-identity services"]
+
+    failures: list[str] = []
+    kb_env = kb.get("environment")
+    if not isinstance(kb_env, dict) or kb_env.get("AIMEE_KB_HTTP_BIND") != "":
+        failures.append("KB must override the image's public HTTP bind with an empty value")
+    if kb.get("ports"):
+        failures.append("KB plain HTTP listener must not be published")
+    server_env = server.get("environment")
+    if not isinstance(server_env, dict) or "AIMEE_KB_API_URL" in server_env:
+        failures.append("server must not retain a cleartext KB fallback URL")
+
+    server_dep = server.get("depends_on")
+    identity_dep = server_dep.get("aimee-server-identity") if isinstance(server_dep, dict) else None
+    if not isinstance(identity_dep, dict) or identity_dep.get("condition") != "service_completed_successfully":
+        failures.append("server must wait for successful KB client identity installation")
+    helper_dep = identity.get("depends_on")
+    kb_dep = helper_dep.get("aimee-kb") if isinstance(helper_dep, dict) else None
+    if not isinstance(kb_dep, dict) or kb_dep.get("condition") != "service_healthy":
+        failures.append("server identity helper must wait for a healthy KB")
+    command = identity.get("command")
+    if not isinstance(command, list) or not all(
+        required in command
+        for required in ("managed-server-identity", "install", "--host=aimee-kb", "--port=8745")
+    ):
+        failures.append("server identity helper command must install for aimee-kb:8745")
+    helper_volumes = identity.get("volumes")
+    for required in (
+        "aimee-kb-home:/var/lib/aimee",
+        "aimee-server-home:/var/lib/aimee-server",
+    ):
+        if not isinstance(helper_volumes, list) or required not in helper_volumes:
+            failures.append(f"server identity helper missing {required}")
+    return failures
+
+
 def server_default_config_failures(text: str) -> list[str]:
     if yaml is None:
         return ["PyYAML is required to validate the server container defaults"]
@@ -607,6 +658,16 @@ def check(root: Path) -> list[str]:
         for failure in managed_kb_llm_contract_failures(managed_text):
             failures.append(f"deploy/container/aimee-managed.compose.yaml {failure}")
 
+    split_compose = root / "deploy" / "compose" / "aimee.yaml"
+    if not split_compose.exists():
+        failures.append("missing deploy/compose/aimee.yaml")
+    else:
+        split_text = read(split_compose)
+        for failure in kb_mtls_failures(split_text):
+            failures.append(f"deploy/compose/aimee.yaml {failure}")
+        for failure in split_kb_identity_failures(split_text):
+            failures.append(f"deploy/compose/aimee.yaml {failure}")
+
     if not dockerignore.exists():
         failures.append("missing .dockerignore")
     else:
@@ -751,6 +812,33 @@ def plant_test() -> int:
             "      EMBEDDER_DIMS: ${EMBEDDER_DIMS:-}\n",
             encoding="utf-8",
         )
+        (root / "deploy/compose").mkdir(parents=True)
+        (root / "deploy/compose/aimee.yaml").write_text(
+            "services:\n"
+            "  aimee-kb:\n"
+            "    environment:\n"
+            '      AIMEE_KB_HTTP_BIND: ""\n'
+            "      AIMEE_KB_MTLS_HOST: aimee-kb\n"
+            '      AIMEE_KB_MTLS_PORT: "8745"\n'
+            "  aimee-server:\n"
+            "    environment: {}\n"
+            "    depends_on:\n"
+            "      aimee-server-identity:\n"
+            "        condition: service_completed_successfully\n"
+            "  aimee-server-identity:\n"
+            "    command:\n"
+            "      - managed-server-identity\n"
+            "      - install\n"
+            "      - --host=aimee-kb\n"
+            "      - --port=8745\n"
+            "    depends_on:\n"
+            "      aimee-kb:\n"
+            "        condition: service_healthy\n"
+            "    volumes:\n"
+            "      - aimee-kb-home:/var/lib/aimee\n"
+            "      - aimee-server-home:/var/lib/aimee-server\n",
+            encoding="utf-8",
+        )
         (root / "deploy/container/aimee-server-remote-writes.yaml").write_text(
             'aimee:\n  api:\n    remote_writes: "off"\n', encoding="utf-8"
         )
@@ -799,6 +887,29 @@ def plant_test() -> int:
                     file=sys.stderr,
                 )
                 return 1
+
+        split_text = read(root / "deploy/compose/aimee.yaml")
+        split_plants = (
+            split_text.replace('      AIMEE_KB_HTTP_BIND: ""\n', "", 1),
+            split_text.replace("    environment: {}\n", "    environment:\n"
+                               "      AIMEE_KB_API_URL: http://aimee-kb:8741\n", 1),
+            split_text.replace("        condition: service_completed_successfully\n",
+                               "        condition: service_started\n", 1),
+            split_text.replace("      - --host=aimee-kb\n", "", 1),
+            split_text.replace("      - aimee-server-home:/var/lib/aimee-server\n", "", 1),
+        )
+        for planted in split_plants:
+            if not split_kb_identity_failures(planted):
+                print("kb-container-packaging plant: missed split mTLS contract", file=sys.stderr)
+                return 1
+        published_split = split_text.replace(
+            "    environment:\n      AIMEE_KB_HTTP_BIND:",
+            '    ports: ["8741:8741"]\n    environment:\n      AIMEE_KB_HTTP_BIND:',
+            1,
+        )
+        if not split_kb_identity_failures(published_split):
+            print("kb-container-packaging plant: missed published split KB", file=sys.stderr)
+            return 1
 
         # The sidecar may exist, but not ungated and not without the kb ordering it
         # depends on. Planting a bare service definition exercises both.

--- a/server-go/bus/module_runtime.go
+++ b/server-go/bus/module_runtime.go
@@ -15,11 +15,23 @@ import (
 const (
 	moduleMaxInFlight  = 16
 	moduleIdle         = time.Millisecond
+	moduleIdleMax      = 10 * time.Millisecond
 	moduleConnectRetry = 100 * time.Millisecond
 	// Well inside the host's 30s stale window, so a client stays admitted
 	// across an idle stretch without heartbeating hot.
 	clientHeartbeatInterval = 5 * time.Second
 )
+
+func nextModuleIdle(delay time.Duration) time.Duration {
+	if delay >= moduleIdleMax {
+		return moduleIdleMax
+	}
+	delay *= 2
+	if delay > moduleIdleMax {
+		return moduleIdleMax
+	}
+	return delay
+}
 
 var (
 	ErrModuleConfig  = errors.New("bus: invalid module process configuration")
@@ -337,6 +349,7 @@ func runModuleClient(ctx context.Context, config ModuleProcessConfig, stages map
 	assemblies := make(map[moduleCallKey]*moduleAssembly)
 	jobs := make(map[moduleCallKey]*moduleWork)
 	done := make(chan moduleResult, moduleMaxInFlight)
+	idleDelay := moduleIdle
 
 	for {
 		for {
@@ -379,9 +392,11 @@ func runModuleClient(ctx context.Context, config ModuleProcessConfig, stages map
 			return err
 		}
 		if !ok {
-			time.Sleep(moduleIdle)
+			time.Sleep(idleDelay)
+			idleDelay = nextModuleIdle(idleDelay)
 			continue
 		}
+		idleDelay = moduleIdle
 		correlation := event.Frame.CorrelationID
 		key := moduleCallKey{principalRef: event.Frame.PrincipalRef, correlationID: correlation}
 		if event.Frame.HdrFlags&FCancel != 0 {

--- a/server-go/bus/module_runtime_test.go
+++ b/server-go/bus/module_runtime_test.go
@@ -194,6 +194,18 @@ func TestGoModuleRuntimeConfigAndBodyLimitMatchC(t *testing.T) {
 	}
 }
 
+func TestModuleIdleBackoffCaps(t *testing.T) {
+	delay := moduleIdle
+	want := []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 8 * time.Millisecond,
+		moduleIdleMax, moduleIdleMax}
+	for i, expected := range want {
+		delay = nextModuleIdle(delay)
+		if delay != expected {
+			t.Fatalf("backoff step %d = %v, want %v", i, delay, expected)
+		}
+	}
+}
+
 func TestConnectModuleWaitsOutStaleSocket(t *testing.T) {
 	path := t.TempDir() + "/stale.sock"
 	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)

--- a/src/headers/kb_http.h
+++ b/src/headers/kb_http.h
@@ -12,9 +12,18 @@
 
 #include "kb_identity.h"
 
+typedef enum
+{
+   KB_HTTP_START_OK = 0,
+   KB_HTTP_START_ERROR = -1,
+   KB_HTTP_START_ADDRESS_IN_USE = -2,
+   KB_HTTP_START_UNSAFE_BIND = -3
+} kb_http_start_result_t;
+
 /* Start the HTTP listener thread on the given port.
- * bearer_token may be NULL or empty to disable auth.
- * Returns 0 on success, -1 on error. */
+ * bearer_token may be NULL or empty to disable auth on the loopback listener.
+ * A non-loopback listener without a bearer fails with
+ * KB_HTTP_START_UNSAFE_BIND. */
 int kb_http_start(int port, const char *bearer_token);
 
 /* Signal the listener thread to stop and wait for it to exit. */

--- a/src/kb/http/kb_http_listener.c
+++ b/src/kb/http/kb_http_listener.c
@@ -234,7 +234,7 @@ static int enforce_bearer_ratchet(int port)
                 "bootstrap, or remove that marker to deliberately return to an unauthenticated "
                 "listener.",
                 port, marker);
-      return -1;
+      return KB_HTTP_START_UNSAFE_BIND;
    }
 
    LOG_ERROR("kb_http",
@@ -242,7 +242,7 @@ static int enforce_bearer_ratchet(int port)
              "AIMEE_KB_API_BEARER_TOKEN through first-boot Vault bootstrap, or unset "
              "AIMEE_KB_HTTP_BIND to keep the unauthenticated listener process-local",
              port);
-   return -1;
+   return KB_HTTP_START_UNSAFE_BIND;
 }
 
 int kb_http_start(int port, const char *bearer_token)
@@ -256,7 +256,7 @@ int kb_http_start(int port, const char *bearer_token)
 
    g_listen_fd = socket(AF_INET, SOCK_STREAM, 0);
    if (g_listen_fd < 0)
-      return -1;
+      return KB_HTTP_START_ERROR;
    fcntl(g_listen_fd, F_SETFD, FD_CLOEXEC);
    int opt = 1;
    setsockopt(g_listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
@@ -279,11 +279,12 @@ int kb_http_start(int port, const char *bearer_token)
     *
     * The marker is written when a bearer is present for diagnostics, but is not
     * an authorization state: an unsealed first boot fails closed too. */
-   if (baddr == INADDR_ANY && enforce_bearer_ratchet(port) != 0)
+   int ratchet_rc = KB_HTTP_START_OK;
+   if (baddr == INADDR_ANY && (ratchet_rc = enforce_bearer_ratchet(port)) != KB_HTTP_START_OK)
    {
       close(g_listen_fd);
       g_listen_fd = -1;
-      return -1;
+      return ratchet_rc;
    }
 
    struct sockaddr_in sa;
@@ -292,12 +293,18 @@ int kb_http_start(int port, const char *bearer_token)
    sa.sin_addr.s_addr = htonl(baddr);
    sa.sin_port = htons((uint16_t)port);
 
-   if (bind(g_listen_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0 ||
-       listen(g_listen_fd, KB_HTTP_BACKLOG) < 0)
+   if (bind(g_listen_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0)
+   {
+      int result = errno == EADDRINUSE ? KB_HTTP_START_ADDRESS_IN_USE : KB_HTTP_START_ERROR;
+      close(g_listen_fd);
+      g_listen_fd = -1;
+      return result;
+   }
+   if (listen(g_listen_fd, KB_HTTP_BACKLOG) < 0)
    {
       close(g_listen_fd);
       g_listen_fd = -1;
-      return -1;
+      return KB_HTTP_START_ERROR;
    }
 
    g_running = 1;
@@ -306,7 +313,7 @@ int kb_http_start(int port, const char *bearer_token)
       g_running = 0;
       close(g_listen_fd);
       g_listen_fd = -1;
-      return -1;
+      return KB_HTTP_START_ERROR;
    }
 
    LOG_INFO("kb_http", "listening on %s:%d", baddr == INADDR_ANY ? "0.0.0.0" : "127.0.0.1", port);

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -2341,9 +2341,9 @@ int main(int argc, char **argv)
       kb_vault_operator_components_destroy(&vault_operator_components);
       if (vault_operator_runtime_opened)
          db2_vault_operator_runtime_close(&vault_operator_runtime);
+      obs_bus_stop();
       db2_shutdown();
       kb_vault_tpm_runtime_lock_release(&vault_tpm_runtime_lock);
-      obs_bus_stop();
       audit_log_close();
       agent_http_cleanup();
       return 1;
@@ -2352,13 +2352,13 @@ int main(int argc, char **argv)
    (void)runtime_secret_get("AIMEE_KB_API_BEARER_TOKEN", kb_http_bearer, sizeof(kb_http_bearer));
    int kb_http_start_rc = kb_http_start(http_port, kb_http_bearer);
    runtime_secret_wipe(kb_http_bearer, sizeof(kb_http_bearer));
-   if (kb_http_start_rc != 0)
+   if (kb_http_start_rc != KB_HTTP_START_OK)
    {
-      /* Another instance owns the port; yield gracefully with success so
-       * systemd (Restart=on-failure) doesn't restart-loop. */
-      LOG_WARN("kb_http",
-               "failed to start HTTP listener on port %d; another instance likely owns it",
-               http_port);
+      if (kb_http_start_rc == KB_HTTP_START_ADDRESS_IN_USE)
+         LOG_WARN("kb_http", "HTTP listener port %d is already in use", http_port);
+      else
+         LOG_ERROR("kb_http", "HTTP listener failed on %d (result=%d)", http_port,
+                   kb_http_start_rc);
       kb_metrics_listener_stop();
       kb_management_runtime_stop();
       kb_service_shutdown(&g_ctx);
@@ -2367,12 +2367,14 @@ int main(int argc, char **argv)
       kb_vault_operator_components_destroy(&vault_operator_components);
       if (vault_operator_runtime_opened)
          db2_vault_operator_runtime_close(&vault_operator_runtime);
+      obs_bus_stop();
       db2_shutdown();
       kb_vault_tpm_runtime_lock_release(&vault_tpm_runtime_lock);
-      obs_bus_stop();
       audit_log_close();
       agent_http_cleanup();
-      return 0;
+      /* A second instance may yield without making an on-failure supervisor restart-loop.
+       * Security/configuration and system failures must remain visible to operators. */
+      return kb_http_start_rc == KB_HTTP_START_ADDRESS_IN_USE ? 0 : 1;
    }
 
    /* Now that this instance owns the port, boot the MCP plugins this kb HOSTS

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -7291,6 +7291,36 @@ static void test_http_listener_concurrent_requests(void)
    kb_http_stop();
 }
 
+static void test_http_listener_refuses_unsafe_public_bind(void)
+{
+   int port = reserve_tcp_port();
+   assert(setenv("AIMEE_KB_HTTP_BIND", "1", 1) == 0);
+   assert(kb_http_start(port, NULL) == KB_HTTP_START_UNSAFE_BIND);
+   assert(unsetenv("AIMEE_KB_HTTP_BIND") == 0);
+
+   /* A refused start must close its socket and leave the listener reusable. */
+   assert(kb_http_start(port, NULL) == KB_HTTP_START_OK);
+   kb_http_stop();
+}
+
+static void test_http_listener_classifies_port_collision(void)
+{
+   int fd = socket(AF_INET, SOCK_STREAM, 0);
+   assert(fd >= 0);
+   struct sockaddr_in sa;
+   memset(&sa, 0, sizeof(sa));
+   sa.sin_family = AF_INET;
+   sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   sa.sin_port = 0;
+   assert(bind(fd, (struct sockaddr *)&sa, sizeof(sa)) == 0);
+   assert(listen(fd, 1) == 0);
+   socklen_t n = sizeof(sa);
+   assert(getsockname(fd, (struct sockaddr *)&sa, &n) == 0);
+
+   assert(kb_http_start(ntohs(sa.sin_port), NULL) == KB_HTTP_START_ADDRESS_IN_USE);
+   close(fd);
+}
+
 /* ---- embedding is asynchronous, full stop ------------------------------------
  *
  * RED-GREEN. /v1/code/build used to do the whole build inline: doc embedding,
@@ -7436,6 +7466,8 @@ int main(void)
    test_mtls_listener();
    test_http_body_too_large_413();
    test_http_listener_concurrent_requests();
+   test_http_listener_refuses_unsafe_public_bind();
+   test_http_listener_classifies_port_collision();
    test_bearer_auth_ok();
    test_bearer_auth_missing();
    test_bearer_auth_wrong();


### PR DESCRIPTION
## Summary

- classify KB listener startup failures so only an occupied port yields gracefully; unsafe/config/system failures exit non-zero
- stop the observability bus before DB2 on listener startup failures, preventing the reproduced double-free during final event drain
- connect the no-Docker-socket split stack over the existing triple-authenticated mTLS lane
- add a one-shot, idempotent server identity installer and keep cleartext KB HTTP loopback-only
- update quickstart/deployment guidance and add static/plant coverage for the split-stack trust boundary

## Release impact

The published `:testing` split profile was not release-ready before this change:

- its KB inherited `AIMEE_KB_HTTP_BIND=1` but had no bearer at runtime, causing a restart loop
- each rejected startup ended in `double free or corruption (out)`
- even with a bearer, the server refused to send it to `http://aimee-kb:8741`

The corrected profile was deployed from a clean Debian 13 CT against the exact current `:testing` images. KB and server became healthy, the identity helper completed successfully, and server-to-KB traffic used port 8745 with client certificates. Port 8741 remained loopback-only and unpublished.

## Verification

- all 75 lint checks passed
- all 661 native unit tests passed
- full ASan/UBSan native suite passed (twice, including after final formatting)
- Go unit tests passed
- frontend clean install, audit, and production build passed (0 vulnerabilities)
- packaging, Vault-only environment, and published-image checks passed
- upstream CI and image-publish workflows for base SHA `70af913a` were green
- patched A25M KB rejected an unsafe public/no-bearer bind twice with exit 1 and clean PostgreSQL shutdown; no heap corruption
- listener tests cover unsafe bind classification/reuse and occupied-port classification
- split-stack live checks:
  - server `/v1/ready`, `/v1/kb/status`, and `/v1/rules` passed
  - direct cleartext `aimee-kb:8741` was unreachable
  - mTLS 8745 rejected clients without a certificate
  - stopping/restarting DB1 produced 503 then automatic recovery
  - stopping/restarting KB produced 503/circuit-open then automatic recovery
  - identity installation remained idempotent across repeated Compose up
  - write → persisted embedding → search → destructive cleanup passed
  - 100 concurrent server-to-KB status requests at concurrency 10 returned 100/100 HTTP 200

## Non-blocking observations

The A25M embedder serves successfully, but logs upstream/runtime warnings about a model produced by sentence-transformers 5.3.0.dev0 running on 5.2.3, a tokenizer regex compatibility advisory, and ONNX thread-affinity failures in the restricted unprivileged CT CPU mask. Embedding, search, readiness, recovery, and the concurrency burst all remained functional.
