### PR TITLE
test(audit): fix wall-clock determinism flake

### DIFF
--- a/src/modules/audit/include/aimee/audit/audit_worm.h
+++ b/src/modules/audit/include/aimee/audit/audit_worm.h
@@ -15,7 +15,7 @@
  *               detail, key_id, prev_hash, row_hash)
  *
  *   seq        1..N, gap-free (allocated MAX(seq)+1 inside the write txn)
- *   ts         RFC3339-UTC, ADVISORY — excluded from row_hash, not an ordering key
+ *   ts         RFC3339-UTC, bound into the current v2-full row_hash; not an ordering key
  *   row_hash   SHA256( AUDIT_WORM_DOMAIN "\n" prev_hash "\n" canonical(record) )
  *   prev_hash  the previous row's row_hash; for seq=1 the genesis is 32 zero bytes
  *              rendered as 64 hex '0's (AUDIT_WORM_GENESIS_PREV)

--- a/src/tests/test_audit_worm.c
+++ b/src/tests/test_audit_worm.c
@@ -132,8 +132,10 @@ static void test_worm_triggers_block_mutation(void)
    printf("  test_worm_triggers_block_mutation: ok\n");
 }
 
-/* Same inputs, two independent stores -> identical row_hash for seq=1. This is
- * the reproducibility the cross-engine (SQLite/Postgres) vectors rest on. */
+/* Same inputs, including the producer timestamp, in two independent stores ->
+ * identical row_hash for seq=1. This is the reproducibility the cross-engine
+ * (SQLite/Postgres) vectors rest on. Use the durable-producer seam so the test
+ * does not accidentally compare different wall-clock seconds. */
 static void test_cross_store_determinism(void)
 {
    char pa[300], pb[300];
@@ -145,8 +147,11 @@ static void test_cross_store_determinism(void)
    {
       const char *p = i == 0 ? pa : pb;
       assert(audit_worm_init_at(p) == 0);
-      assert(audit_worm_append("primary", "u1", "tool.read", "v1-fixed", "allow", "{\"x\":1}") ==
-             0);
+      long long seq = 0;
+      assert(audit_worm_append_idempotent("evt-fixed", "2026-01-02T03:04:05Z", "primary", "u1",
+                                          "tool.read", "v1-fixed", "allow", "{\"x\":1}",
+                                          &seq) == 0);
+      assert(seq == 1);
       audit_worm_close();
       sqlite3 *raw = NULL;
       assert(sqlite3_open(p, &raw) == SQLITE_OK);


### PR DESCRIPTION
## Summary

- make the cross-store WORM hash determinism test provide an explicit producer timestamp
- exercise the idempotent durable-producer seam so every hashed input is identical
- correct the public header's stale statement that timestamps are excluded from the current v2 hash
- remove the one-second wall-clock boundary race without changing production hashing

## Failure evidence

PR #2890 CI run 33196481899 failed `unit-tests-pg (1/3)` at `test_cross_store_determinism`:

```
Assertion `ha[0] && strcmp(ha, hb) == 0' failed.
```

The v2 row hash includes `ts`, while the old test called `audit_worm_append()` twice and allowed each independent store to generate `time(NULL)`. The assertion therefore failed whenever the calls crossed a UTC second boundary.

## Verification

- `make -C src build/obj/tests/unit-test-audit-worm`
- 500 consecutive executions of `unit-test-audit-worm`: 500/500 passed
- `make -C src lint`: all 75 checks passed
- `git diff --check`
