### PR TITLE
fix: restore per-actor authorization dropped by the shared-environment model

### DIFF
--- a/scripts/check-actor-authz.py
+++ b/scripts/check-actor-authz.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Gate: per-actor authorization survives the shared-environment model.
+
+The deployment collapsed several PER-ACTOR NAMESPACES into one environment: one
+credential vault, one workspace root, one runtime dir, one Claude-tab binding.
+That is deliberate (see the tenancy note in modules/vault/vault_service.h).
+
+Collapsing a namespace is not the same as dropping an authorization decision,
+and the migration confused the two in four places. Each removed a check while
+leaving the surrounding code still promising it:
+
+  * turn_registry_cancel stopped comparing the caller's attested principal to
+    the session owner, while handle_chat_graceful_cancel kept passing the
+    principal and kept rendering `rc < 0` as "forbidden: not the session owner".
+    Any attested caller could cancel any session.
+  * wf_owns became `return 1`, while the route table kept admitting every
+    workflow lifecycle mutation on CAP_DASHBOARD_READ *because* the handler
+    re-checked ownership. Any dashboard reader could stop or delete another
+    actor's work item.
+  * vault_service_rekey_password returned VAULT_OK for a principal with no
+    vault. The old password is verified AFTER that point, so the route answered
+    {"status":"ok"} to a password change that verified nothing.
+  * handle_vault_unlock initialised its status to VAULT_OK and skipped the
+    unlock when no legacy vault existed, so /v1/vault/unlock succeeded for any
+    password.
+
+None of those had to happen for the namespaces to merge. This check pins the
+repaired sites so the next migration pass cannot quietly vacate them again: a
+namespace may be shared, an authorization decision may not be skipped.
+
+Each rule is a REQUIRED pattern (the check must still be there) or a FORBIDDEN
+one (the vacated form must not come back), anchored to a named function so a
+rename surfaces here rather than silently passing.
+
+  --plant-test  prove the gate is not vacuously passing.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+
+# (file, function, kind, pattern, why)
+#   kind "require": the pattern MUST appear inside the function.
+#   kind "forbid":  the pattern must NOT appear inside the function.
+RULES = [
+    ("server/turn_registry.c", "turn_registry_cancel", "require",
+     r"presence_session_owner\s*\(",
+     "cancel must compare the caller's attested principal to the session owner"),
+    ("server/turn_registry.c", "turn_registry_cancel", "require",
+     r"strcmp\s*\(\s*owner\s*,\s*owner_principal\s*\)\s*!=\s*0",
+     "the owner comparison itself must remain, not just the lookup"),
+    ("server/turn_registry.c", "turn_registry_cancel", "forbid",
+     r"\(void\)\s*owner_principal\s*;",
+     "discarding owner_principal is how the cross-principal cancel check was lost"),
+
+    ("server/server_workflow_api.c", "wf_owns", "require",
+     r"server_http_identity_principal\s*\(",
+     "work-item ownership must be decided against the calling principal"),
+    ("server/server_workflow_api.c", "wf_owns", "forbid",
+     r"\(void\)\s*wi\s*;",
+     "an unconditional wf_owns opens every workflow route to any dashboard reader"),
+    ("server/server_workflow_api.c", "wf_load_for_mutation", "require",
+     r"!is_operator\s*&&\s*!wf_owns\s*\(",
+     "lifecycle mutations must 403 a non-owner non-operator"),
+
+    ("modules/vault/vault_service.c", "vault_service_rekey_password", "require",
+     r"vault_store_salt_readonly\s*\([^)]*\)\s*!=\s*0\s*\)\s*\n\s*return\s+VAULT_ERR_CRYPTO\s*;",
+     "a rekey against a principal with no vault must fail closed, never report success"),
+
+    ("server/server_vault.c", "handle_vault_unlock", "forbid",
+     r"vault_status_t\s+st\s*=\s*VAULT_OK\s*;",
+     "seeding the unlock status with a success value makes any skipped path authenticate nobody"),
+    ("server/server_vault.c", "handle_vault_unlock", "require",
+     r"return\s+vault_send_status_error\s*\(\s*conn\s*,\s*VAULT_NO_ENTRY\s*\)\s*;",
+     "no legacy vault must return before the success tail, not fall through to it"),
+]
+
+
+def function_body(text, name):
+    """Source of `name` from its definition to the closing brace in column 0."""
+    m = re.search(rf"^[A-Za-z_][\w \*]*\b{re.escape(name)}\s*\(", text, re.M)
+    if not m:
+        return None
+    start = m.start()
+    end = text.find("\n}", start)
+    return text[start:end + 2] if end != -1 else text[start:]
+
+
+def check(mutate=None):
+    failures = []
+    for rel, func, kind, pattern, why in RULES:
+        path = SRC / rel
+        if not path.exists():
+            failures.append(f"{rel}: file is gone; {func} carried an authorization check")
+            continue
+        text = path.read_text(encoding="utf-8")
+        if mutate and mutate[0] == rel and mutate[1] == func:
+            text = mutate[2](text)
+        body = function_body(text, func)
+        if body is None:
+            failures.append(f"{rel}: {func} not found (renamed?); it carried: {why}")
+            continue
+        found = re.search(pattern, body) is not None
+        if kind == "require" and not found:
+            failures.append(f"{rel}: {func} no longer has the check — {why}")
+        elif kind == "forbid" and found:
+            failures.append(f"{rel}: {func} reintroduced the vacated form — {why}")
+    return failures
+
+
+def main():
+    if "--plant-test" in sys.argv:
+        # Vacate wf_owns exactly the way the migration did and confirm we catch it.
+        planted = check(mutate=("server/server_workflow_api.c", "wf_owns",
+                                lambda t: t.replace("server_http_identity_principal()",
+                                                    "NULL /* planted */")))
+        if not any("wf_owns" in f for f in planted):
+            print("check-actor-authz: FAIL — plant-test did not catch a vacated check")
+            return 1
+        print("check-actor-authz: plant-test ok (vacated authorization check detected)")
+        return 0
+
+    failures = check()
+    if failures:
+        print(f"check-actor-authz: FAIL — {len(failures)} per-actor authorization "
+              f"check(s) missing:")
+        for f in failures:
+            print(f"  {f}")
+        print("  A shared namespace does not imply a shared authority. If a check here is "
+              "genuinely obsolete, move the decision to a named enforcement point and "
+              "update this file in the same commit.")
+        return 1
+    print(f"check-actor-authz: ok ({len(RULES)} per-actor authorization checks intact)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Makefile
+++ b/src/Makefile
@@ -1984,6 +1984,14 @@ kb-intelligence-surfaced-check:
 proposal-links-check:
 	@python3 ../scripts/check-proposal-links.py
 
+# Per-actor authorization survives the shared-environment model. Merging the
+# per-actor NAMESPACES (one vault, one workspace root, one runtime dir) did not
+# require dropping per-actor authorization DECISIONS, but four went with them.
+# This pins the repaired sites. --plant-test proves the gate is not vacuous.
+actor-authz-check:
+	@python3 ../scripts/check-actor-authz.py --plant-test
+	@python3 ../scripts/check-actor-authz.py
+
 # The dated pending-audit manifest must keep describing the tree: every row's
 # final path resolves, archived rows carry a done state and a reciprocal residual
 # in pending/. This gate existed but nothing ran it, so it drifted; its own unit
@@ -2144,7 +2152,7 @@ lint:
 	echo "lint: all $$n checks passed"
 
 # Appended separately to keep the already-wide canonical check list readable.
-LINT_CHECKS += event-durability-check shell-quote-check workflow-pin-check build-input-integrity-check config-failopen-check security-claims-check
+LINT_CHECKS += actor-authz-check event-durability-check shell-quote-check workflow-pin-check build-input-integrity-check config-failopen-check security-claims-check
 
 background-skill-curator-absence-check:
 	@python3 -I -S ../scripts/check_background_skill_curator_absence.py

--- a/src/modules/vault/vault_service.c
+++ b/src/modules/vault/vault_service.c
@@ -338,11 +338,18 @@ vault_status_t vault_service_rekey_password(const char *principal, attested_tran
    if (!old_password || old_len == 0 || !new_password || new_len == 0)
       return VAULT_ERR_BADARG;
 
-   /* Read-only compatibility path. No legacy actor vault means there is nothing
-    * to rekey; the shared environment vault is independent of PAM passwords. */
+   /* Read-only: a rekey against a non-existent principal must fail closed, never
+    * materialize a vault an attacker could then own.
+    *
+    * It must also not report success. The old password is verified BELOW, by
+    * deriving from this salt — so returning VAULT_OK here would make
+    * handle_vault_rekey answer {"status":"ok"} to a password change that
+    * verified no old password and re-wrapped nothing. The shared environment
+    * vault being independent of PAM passwords is a reason there is nothing to
+    * rekey, not a reason to call a no-op a success. */
    uint8_t salt[VAULT_SALT_LEN];
    if (vault_store_salt_readonly(principal, salt) != 0)
-      return VAULT_OK;
+      return VAULT_ERR_CRYPTO;
 
    uint8_t old_kek[VAULT_KEK_LEN], new_kek[VAULT_KEK_LEN];
    vault_status_t st = VAULT_OK;

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -78,10 +78,26 @@ static int hex_decode(const char *hex, uint8_t *out, size_t n)
 int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
-   vault_status_t st = VAULT_OK;
-   uint8_t legacy_salt[VAULT_SALT_LEN];
-   int has_legacy_vault = vault_store_salt_readonly(conn->vault_principal, legacy_salt) == 0;
-   OPENSSL_cleanse(legacy_salt, sizeof(legacy_salt));
+   /* No legacy actor vault means there is nothing to unlock: the environment
+    * vault needs no unlock, and vault_service_unlock_password would MINT a new
+    * per-actor vault on first use (vault_store_get_or_create_salt), which the
+    * shared-environment model does not want.
+    *
+    * Answered here with an early return, not by gating the unlock calls below.
+    * The credentials are verified INSIDE vault_service_unlock*, so any path that
+    * skips those calls and still reaches the success tail authenticates nobody —
+    * this route would answer {"status":"ok"} to any password. Returning before
+    * `st` exists makes that state unreachable rather than dependent on how `st`
+    * happens to be initialised. */
+   {
+      uint8_t legacy_salt[VAULT_SALT_LEN];
+      int has_legacy_vault = vault_store_salt_readonly(conn->vault_principal, legacy_salt) == 0;
+      OPENSSL_cleanse(legacy_salt, sizeof(legacy_salt));
+      if (!has_legacy_vault)
+         return vault_send_status_error(conn, VAULT_NO_ENTRY);
+   }
+
+   vault_status_t st;
 
    /* A webchat-asserted webuser principal unlocks with its login password
     * (scrypt KEK, WP-C.2); a kernel-attested uid: peer unlocks with its 32-byte
@@ -92,10 +108,9 @@ int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       cJSON *jpw = cJSON_GetObjectItemCaseSensitive(req, "password");
       if (!cJSON_IsString(jpw))
          return server_send_error(conn, "vault: missing password", NULL);
-      if (has_legacy_vault)
-         st = vault_service_unlock_password(conn->vault_principal, conn->attested_transport,
-                                            (const uint8_t *)jpw->valuestring,
-                                            strlen(jpw->valuestring), time(NULL));
+      st = vault_service_unlock_password(conn->vault_principal, conn->attested_transport,
+                                         (const uint8_t *)jpw->valuestring,
+                                         strlen(jpw->valuestring), time(NULL));
       /* Best-effort scrub of the request-body copy of the password. */
       OPENSSL_cleanse(jpw->valuestring, strlen(jpw->valuestring));
    }
@@ -107,9 +122,8 @@ int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       uint8_t root_key[VAULT_ROOT_KEY_LEN];
       if (hex_decode(jrk->valuestring, root_key, sizeof(root_key)) != 0)
          return server_send_error(conn, "vault: root_key_hex must be 64 hex chars", NULL);
-      if (has_legacy_vault)
-         st = vault_service_unlock(conn->vault_principal, conn->attested_transport, root_key,
-                                   sizeof(root_key), time(NULL));
+      st = vault_service_unlock(conn->vault_principal, conn->attested_transport, root_key,
+                                sizeof(root_key), time(NULL));
       OPENSSL_cleanse(root_key, sizeof(root_key));
    }
    if (st != VAULT_OK)

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -649,13 +649,30 @@ static const char *path_basename(const char *p)
    return slash ? slash + 1 : (p ? p : "");
 }
 
-/* Work items belong to the one server environment, never to a PAM login. The
- * submitter remains actor attribution and human-gate decisions remain separately
- * CAP_WORKFLOW_ADMIN-gated; visibility does not grant mutation authority. */
+/* Ownership / operator-visibility for the Workflow Actions surface. True iff:
+ *   - the run is AUTONOMOUS (system/triggered: the proposals trigger, cron, or a
+ *     dev-submit pipeline). These are not private human proposals, so they are
+ *     visible to — and operable (pause/resume/stop) by — any authenticated
+ *     dashboard operator; OR
+ *   - the item's submitter equals the calling principal — an INTERACTIVE human
+ *     proposal stays owner-scoped (closes the list IDOR; one user never sees
+ *     another's drafts).
+ * A NULL/empty submitter on a non-autonomous row is owned by nobody -> fail
+ * closed. The human-gate decision (approve/reject) is separately CAP_WORKFLOW_
+ * ADMIN-gated, so visibility here does not widen gate authority.
+ *
+ * This predicate is the ONLY thing separating one actor's drafts from another's
+ * on these routes. The route table admits every lifecycle mutation on
+ * CAP_DASHBOARD_READ precisely because the handler re-checks ownership; making
+ * this return 1 unconditionally would let any dashboard reader stop or delete
+ * another actor's work item, and would leave the CAP_WORKFLOW_ADMIN-gated
+ * /v1/workflow/items/all with nothing to distinguish it from the plain list. */
 static int wf_owns(const db1_work_item_t *wi)
 {
-   (void)wi;
-   return 1;
+   if (strcmp(wi->mode, "autonomous") == 0)
+      return 1;
+   const char *principal = server_http_identity_principal();
+   return wi->submitter[0] && principal && principal[0] && strcmp(principal, wi->submitter) == 0;
 }
 
 /* shared: serialize one work-item row. The base keys (id..repo) are unchanged so
@@ -857,7 +874,8 @@ static int wf_load_for_mutation(const char *id, int is_operator, db1_work_item_t
       return err(resp, cap, 400, "missing work item id");
    if (db1_work_item_get(id, wi) != 1)
       return err(resp, cap, 404, "work item not found");
-   (void)is_operator;
+   if (!is_operator && !wf_owns(wi))
+      return err(resp, cap, 403, "not your work item");
    return 0;
 }
 

--- a/src/server/turn_registry.c
+++ b/src/server/turn_registry.c
@@ -89,9 +89,32 @@ turn_entry_t *turn_registry_publish(const char *session_id, const char *turn_id)
 
 int turn_registry_cancel(const char *session_id, const char *owner_principal)
 {
-   /* PAM identity is actor/audit metadata, not session ownership. Route-level
-    * authentication and capabilities decide whether the actor may cancel. */
-   (void)owner_principal;
+   /* Cross-principal protection. `owner_principal` is the CALLER'S ATTESTED
+    * identity (conn->vault_principal); the presence owner is what the attaching
+    * client declared. Requiring them to match is what stops one attested caller
+    * cancelling another's session: an attacker can claim any owner at attach
+    * time, but cannot authenticate as it.
+    *
+    * This is not "PAM identity as session ownership" — it is the only ownership
+    * signal the cancel path has. handle_chat_graceful_cancel and
+    * handle_chat_interrupt both pass the principal and both render a `rc < 0`
+    * as "forbidden: not the session owner", so dropping the comparison here
+    * does not move the check to the route, it deletes it and leaves those
+    * branches unreachable. A trusted-local caller passes NULL and is exempt,
+    * because it binds session id to authenticated caller before forwarding.
+    *
+    * Decided OUTSIDE the registry lock: presence has its own lock and the
+    * leaf-mutex rule forbids holding g_lock across a presence call. */
+   if (owner_principal && owner_principal[0])
+   {
+      char owner[PRESENCE_OWNER_MAX];
+      if (!presence_session_owner(session_id, owner, sizeof(owner)) ||
+          strcmp(owner, owner_principal) != 0)
+      {
+         LOG_WARN("turn_registry", "refused cross-principal cancel of session %s", session_id);
+         return -1;
+      }
+   }
    pthread_mutex_lock(&g_lock);
    turn_entry_t *e = find_locked(session_id);
    if (!e)

--- a/src/tests/test_turn_registry.c
+++ b/src/tests/test_turn_registry.c
@@ -43,6 +43,36 @@ static void test_publish_and_collision(void)
    printf("ok: publish + collision\n");
 }
 
+/* Cross-principal cancel: the caller's ATTESTED principal must match the
+ * session's presence owner. An attacker can declare any owner at attach time
+ * but cannot authenticate as it, so this comparison is what keeps one attested
+ * caller from cancelling another's session. handle_chat_graceful_cancel and
+ * handle_chat_interrupt both render a -1 here as "forbidden: not the session
+ * owner"; without the comparison those branches are unreachable. */
+static void test_cancel_authz(void)
+{
+   turn_entry_t *e = turn_registry_publish("sess-D", "turn-1");
+   assert(e);
+   snprintf(g_stub_owner, sizeof(g_stub_owner), "webuser:alice");
+   /* A different principal is refused (-1) and does NOT set the flag. */
+   assert(turn_registry_cancel("sess-D", "webuser:bob") == -1);
+   assert(turn_entry_cancelled(e) == 0);
+   /* The matching principal succeeds. */
+   assert(turn_registry_cancel("sess-D", "webuser:alice") == 1);
+   assert(turn_entry_cancelled(e) == 1);
+   /* A trusted-local caller (NULL principal) is exempt: it binds session id to
+    * its authenticated caller before forwarding. */
+   turn_entry_t *f = turn_registry_publish("sess-E", "turn-2");
+   assert(f && turn_registry_cancel("sess-E", NULL) == 1);
+   /* An unknown session is still 0, so the route can tell "nothing to cancel"
+    * from "cancelled" rather than reporting success for a typo. */
+   assert(turn_registry_cancel("sess-D-gone", "webuser:alice") == 0);
+   g_stub_owner[0] = '\0';
+   turn_registry_clear(e);
+   turn_registry_clear(f);
+   printf("ok: cancel authz (cross-principal cancel refused)\n");
+}
+
 static void test_cancel_and_find(void)
 {
    turn_entry_t *e = turn_registry_publish("sess-C", "turn-1");
@@ -57,27 +87,6 @@ static void test_cancel_and_find(void)
    turn_registry_clear(e);
    assert(turn_registry_find("sess-C") == NULL);
    printf("ok: cancel + find\n");
-}
-
-static void test_cancel_actor_is_attribution_not_ownership(void)
-{
-   turn_entry_t *e = turn_registry_publish("sess-D", "turn-1");
-   assert(e);
-   /* The server is single-tenant: a session belongs to the environment, not to
-    * the PAM actor who happened to start it. The actor is carried for audit and
-    * is not an ownership test here — whether a caller may cancel at all is
-    * decided at the route, which refuses an unattested caller outright
-    * (server_session.c) before this is ever reached. */
-   snprintf(g_stub_owner, sizeof(g_stub_owner), "webuser:alice");
-   assert(turn_registry_cancel("sess-D", "webuser:bob") == 1);
-   assert(turn_entry_cancelled(e) == 1);
-   g_stub_owner[0] = '\0';
-   turn_registry_clear(e);
-
-   /* An unknown session is still 0, so the route can tell "nothing to cancel"
-    * from "cancelled" rather than reporting success for a typo. */
-   assert(turn_registry_cancel("sess-D-gone", "webuser:alice") == 0);
-   printf("ok: cancel attributes an actor without gating on it\n");
 }
 
 static void test_cancel_all(void)
@@ -159,7 +168,7 @@ int main(void)
    turn_registry_init();
    test_publish_and_collision();
    test_cancel_and_find();
-   test_cancel_actor_is_attribution_not_ownership();
+   test_cancel_authz();
    test_cancel_all();
    test_reaped();
    test_steer_set_take();

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -215,14 +215,17 @@ static void test_rekey_empty_and_missing_vault(void)
 {
    const uint8_t old_pw[] = "carol-old", new_pw[] = "carol-new", wrong[] = "carol-wrong";
 
-   /* (b) A principal with NO legacy vault has nothing to rekey: the environment
-    * vault is sealed under the server master KEK, not a PAM password, so a
-    * password change is a no-op rather than an error. The property that still
-    * matters is unchanged and asserted below — it must not MATERIALIZE a vault
-    * for a principal that has none. */
+   /* (b) A principal with NO legacy vault has nothing to rekey — and must not be
+    * told the rekey SUCCEEDED. The old password is verified further down by
+    * deriving from this principal's salt, so answering VAULT_OK here makes
+    * handle_vault_rekey reply {"status":"ok"} to a password change that
+    * verified no old password and re-wrapped nothing. The environment vault
+    * being independent of PAM passwords is a reason there is nothing to rekey,
+    * not a reason to call a no-op a success. It must also not MATERIALIZE a
+    * vault for a principal that has none (asserted next). */
    assert(vault_service_rekey_password("webuser:nobody", ATTEST_WEBCHAT_TRUSTED, old_pw,
                                        sizeof(old_pw) - 1, new_pw, sizeof(new_pw) - 1,
-                                       T0) == VAULT_OK);
+                                       T0) == VAULT_ERR_CRYPTO);
    uint8_t salt[VAULT_SALT_LEN];
    assert(vault_store_salt_readonly("webuser:nobody", salt) == -1); /* no vault materialized */
 


### PR DESCRIPTION
## Summary

Four per-actor authorization checks are absent on `testing`. Each was removed as part of
collapsing the per-actor **namespaces** into one shared environment — one credential vault,
one workspace root, one runtime dir. Merging those namespaces is deliberate and this PR
does not touch it. Dropping the authorization **decisions** was not necessary for it, and
in each case the surrounding code still promises the check that is gone.

## The four

**1. Any attested caller can cancel or interrupt any session.**
`turn_registry_cancel` discards `owner_principal` (`turn_registry.c:94`). But
`handle_chat_graceful_cancel` and `handle_chat_interrupt` still pass it and still render a
`rc < 0` as `"forbidden: not the session owner"` — branches that are now unreachable. The
route refuses an *unattested* caller; it does not check *which* attested caller. So
`webuser:bob` can cancel `webuser:alice`'s in-flight turn.

**2. Any dashboard reader can stop or delete another actor's work item.**
`wf_owns` returns `1` unconditionally (`server_workflow_api.c:655`). The route table admits
every lifecycle mutation (`/pause`, `/resume`, `/stop`, `DELETE`) on `CAP_DASHBOARD_READ`
*because* the handler re-checked ownership, and its comment still says so. It also leaves
the `CAP_WORKFLOW_ADMIN`-gated `/v1/workflow/items/all` with nothing distinguishing it from
the plain list. The deleted comment named this exactly: it "closes the list IDOR".

**3. `/v1/vault/rekey` reports success without verifying the old password.**
`vault_service_rekey_password` returns `VAULT_OK` when the principal has no vault
(`vault_service.c:345`). The old password is verified *after* that point, by deriving from
the salt — so `handle_vault_rekey` answers `{"status":"ok"}` to a password change that
verified nothing and re-wrapped nothing.

**4. `/v1/vault/unlock` succeeds with any password.**
`handle_vault_unlock` seeds `vault_status_t st = VAULT_OK` and skips the unlock call
entirely when there is no legacy vault (`server_vault.c:81`). The credentials are verified
*inside* `vault_service_unlock*`, so that path authenticates nobody and still reaches the
success tail.

## What this changes

Restores the comparison in `turn_registry_cancel`, the ownership predicate and the mutation
403 in `server_workflow_api.c`, and fails closed in `vault_service_rekey_password`.

For the unlock, the gate itself is kept — `vault_service_unlock_password` mints a vault on
first use via `vault_store_get_or_create_salt`, which the shared-environment model does not
want — but it now returns before `st` exists rather than depending on how `st` is
initialised. The unsafe state is unrepresentable rather than merely avoided.

Namespaces stay shared. `(void) principal` in `git_forge_vault`, `inject_api_key`,
`ws_scope_user_root` and the Claude-tab binding are untouched: those select *state*, and
sharing state is the point of the migration.

## Tests

Two tests on `testing` currently assert the vacated behaviour and are replaced:

- `test_cancel_actor_is_attribution_not_ownership` asserts a cross-principal cancel
  **succeeds**. Its stated premise is that "whether a caller may cancel at all is decided at
  the route, which refuses an unattested caller outright" — true, and insufficient: the route
  refuses unattested callers, not *other* attested ones. Replaced with `test_cancel_authz`,
  which keeps its still-valid unknown-session assertion.
- `test_rekey_empty_and_missing_vault` asserts `VAULT_OK` for a missing vault; now asserts
  `VAULT_ERR_CRYPTO`. Its "must not materialize a vault" assertion is kept unchanged.

## Regression guard

`scripts/check-actor-authz.py`, wired into `LINT_CHECKS`. Nine assertions pinning the four
sites — required patterns (the comparison must be present) and forbidden ones
(`(void) owner_principal`, `(void) wi`, `vault_status_t st = VAULT_OK`), anchored per
function so a rename fails rather than silently passing. Carries `--plant-test` like the
repo's other gates: it vacates `wf_owns` the same way and confirms it is caught.

The failure message states the rule: **a shared namespace does not imply a shared
authority.** If a check here becomes genuinely obsolete, the gate requires the decision to
move to a named enforcement point in the same commit rather than just disappearing.

## Verification

`make all`, full `make unit-tests`, and `make lint` (all checks, including the new one) pass
on this branch.
