### PR TITLE
fix(kb-client): say when the kb identity exists but is not usable

### DIFF
--- a/src/modules/kb_client/kb_client_mtls.c
+++ b/src/modules/kb_client/kb_client_mtls.c
@@ -768,6 +768,50 @@ static void pool_return(kb_pool_entry_t *entry, int reusable)
    pthread_mutex_unlock(&g_lock);
 }
 
+/* An identity file that exists but is not usable is NOT the same as having no
+ * identity, and reporting it as "not configured" is what makes this failure so
+ * expensive to diagnose.
+ *
+ * A managed deploy whose `managed-server-identity install` step does not finish
+ * leaves a v2 record with state "pending" and no ca/cert/key. identity_load
+ * rejects it, so the caller falls back to the plain http:// kb URL -- and then
+ * kb_plain_would_leak refuses to send the bearer in cleartext to a non-loopback
+ * host, because that is exactly what it is there to prevent. The KB is
+ * unreachable from that moment on, every container still reports healthy, and
+ * the only line in the log is the cleartext refusal, which names the transport
+ * rather than the reason it was chosen. Following that message leads away from
+ * the cause: the enrollment never completed.
+ *
+ * So say it, once, naming the file and the state. This changes no decision --
+ * an unusable identity is still not configured -- it only stops the operator
+ * chasing the wrong half of the system. */
+static void warn_unusable_identity_once(void)
+{
+   static int warned = 0;
+   if (warned)
+      return;
+
+   char path[1024];
+   if (identity_path(path, sizeof(path)) != 0)
+      return;
+   cJSON *j = identity_document_load(path);
+   if (!j)
+      return; /* absent is the ordinary un-enrolled case, not a failure */
+
+   const cJSON *version = cJSON_GetObjectItemCaseSensitive(j, "version");
+   const cJSON *state = cJSON_GetObjectItemCaseSensitive(j, "state");
+   const char *state_text = cJSON_IsString(state) && state->valuestring[0] ? state->valuestring
+                                                                          : "unset";
+   warned = 1;
+   LOG_WARN("kb_client",
+            "%s exists but is not usable (version=%d state=%s), so this server has no mTLS "
+            "identity for the kb and will fall back to the plain endpoint. Managed server "
+            "identity enrollment did not complete; re-run the wizard's Deploy. Until it does, "
+            "kb calls fail and the visible error is about cleartext bearers, not about this.",
+            path, cJSON_IsNumber(version) ? (int)version->valuedouble : 0, state_text);
+   cJSON_Delete(j);
+}
+
 int kb_client_mtls_configured(void)
 {
    char connection[4096];
@@ -781,6 +825,8 @@ int kb_client_mtls_configured(void)
        identity_load(NULL, ca, sizeof(ca), cert, sizeof(cert), key, sizeof(key), &metadata) == 0 &&
        metadata.version == 2;
    OPENSSL_cleanse(key, sizeof(key));
+   if (!configured)
+      warn_unusable_identity_once();
    return configured;
 }
 

--- a/src/tests/test_audit_worm.c
+++ b/src/tests/test_audit_worm.c
@@ -145,8 +145,17 @@ static void test_cross_store_determinism(void)
    {
       const char *p = i == 0 ? pa : pb;
       assert(audit_worm_init_at(p) == 0);
-      assert(audit_worm_append("primary", "u1", "tool.read", "v1-fixed", "allow", "{\"x\":1}") ==
-             0);
+      /* The timestamp is a hash input (audit_worm_row_hash_v2), and plain
+       * audit_worm_append stamps it from time(NULL) at one-second granularity.
+       * Appending to the two stores in sequence therefore produces different
+       * hashes whenever the pair straddles a second boundary -- rare on an idle
+       * machine, routine on a loaded CI runner, which is where this failed. The
+       * claim under test is that identical INPUTS hash identically across stores,
+       * so pin the timestamp rather than race the clock. Plain append keeps its
+       * coverage from the other cases in this file. */
+      assert(audit_worm_append_idempotent("determinism:1", "2026-08-26T01:02:03Z", "primary", "u1",
+                                          "tool.read", "v1-fixed", "allow", "{\"x\":1}",
+                                          NULL) == 0);
       audit_worm_close();
       sqlite3 *raw = NULL;
       assert(sqlite3_open(p, &raw) == SQLITE_OK);


### PR DESCRIPTION
Found while retesting the managed profile on current `testing`. It cost hours to
diagnose, and the reason it did is the whole point of this change.

## What happens

A managed deploy whose `managed-server-identity install` step does not finish leaves
`/var/lib/aimee/kb-client-identity.json` as a **v2 record with `state: "pending"` and no
ca/cert/key**. `identity_load` rejects it, correctly, and `kb_client_mtls_configured()`
reports "not configured" — which is indistinguishable from never having enrolled.

The caller falls back to the plain `http://aimee-kb:8741` URL, and `kb_plain_would_leak`
then refuses to send the bearer in cleartext to a non-loopback host, because that is
exactly what it is there to prevent. The KB is unreachable from that point on:

```text
$ docker ps
aimee-aimee-kb-1        healthy
aimee-aimee-server-1    healthy
aimee-aimee-store-db-1  healthy

$ aimee status
aimee-kb: unreachable
  QUERIES SUPPRESSED: the transport breaker is open ...
  next retry in 25000ms; see the server log for the cause.
  the knowledge base did not answer; memory and kb search will not work.

server.log: kb_client: refusing to send the kb bearer in cleartext to
            non-loopback host 'aimee-kb'; use the mTLS endpoint or
            terminate TLS in front of the kb
```

Every container reports healthy. `aimee status` defers to a log whose only relevant line
names the *transport* rather than the reason that transport was chosen. Following it leads
to the TLS posture and away from the cause. The KB was healthy throughout and serving mTLS
on 8745; the server simply had nothing usable to present.

Measured on a managed install:

```text
kb-client-identity.json:  version=2  state=pending  has ca/cert/key: False
kb logs:                  kb_mtls: mTLS listening on 0.0.0.0:8745
deploy status:            aimee-kb managed-server-identity: install failed
```

## What this changes

Nothing about the decision. An unusable identity is still not configured, and the fallback
is unchanged. It logs once, naming the file and the state, so the operator is pointed at
Deploy rather than at cleartext bearers. An absent file stays silent, because that is the
ordinary un-enrolled case and not a failure.

## Scope

This is the diagnostic half only. **Why the enrollment step fails is not addressed here**
and I have not established it — my test host had accumulated real damage by the time I got
there (a stale cached `aimee-authority-bootstrap:testing` image, my own manual `compose run`
probes, a KB recreated mid-install), and the container was destroyed by another process
before I could run the clean-slate check. So I cannot yet say whether the enrollment failure
reproduces from a clean deploy or was self-inflicted.

That uncertainty is the reason to land this regardless: whatever causes an incomplete
enrollment, the resulting state should announce itself instead of presenting as a TLS
problem.
