### PR TITLE
Reduce idle observability bus CPU

### DIFF
--- a/src/modules/audit/obs_bus.c
+++ b/src/modules/audit/obs_bus.c
@@ -877,7 +877,9 @@ static void *consumer_main(void *arg)
    /* Nap only when idle. During a burst the consumer must keep pace with the
     * producer or the ring backs up and the producer is forced to wait, so it
     * loops without napping as long as it is moving rows. */
-   const struct timespec nap = {.tv_sec = 0, .tv_nsec = 200 * 1000}; /* 200 us */
+   const long nap_min_ns = 200 * 1000;      /* 200 us */
+   const long nap_max_ns = 5 * 1000 * 1000; /* 5 ms */
+   long nap_ns = nap_min_ns;
    while (!atomic_load_explicit(&g.stop, memory_order_acquire))
    {
       uint64_t now = bus_runtime_monotonic_ns();
@@ -889,7 +891,11 @@ static void *consumer_main(void *arg)
       pthread_mutex_lock(&g.host_lock);
       if (g.runtime)
          (void)bus_runtime_maintain(g.runtime, now);
-      bus_host_pump(&g.host); /* the tap records each routed event into g.capture */
+      /* The tap records each routed event into g.capture. Keep this count separate
+       * from drain(): a routed module request may target another client rather than
+       * the observability consumer, but it is still activity that must reset the
+       * idle backoff so a burst is pumped without delay. */
+      uint32_t routed = bus_host_pump(&g.host);
       pthread_mutex_unlock(&g.host_lock);
       uint32_t n = drain();
       n += flush_pending_durable();
@@ -898,8 +904,19 @@ static void *consumer_main(void *arg)
        * waiting for more traffic). */
       if (g.capture.broken || g.capture.len >= AB_CAP_FLUSH_AT || (n == 0 && g.capture.len > 0))
          capture_flush();
-      if (n == 0)
+      if (n == 0 && routed == 0)
+      {
+         struct timespec nap = {.tv_sec = 0, .tv_nsec = nap_ns};
          nanosleep(&nap, NULL);
+         if (nap_ns < nap_max_ns)
+         {
+            nap_ns *= 2;
+            if (nap_ns > nap_max_ns)
+               nap_ns = nap_max_ns;
+         }
+      }
+      else
+         nap_ns = nap_min_ns;
    }
    /* Final lossless drain: pump+drain until two consecutive empty rounds, so a
     * row published just before stop is handed to its sink before this thread


### PR DESCRIPTION
## Summary

- exponentially back off the native observability/event-bus consumer from 200 microseconds to a 5 millisecond ceiling when fully idle
- reset the backoff immediately when either observability rows or other routed module traffic is detected
- preserve burst throughput, capture flushing, shutdown draining, and deadline behavior

## Why

Post-merge exploratory testing of the 0.4.0 testing-tag stack found the native observability consumer polling every 200 microseconds even with no traffic. The same loop runs in both the server and KB processes and remained a measurable component of idle CPU after the Go module polling fix.

## Verification

- all 75 native lint gates
- full native unit registry: all tests passed
- full native unit registry under ASan/UBSan with leak detection: all tests passed
- focused bus audit durability, shutdown-race, and module-concurrency tests
- exact merged testing baseline ec42178ca3: healthy split stack, 100/100 concurrent KB status calls, cleartext KB port refused, no-cert mTLS rejected

Live exact-head CPU and latency validation is continuing in CT 112 and will be added to this PR.