### PR TITLE
Honor typed error status on dispatch-backed HTTP routes

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3597,6 +3597,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "503":
+          description: Knowledge service unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /memory/list:
     post:
       summary: List memories by tier/kind
@@ -3915,6 +3920,16 @@ paths:
               schema: { type: object }
         "400":
           description: Missing id or invalid body
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Memory not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "503":
+          description: Knowledge service unavailable
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3584,8 +3584,8 @@ paths:
               type: object
               required: [keywords]
               properties:
-                keywords: { type: array, items: { type: string } }
-                limit: { type: integer }
+                keywords: { type: array, minItems: 1, maxItems: 16, items: { type: string, minLength: 1 } }
+                limit: { type: integer, minimum: 1, maximum: 32 }
       responses:
         "200":
           description: Memory search envelope

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -4068,6 +4068,16 @@ paths:
           content:
             application/json:
               schema: { type: object }
+        "400":
+          description: Missing kind, key, or content
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "503":
+          description: Per-user memory store unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /tools/execute:
     post:
       summary: Execute a tool via the workspace plane (privileged)

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3911,7 +3911,7 @@ paths:
               type: object
               required: [id]
               properties:
-                id: { type: integer }
+                id: { type: integer, minimum: 1, maximum: 9007199254740991 }
       responses:
         "200":
           description: Memory envelope

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -344,6 +344,12 @@ int server_send_error(server_conn_t *conn, const char *message, const char *requ
  * one. Same function builds both forms, so they cannot drift. */
 cJSON *server_error_kind_json(const char *kind, const char *message, const char *request_id);
 
+/* Add or replace the typed-error classification on an existing response. This
+ * preserves richer dependency fields (retryability, dependency, retry delay)
+ * while giving the HTTP boundary the same authoritative status mapping used by
+ * server_error_kind_json(). */
+void server_error_kind_apply(cJSON *resp, const char *kind);
+
 int server_send_error_kind(server_conn_t *conn, const char *kind, const char *message,
                            const char *request_id);
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1326,11 +1326,14 @@ static int handle_memory_user_capture(server_ctx_t *ctx, server_conn_t *conn, cJ
    const char *tier = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "tier"));
    const char *sid = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "session_id"));
    if (!kind || !kind[0] || !key || !key[0])
-      return server_send_error(conn, "kind and key are required", request_id);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT, "kind and key are required",
+                                    request_id);
    if (!content || !content[0])
-      return server_send_error(conn, "content is required", request_id);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT, "content is required",
+                                    request_id);
    if (db1_user_memory_upsert(kind, tier, key, content, 1.0, sid) != 0)
-      return server_send_error(conn, "failed to store user memory", request_id);
+      return server_send_error_kind(conn, SERVER_ERR_UNAVAILABLE, "failed to store user memory",
+                                    request_id);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "kind", kind);

--- a/src/server/server_error_kind.c
+++ b/src/server/server_error_kind.c
@@ -16,6 +16,22 @@ void server_error_kind_register_http_status_provider(server_error_http_status_pr
    g_http_status_provider = provider;
 }
 
+void server_error_kind_apply(cJSON *resp, const char *kind)
+{
+   if (!resp)
+      return;
+
+   cJSON_DeleteItemFromObjectCaseSensitive(resp, "kind");
+   if (kind && kind[0])
+      cJSON_AddStringToObject(resp, "kind", kind);
+
+   cJSON_DeleteItemFromObjectCaseSensitive(resp, "http_status");
+   uint32_t http_status = 0;
+   if (g_http_status_provider && g_http_status_provider(kind, &http_status) == 0 &&
+       http_status >= 400u && http_status <= 599u)
+      cJSON_AddNumberToObject(resp, "http_status", (double)http_status);
+}
+
 /* Send a dispatch error, naming WHO was at fault.
  *
  * The envelope otherwise carries only {status:"error", message}, so anything in
@@ -53,12 +69,7 @@ cJSON *server_error_kind_json(const char *kind, const char *message, const char 
    cJSON *resp = cJSON_CreateObject();
    cJSON_AddStringToObject(resp, "status", "error");
    cJSON_AddStringToObject(resp, "message", message);
-   if (kind && kind[0])
-      cJSON_AddStringToObject(resp, "kind", kind);
-   uint32_t http_status = 0;
-   if (g_http_status_provider && g_http_status_provider(kind, &http_status) == 0 &&
-       http_status >= 400u && http_status <= 599u)
-      cJSON_AddNumberToObject(resp, "http_status", (double)http_status);
+   server_error_kind_apply(resp, kind);
    if (request_id)
       cJSON_AddStringToObject(resp, "request_id", request_id);
    return resp;

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -963,8 +963,13 @@ int loopback_rpc(const char *body, int body_len, char *resp, int resp_cap, uint3
    cJSON *chk = cJSON_Parse(resp);
    if (!chk)
       return err_json(resp, resp_cap, 502, "rpc response too large or malformed");
+   int status = 200;
+   cJSON *declared_status = cJSON_GetObjectItemCaseSensitive(chk, "http_status");
+   if (cJSON_IsNumber(declared_status) && declared_status->valueint >= 400 &&
+       declared_status->valueint <= 599)
+      status = declared_status->valueint;
    cJSON_Delete(chk);
-   return 200;
+   return status;
 }
 
 int server_http_route(const char *method, const char *path, const char *body, int body_len,

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -189,7 +189,8 @@ cJSON *memory_store_command(const cJSON *req, memory_authority_t authority)
    const char *key, *content;
    if (jo_need_str((cJSON *)req, "key", &key) < 0 ||
        jo_need_str((cJSON *)req, "content", &content) < 0)
-      return jo_err("missing key or content");
+      return server_error_kind_json(SERVER_ERR_INVALID_ARGUMENT,
+                                    "memory.store requires a key and content", NULL);
    /* An empty key or content is a malformed REQUEST, not a storage failure. The
     * store already refuses it, but the refusal surfaced as "failed to store
     * memory" -- which reads as the database declining a valid write and sends

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -144,6 +144,8 @@ int handle_memory_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       free(json);
       if (!err)
          return server_send_error(conn, detail, NULL);
+      server_error_kind_apply(err, active_context_missing ? SERVER_ERR_INVALID_ARGUMENT
+                                                          : SERVER_ERR_UNAVAILABLE);
       cJSON_AddBoolToObject(err, "active_context_missing", active_context_missing);
       return send_and_free(conn, err);
    }
@@ -462,15 +464,18 @@ cJSON *memory_get_command(cJSON *req)
    }
    else if (rc > 0)
    {
-      resp = jo_err("memory not found");
+      resp = server_error_kind_json(SERVER_ERR_NOT_FOUND, "memory not found", NULL);
    }
    else
    {
       char *typed = kb_client_last_result_json("memory lookup failed");
       resp = typed ? cJSON_Parse(typed) : NULL;
       free(typed);
-      if (!resp)
-         resp = jo_err("knowledge service unavailable");
+      if (resp)
+         server_error_kind_apply(resp, SERVER_ERR_UNAVAILABLE);
+      else
+         resp =
+             server_error_kind_json(SERVER_ERR_UNAVAILABLE, "knowledge service unavailable", NULL);
    }
    return resp;
 }

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -87,7 +87,8 @@ int handle_memory_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int limit = jo_int(req, "limit", 10);
 
    if (!cJSON_IsArray(jkw) || cJSON_GetArraySize(jkw) == 0)
-      return server_send_error(conn, "missing or empty keywords array", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "missing or empty keywords array", NULL);
 
    int count = cJSON_GetArraySize(jkw);
    if (count > 16)
@@ -413,7 +414,7 @@ cJSON *memory_get_command(cJSON *req)
 
    cJSON *jid = cJSON_GetObjectItemCaseSensitive(req, "id");
    if (!cJSON_IsNumber(jid))
-      return jo_err("missing id");
+      return server_error_kind_json(SERVER_ERR_INVALID_ARGUMENT, "memory.get requires an id", NULL);
 
    /* `memory get --as-of <ts>` asks the EVENT-time question, and this handler is
     * the only thing between the flag and aimee-kb, which owns the interval. It

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -39,7 +39,6 @@
 #include <stdatomic.h>
 #include <sys/stat.h>
 #include <time.h>
-#include <unistd.h>
 
 /* Send a response object and delete it. Returns send rc. */
 int send_and_free(server_conn_t *conn, cJSON *resp)
@@ -84,23 +83,30 @@ int handle_memory_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)ctx;
 
    cJSON *jkw = cJSON_GetObjectItemCaseSensitive(req, "keywords");
-   int limit = jo_int(req, "limit", 10);
-
+   cJSON *jlimit = cJSON_GetObjectItemCaseSensitive(req, "limit");
+   if (jlimit &&
+       (!cJSON_IsNumber(jlimit) || !isfinite(jlimit->valuedouble) || jlimit->valuedouble < 1 ||
+        jlimit->valuedouble > 32 || jlimit->valuedouble != (double)(int)jlimit->valuedouble))
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "memory.search limit must be an integer between 1 and 32",
+                                    NULL);
+   int limit = jlimit ? (int)jlimit->valuedouble : 10;
    if (!cJSON_IsArray(jkw) || cJSON_GetArraySize(jkw) == 0)
       return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
                                     "missing or empty keywords array", NULL);
-
    int count = cJSON_GetArraySize(jkw);
    if (count > 16)
-      count = 16;
-
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "memory.search accepts at most 16 keywords", NULL);
    char *clusters[16];
    for (int i = 0; i < count; i++)
    {
       cJSON *item = cJSON_GetArrayItem(jkw, i);
-      clusters[i] = cJSON_IsString(item) ? item->valuestring : "";
+      if (!cJSON_IsString(item) || !item->valuestring[0])
+         return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                       "memory.search keywords must be non-empty strings", NULL);
+      clusters[i] = item->valuestring;
    }
-
    /* Build query string for fact search */
    char query_buf[2048];
    int qpos = 0;

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -419,10 +419,10 @@ int handle_memory_delete(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 cJSON *memory_get_command(cJSON *req)
 {
-
-   cJSON *jid = cJSON_GetObjectItemCaseSensitive(req, "id");
-   if (!cJSON_IsNumber(jid))
-      return server_error_kind_json(SERVER_ERR_INVALID_ARGUMENT, "memory.get requires an id", NULL);
+   int64_t id = 0;
+   if (memory_request_positive_id(req, "id", &id) != 0)
+      return server_error_kind_json(SERVER_ERR_INVALID_ARGUMENT,
+                                    "memory.get requires a positive integer id", NULL);
 
    /* `memory get --as-of <ts>` asks the EVENT-time question, and this handler is
     * the only thing between the flag and aimee-kb, which owns the interval. It
@@ -434,7 +434,7 @@ cJSON *memory_get_command(cJSON *req)
    memory_t m;
    kb_valid_at_t verdict = KB_VALID_AT_UNASKED;
    server_memory_scope_begin(req);
-   int rc = kb_client_memory_get_as_of((int64_t)jid->valuedouble, as_of, &m, &verdict);
+   int rc = kb_client_memory_get_as_of(id, as_of, &m, &verdict);
    kb_client_memory_scope_context_clear();
 
    cJSON *resp;

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1288,6 +1288,27 @@ fi  # DB1_SESSIONS_AVAILABLE
 # 5. Memory via server
 # ============================================================
 
+# These argument failures are typed INVALID_ARGUMENT replies. The dedicated
+# HTTP adapter must preserve that mapping as a physical 400 instead of masking
+# a rejected write behind 200 OK.
+RESP=$(http_call POST /v1/memory/store '{"key":"integ-invalid"}') || true
+check_output "memory.store missing content stays typed" '"kind":"invalid_argument"' echo "$RESP"
+if echo "$RESP" | grep -q '"http_status":400'; then
+    check_output "memory.store missing content returns HTTP 400" "400 " echo "$RESP"
+else
+    echo "SKIP: memory.store missing-content HTTP mapping (runtime-web status provider is not attached)"
+    SKIP=$((SKIP + 1))
+fi
+
+RESP=$(http_call POST /v1/memory/store '{"key":"integ-invalid","content":""}') || true
+check_output "memory.store empty content stays typed" '"kind":"invalid_argument"' echo "$RESP"
+if echo "$RESP" | grep -q '"http_status":400'; then
+    check_output "memory.store empty content returns HTTP 400" "400 " echo "$RESP"
+else
+    echo "SKIP: memory.store empty-content HTTP mapping (runtime-web status provider is not attached)"
+    SKIP=$((SKIP + 1))
+fi
+
 if [ "$KB_AVAILABLE" -eq 1 ]; then
     RESP=$(srv_auth_req '{"method":"memory.store","key":"integ-test","content":"integration test value","tier":"L0","kind":"fact"}') || true
     check_output "memory.store" '"status":"ok"' echo "$RESP"

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1327,6 +1327,15 @@ else
     SKIP=$((SKIP + 1))
 fi
 
+RESP=$(http_call POST /v1/memory/user_capture '{}') || true
+check_output "memory.user_capture missing fields stays typed" '"kind":"invalid_argument"' echo "$RESP"
+if echo "$RESP" | grep -q '"http_status":400'; then
+    check_output "memory.user_capture missing fields returns HTTP 400" "400 " echo "$RESP"
+else
+    echo "SKIP: memory.user_capture missing-fields HTTP mapping (runtime-web status provider is not attached)"
+    SKIP=$((SKIP + 1))
+fi
+
 if [ "$KB_AVAILABLE" -eq 1 ]; then
     RESP=$(srv_auth_req '{"method":"memory.store","key":"integ-test","content":"integration test value","tier":"L0","kind":"fact"}') || true
     check_output "memory.store" '"status":"ok"' echo "$RESP"

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1309,6 +1309,24 @@ else
     SKIP=$((SKIP + 1))
 fi
 
+RESP=$(http_call POST /v1/memory/search '{}') || true
+check_output "memory.search missing keywords stays typed" '"kind":"invalid_argument"' echo "$RESP"
+if echo "$RESP" | grep -q '"http_status":400'; then
+    check_output "memory.search missing keywords returns HTTP 400" "400 " echo "$RESP"
+else
+    echo "SKIP: memory.search missing-keywords HTTP mapping (runtime-web status provider is not attached)"
+    SKIP=$((SKIP + 1))
+fi
+
+RESP=$(http_call POST /v1/memory/get '{}') || true
+check_output "memory.get missing id stays typed" '"kind":"invalid_argument"' echo "$RESP"
+if echo "$RESP" | grep -q '"http_status":400'; then
+    check_output "memory.get missing id returns HTTP 400" "400 " echo "$RESP"
+else
+    echo "SKIP: memory.get missing-id HTTP mapping (runtime-web status provider is not attached)"
+    SKIP=$((SKIP + 1))
+fi
+
 if [ "$KB_AVAILABLE" -eq 1 ]; then
     RESP=$(srv_auth_req '{"method":"memory.store","key":"integ-test","content":"integration test value","tier":"L0","kind":"fact"}') || true
     check_output "memory.store" '"status":"ok"' echo "$RESP"

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1336,6 +1336,15 @@ else
     SKIP=$((SKIP + 1))
 fi
 
+RESP=$(http_call POST /v1/memory/get '{"id":0}') || true
+check_output "memory.get rejects non-positive ids" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call POST /v1/memory/get '{"id":1.5}') || true
+check_output "memory.get rejects fractional ids" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call POST /v1/memory/get '{"id":1e30}') || true
+check_output "memory.get rejects unrepresentable ids" '"kind":"invalid_argument"' echo "$RESP"
+
 RESP=$(http_call POST /v1/memory/user_capture '{}') || true
 check_output "memory.user_capture missing fields stays typed" '"kind":"invalid_argument"' echo "$RESP"
 if echo "$RESP" | grep -q '"http_status":400'; then

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1318,6 +1318,15 @@ else
     SKIP=$((SKIP + 1))
 fi
 
+RESP=$(http_call POST /v1/memory/search '{"keywords":[123]}') || true
+check_output "memory.search rejects non-string keywords" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call POST /v1/memory/search '{"keywords":[""],"limit":10}') || true
+check_output "memory.search rejects empty keywords" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call POST /v1/memory/search '{"keywords":["probe"],"limit":-1}') || true
+check_output "memory.search rejects invalid limits" '"kind":"invalid_argument"' echo "$RESP"
+
 RESP=$(http_call POST /v1/memory/get '{}') || true
 check_output "memory.get missing id stays typed" '"kind":"invalid_argument"' echo "$RESP"
 if echo "$RESP" | grep -q '"http_status":400'; then

--- a/src/tests/test_server_error_kind.c
+++ b/src/tests/test_server_error_kind.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 extern aimee_module_status_t aimee_runtime_web_module_handler(const aimee_module_invocation_t *,
                                                               const uint8_t *, uint32_t, uint8_t *,
@@ -78,6 +79,17 @@ int main(void)
    expect_status(SERVER_ERR_UNAVAILABLE, 503);
    expect_status("unknown", 502);
    expect_status(NULL, 502);
+
+   cJSON *rich = cJSON_Parse("{\"status\":\"unavailable\",\"retryable\":true,"
+                             "\"dependency\":\"kb\",\"retry_after_ms\":1000}");
+   assert(rich != NULL);
+   server_error_kind_apply(rich, SERVER_ERR_UNAVAILABLE);
+   assert(strcmp(cJSON_GetObjectItem(rich, "kind")->valuestring, SERVER_ERR_UNAVAILABLE) == 0);
+   assert(cJSON_GetObjectItem(rich, "http_status")->valueint == 503);
+   assert(cJSON_IsTrue(cJSON_GetObjectItem(rich, "retryable")));
+   assert(strcmp(cJSON_GetObjectItem(rich, "dependency")->valuestring, "kb") == 0);
+   assert(cJSON_GetObjectItem(rich, "retry_after_ms")->valueint == 1000);
+   cJSON_Delete(rich);
 
    server_conn_t conn = {0};
    server_error_kind_register_http_status_provider(NULL);

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -265,7 +265,10 @@ int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, siz
    /* Mimic a real method handler: write an NDJSON response to the loopback fd
     * the first-class /v1 route handed us, so the capture path is exercised end to
     * end. */
-   const char *r = "{\"status\":\"ok\",\"result\":42}\n";
+   const char *r = strstr(g_disp_body, "\"test_http_status\":true")
+                       ? "{\"status\":\"error\",\"kind\":\"invalid_argument\","
+                         "\"http_status\":400}\n"
+                       : "{\"status\":\"ok\",\"result\":42}\n";
    ssize_t w = write(conn->fd, r, strlen(r));
    (void)w;
    return 0;
@@ -2478,6 +2481,16 @@ int main(void)
           server_http_route("POST", "/v1/cron/add", spoof, (int)strlen(spoof), resp, sizeof(resp));
       assert(st == 200);
       assert(strcmp(g_disp_method, "cron.add") == 0);
+
+      /* Typed NDJSON errors carry their transport-independent HTTP mapping in
+       * the envelope. The first-class HTTP adapter must honor it rather than
+       * reporting a failed operation as a successful 200 response. */
+      const char *typed_error = "{\"test_http_status\":true}";
+      st = server_http_route("POST", "/v1/cron/add", typed_error, (int)strlen(typed_error), resp,
+                             sizeof(resp));
+      assert(st == 400);
+      assert(strcmp(resp, "{\"status\":\"error\",\"kind\":\"invalid_argument\","
+                          "\"http_status\":400}") == 0);
    }
 
    /* (The /v1/rpc method-allowlist tests were removed with the bridge: each method


### PR DESCRIPTION
## Summary

- propagate a typed dispatch envelope HTTP status through the first-class HTTP adapter
- retain the existing 200 behavior for successful NDJSON dispatch responses
- add an end-to-end route/loopback regression case

## Live reproduction

Against the latest published testing stack, POST /v1/memory/store with an empty content string returned this typed validation envelope:

    {"status":"error","message":"memory.store requires a non-empty key and content","kind":"invalid_argument","http_status":400}

The actual HTTP status was 200, contradicting both the envelope and the OpenAPI 400 response. No memory row was stored.

## Verification

- targeted unit-test-server-http: pass
- make -C src lint: all 75 checks pass
- make -C src unit-tests: all 661 test binaries and sanitizer support tests pass
- git diff --check: pass