### PR TITLE
ci: rebuild testing images only when inputs change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,12 @@ jobs:
       - name: Test the CI change classifier
         run: python3 -I scripts/tests/test_ci_change_scope.py
 
+      # This controls whether multi-gigabyte release images are rebuilt or their
+      # existing manifest is reused.  Run its contract test unconditionally: a
+      # docs-only change can still expose drift in the workflow or Dockerfile inputs.
+      - name: Test the testing-image publication planner
+        run: python3 -I scripts/tests/test_publish_testing_plan.py
+
       # docs_CHANGED, not docs_only. Gated on docs_only, this never ran for a pull
       # request that touched documentation AND anything else -- which is most of them,
       # and is how six em-dash violations reached testing in #2280: that PR edited

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -1,14 +1,14 @@
-# Build the deployable aimee images on every push to `testing` and publish them
-# under a DELIBERATELY non-semver tag (`:testing` + `:testing-<sha>`), so the
-# testing branch can be deployed/validated (e.g. on .254) WITHOUT promoting to
-# main.
+# Publish the deployable aimee image set on relevant pushes to `testing` under a
+# DELIBERATELY non-semver tag (`:testing` + `:testing-<sha>`), so the testing branch
+# can be deployed/validated (e.g. on .254) WITHOUT promoting to main.  An image is
+# rebuilt only when one of its declared inputs changed.  Otherwise its existing
+# manifest is promoted registry-side to the new immutable `testing-<sha>` tag.
 #
-# Builds the split images, the control console, ALL THREE kb embedder variants, and
-# the isolated one-shot authority bootstrap, so every committed Compose topology can
-# pull a single coherent `:testing`
-# channel whichever embedder the wizard selected. Synthesis is NOT here: it is its own
-# image on its own trigger (publish-llm.yml), rebuilt when the model changes rather
-# than when kb code does.
+# The published set covers the split images, the control console, ALL THREE kb
+# embedder variants, and the isolated one-shot authority bootstrap, so every committed
+# Compose topology has a coherent immutable channel revision whichever embedder the
+# wizard selected. Synthesis is NOT here: it is its own image on its own trigger
+# (publish-llm.yml), rebuilt when the model changes rather than when kb code does.
 # Versioned + `:latest` publishing of the full image set
 # stays owned by main (auto-release.yml -> publish-images.yml). Keeping testing on
 # a `:testing` tag — never a version number — avoids confusing a tested-but-
@@ -49,44 +49,53 @@ permissions:
   packages: write
 
 jobs:
-  build:
+  # Compute the image set from a source-controlled input contract.  Unchanged images
+  # are promoted registry-side below; they are not pulled and they are not rebuilt.
+  # Unknown paths fail safe by selecting every image.  workflow_dispatch is the
+  # explicit recovery/force-rebuild path.
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.images.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+
+      - name: Select images whose inputs changed
+        id: images
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            matrix=$(python3 scripts/publish_testing_plan.py --all </dev/null)
+          else
+            if [ -z "${BEFORE_SHA:-}" ] ||
+               [ "$BEFORE_SHA" = 0000000000000000000000000000000000000000 ] ||
+               ! git cat-file -e "${BEFORE_SHA}^{commit}"; then
+              echo "::error::cannot resolve the previous testing commit; use workflow_dispatch to force a complete rebuild"
+              exit 1
+            fi
+            matrix=$(git diff --name-only -z "$BEFORE_SHA" "$GITHUB_SHA" |
+              python3 scripts/publish_testing_plan.py --null)
+          fi
+          python3 -m json.tool <<< "$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: [plan]
+    name: ${{ matrix.image.name }} (${{ matrix.image.rebuild && 'build' || 'reuse' }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        # Same image set + Dockerfiles as the release pipeline
-        # (publish-images.yml), minus the css leg that testing does not redeploy.
-        # Cache scopes match publish-images so testing reuses the release layer
-        # cache and never restarts the LTO C build from scratch.
-        #
-        # NO -llm LEGS HERE, and that is the point. An image carrying llama.cpp and
-        # multi-gigabyte weights must not be rebuilt because kb code changed, and
-        # every leg in this matrix rebuilds on every push that touches src/**. The
-        # two -llm kb variants published from here cost a full kb rebuild each —
-        # under a separate cache scope, so the LTO C build, postgres, pgvectorscale
-        # and torch were all built three times per push for one code change.
-        #
-        # Bundled synthesis moves to its own aimee-llm-e{2,4}b image, deployed
-        # beside the kb, rebuilt only when the model or the model list changes. The
-        # weights stay baked — that property is why they were baked in the first
-        # place — they are just baked into the image whose inputs are stable.
-        #
-        # ALL THREE EMBEDDER VARIANTS, not a subset. An earlier version of this matrix
-        # carried the bekko legs only, on the reasoning that nomic is a one-way choice
-        # this channel had never deployed. That reasoning was wrong: a variant absent
-        # from the channel cannot be deployed FROM the channel, so an operator who
-        # selects nomic on a :testing stack gets a manifest that does not exist. The
-        # deploy layer now picks the image from the embedder choice
-        # (AIMEE_KB_VARIANT), so every choice it can emit has to be publishable here.
-        image:
-          - { name: aimee-server,    dockerfile: Dockerfile.server }
-          - { name: aimee-control-web, dockerfile: Dockerfile.control-web }
-          - { name: aimee-kb,        dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=none" }
-          - { name: aimee-kb-a25m,   dockerfile: Dockerfile, args: "AIMEE_EMBEDDER=bekko-a25m" }
-          - { name: aimee-kb-nomic,  dockerfile: Dockerfile,
-              args: "AIMEE_EMBEDDER=nomic-embed-text-v2-moe" }
-          - { name: aimee-authority-bootstrap, dockerfile: Dockerfile.authority-bootstrap }
+        # The planner always returns the complete image set.  Each entry says whether
+        # its declared inputs changed; the other entries reuse their current manifest
+        # while still receiving this revision's immutable testing-<sha> tag.
+        image: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
@@ -103,14 +112,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Point the -llm legs at the model image the `models` job just guaranteed, so
-      # the build copies a registry layer. The fetch fallback is kept for the same
-      # reason publish-images keeps it: it makes the model image an optimisation
-      # rather than a dependency, so a quant bump still builds.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
+      # A missing moving tag is a real need to build, even when source inputs did not
+      # change (for example when bootstrapping a new package registry).  Otherwise an
+      # unchanged manifest is promoted without downloading any of its layers.
+      - name: Find reusable ${{ matrix.image.name }} manifest
+        id: have
+        env:
+          IMAGE: ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}
+        run: |
+          if docker manifest inspect "$IMAGE:testing" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No existing $IMAGE:testing manifest; a bootstrap build is required"
+          fi
+
       - name: Build and push ${{ matrix.image.name }}:testing
+        if: ${{ matrix.image.rebuild || steps.have.outputs.exists != 'true' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
@@ -137,6 +158,23 @@ jobs:
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}
+
+      - name: Reuse ${{ matrix.image.name }} without rebuilding
+        if: ${{ !matrix.image.rebuild && steps.have.outputs.exists == 'true' }}
+        env:
+          IMAGE: ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "$IMAGE:testing-${SHA7}" \
+            "$IMAGE:testing"
+          old=$(docker buildx imagetools inspect "$IMAGE:testing" --raw | sha256sum | cut -d' ' -f1)
+          new=$(docker buildx imagetools inspect "$IMAGE:testing-${SHA7}" --raw | sha256sum | cut -d' ' -f1)
+          if [ "$old" != "$new" ]; then
+            echo "::error::registry-side promotion changed the manifest digest ($old != $new)"
+            exit 1
+          fi
+          echo "Reused $IMAGE:testing as $IMAGE:testing-${SHA7} ($new)"
 
   # The thin client, published on the SAME cadence as the images it talks to.
   #

--- a/scripts/check-published-compose-images.py
+++ b/scripts/check-published-compose-images.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 import re
 import sys
@@ -18,12 +19,45 @@ WORKFLOWS = (
     ROOT / ".github/workflows/publish-images.yml",
 )
 LLM_WORKFLOW = ROOT / ".github/workflows/publish-llm.yml"
+TESTING_PLANNER = ROOT / "scripts/publish_testing_plan.py"
 BUNDLED_KB_COMPOSE = (ROOT / "compose.yaml", ROOT / "compose.server.yaml")
 BUNDLED_KB_IMAGE = "ghcr.io/rakuensoftware/aimee-kb-a25m:"
 
 
 class PublisherError(RuntimeError):
     """A Compose image has no coherent publishing path."""
+
+
+def testing_planner_images(root: Path) -> set[str]:
+    """Read the canonical testing matrix without executing repository code."""
+
+    path = root / TESTING_PLANNER.relative_to(ROOT)
+    if not path.exists():
+        raise PublisherError(f"{path.relative_to(root)} is missing")
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not any(
+            isinstance(target, ast.Name) and target.id == "IMAGES"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, (ast.Tuple, ast.List)):
+            break
+        names: set[str] = set()
+        for entry in node.value.elts:
+            if (
+                isinstance(entry, ast.Call)
+                and isinstance(entry.func, ast.Name)
+                and entry.func.id == "Image"
+                and entry.args
+                and isinstance(entry.args[0], ast.Constant)
+                and isinstance(entry.args[0].value, str)
+            ):
+                names.add(entry.args[0].value)
+        if names:
+            return names
+        break
+    raise PublisherError(f"{path.relative_to(root)} has no static IMAGES contract")
 
 
 def compose_files(root: Path) -> list[Path]:
@@ -77,8 +111,21 @@ def validate(root: Path = ROOT) -> tuple[int, int]:
     workflows = tuple(root / path.relative_to(ROOT) for path in WORKFLOWS)
     for workflow in workflows:
         text = workflow.read_text(encoding="utf-8")
+        if workflow.name == "publish-testing.yml":
+            planner_ref = "scripts/publish_testing_plan.py"
+            if planner_ref not in text:
+                errors.append(
+                    f"{workflow.relative_to(root)} does not invoke {planner_ref}"
+                )
+            published = testing_planner_images(root)
+        else:
+            published = {
+                image
+                for image in images
+                if re.search(MATRIX_ENTRY % re.escape(image), text)
+            }
         for image in sorted(images):
-            if not re.search(MATRIX_ENTRY % re.escape(image), text):
+            if image not in published:
                 errors.append(f"{workflow.relative_to(root)} does not publish {image}")
 
     if llm_images:

--- a/scripts/publish_testing_plan.py
+++ b/scripts/publish_testing_plan.py
@@ -46,9 +46,11 @@ AUTHORITY = frozenset(("aimee-authority-bootstrap",))
 
 # Files that define publication, not image bytes.  Keeping these out of every image
 # is important: fixing this planner must not itself trigger six unrelated rebuilds.
-ORCHESTRATION = frozenset(
+PUBLISH_TOOLING = frozenset(
     (
+        ".github/workflows/ci.yml",
         ".github/workflows/publish-testing.yml",
+        "scripts/check-published-compose-images.py",
         "scripts/publish_testing_plan.py",
         "scripts/tests/test_publish_testing_plan.py",
     )
@@ -90,7 +92,7 @@ def consumers(path: str) -> frozenset[str]:
     """
 
     path = path.removeprefix("./")
-    if not path or path in ORCHESTRATION:
+    if not path or path in PUBLISH_TOOLING:
         return frozenset()
     if path.startswith("src/tests/") or path.startswith("scripts/tests/"):
         return frozenset()

--- a/scripts/publish_testing_plan.py
+++ b/scripts/publish_testing_plan.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Plan testing-channel image publication from the files that actually changed.
+
+The testing channel has one moving tag and one immutable tag per source revision.
+An unchanged image does not need to be rebuilt to participate in a new channel
+revision: its existing ``:testing`` manifest can be given the new immutable tag.
+
+This classifier is deliberately conservative.  Known image inputs select only the
+images that consume them; a path not covered by the contract selects every image.
+That makes adding a new build input expensive until it is classified, never silent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Image:
+    name: str
+    dockerfile: str
+    args: str = ""
+
+
+IMAGES = (
+    Image("aimee-server", "Dockerfile.server"),
+    Image("aimee-control-web", "Dockerfile.control-web"),
+    Image("aimee-kb", "Dockerfile", "AIMEE_EMBEDDER=none"),
+    Image("aimee-kb-a25m", "Dockerfile", "AIMEE_EMBEDDER=bekko-a25m"),
+    Image(
+        "aimee-kb-nomic",
+        "Dockerfile",
+        "AIMEE_EMBEDDER=nomic-embed-text-v2-moe",
+    ),
+    Image("aimee-authority-bootstrap", "Dockerfile.authority-bootstrap"),
+)
+
+ALL = frozenset(image.name for image in IMAGES)
+SERVER = frozenset(("aimee-server",))
+CONTROL = frozenset(("aimee-control-web",))
+KB = frozenset(("aimee-kb", "aimee-kb-a25m", "aimee-kb-nomic"))
+AUTHORITY = frozenset(("aimee-authority-bootstrap",))
+
+# Files that define publication, not image bytes.  Keeping these out of every image
+# is important: fixing this planner must not itself trigger six unrelated rebuilds.
+ORCHESTRATION = frozenset(
+    (
+        ".github/workflows/publish-testing.yml",
+        "scripts/publish_testing_plan.py",
+        "scripts/tests/test_publish_testing_plan.py",
+    )
+)
+
+KB_CONTAINER_FILES = frozenset(
+    (
+        "deploy/container/aimee.yaml",
+        "deploy/container/aimee-kb-entrypoint.sh",
+        "deploy/container/optional-modules-lib.sh",
+        "deploy/container/module-supervisor.sh",
+        "deploy/container/aimee-kb-db-export.sh",
+    )
+)
+
+SERVER_CONTAINER_FILES = frozenset(
+    (
+        "deploy/container/aimee-managed.compose.yaml",
+        "deploy/container/pam.d-aimee",
+        "deploy/container/runtime-web-lib.sh",
+        "deploy/container/optional-modules-lib.sh",
+        "deploy/container/plane-supervisor.sh",
+        "deploy/container/module-supervisor.sh",
+        "deploy/container/core-storage.sh",
+        "deploy/container/server-entrypoint.sh",
+        "deploy/container/aimee-server.yaml",
+    )
+)
+
+AUTHORITY_CONTAINER_FILES = frozenset(
+    ("deploy/container/aimee-managed-authority-bootstrap.sh",)
+)
+
+
+def consumers(path: str) -> frozenset[str]:
+    """Return image names whose declared inputs include *path*.
+
+    Empty means a known non-image input.  ALL is the fail-safe for an unknown path.
+    """
+
+    path = path.removeprefix("./")
+    if not path or path in ORCHESTRATION:
+        return frozenset()
+    if path.startswith("src/tests/") or path.startswith("scripts/tests/"):
+        return frozenset()
+
+    if path == ".dockerignore":
+        return ALL
+    if path == "Dockerfile":
+        return KB
+    if path == "Dockerfile.server":
+        return SERVER
+    if path == "Dockerfile.control-web":
+        return CONTROL
+    if path == "Dockerfile.authority-bootstrap":
+        return AUTHORITY
+
+    if path.startswith("control-web/"):
+        return CONTROL
+    if path.startswith("frontend/"):
+        return SERVER | CONTROL
+    if path.startswith("runtime-web/"):
+        return SERVER
+    if path.startswith("config/"):
+        return SERVER
+
+    if path.startswith("server-go/"):
+        out = SERVER | KB  # both images build the module multicall runtime
+        if path in ("server-go/go.mod", "server-go/go.sum") or path.startswith(
+            "server-go/modules/control-web/policy/"
+        ):
+            out |= CONTROL
+        return out
+
+    if path.startswith("src/modules/kb_client/"):
+        # Makefile's KB_CLIENT_OBJS are linked only into aimee-server.  A regression
+        # test enforces that this directory never enters an aimee-kb target unnoticed.
+        return SERVER
+    if path.startswith("src/"):
+        # The C make graph has broad shared closures.  Until a narrower ownership
+        # boundary is mechanically proven, source outside the two exclusions above
+        # invalidates every C image.  This is conservative, not a guessed omission.
+        return SERVER | KB | AUTHORITY
+
+    if path in KB_CONTAINER_FILES:
+        out = KB
+        if path in SERVER_CONTAINER_FILES:
+            out |= SERVER
+        return out
+    if path in SERVER_CONTAINER_FILES:
+        return SERVER
+    if path in AUTHORITY_CONTAINER_FILES:
+        return AUTHORITY
+    if path.startswith("deploy/container/"):
+        return ALL
+
+    if path.startswith("scripts/"):
+        # Build/export scripts and runtime helpers are copied by the C images.  A
+        # future script is therefore all-C until this contract classifies it.
+        return SERVER | KB | AUTHORITY
+
+    # publish-testing's trigger should make this rare.  If its path list expands,
+    # rebuild everything until the new input is deliberately assigned above.
+    return ALL
+
+
+def plan(paths: list[str], force_all: bool = False) -> list[dict[str, object]]:
+    affected = set(ALL if force_all else ())
+    for path in paths:
+        affected.update(consumers(path))
+    return [
+        {
+            "name": image.name,
+            "dockerfile": image.dockerfile,
+            "args": image.args,
+            "rebuild": image.name in affected,
+        }
+        for image in IMAGES
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--all", action="store_true", help="rebuild every image (manual recovery)"
+    )
+    parser.add_argument(
+        "--null",
+        action="store_true",
+        help="read NUL-separated paths from stdin (the format of git diff -z)",
+    )
+    args = parser.parse_args()
+    raw = sys.stdin.buffer.read()
+    separator = b"\0" if args.null else b"\n"
+    paths = [item.decode("utf-8") for item in raw.split(separator) if item]
+    result = plan(paths, force_all=args.all)
+    rebuilt = [item["name"] for item in result if item["rebuild"]]
+    reused = [item["name"] for item in result if not item["rebuild"]]
+    print(f"rebuild: {', '.join(rebuilt) or '(none)'}", file=sys.stderr)
+    print(f"reuse: {', '.join(reused) or '(none)'}", file=sys.stderr)
+    print(json.dumps(result, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_published_compose_images.py
+++ b/scripts/tests/test_check_published_compose_images.py
@@ -25,6 +25,7 @@ class PublishedComposeImagesTests(unittest.TestCase):
             "compose.server.yaml",
             ".github/workflows/publish-testing.yml",
             ".github/workflows/publish-images.yml",
+            "scripts/publish_testing_plan.py",
         ):
             source = REPO / relative
             target = root / relative
@@ -42,20 +43,34 @@ class PublishedComposeImagesTests(unittest.TestCase):
     def test_repository_passes(self) -> None:
         image_count, workflow_count = checker.validate(REPO)
         self.assertGreaterEqual(image_count, 4)
-        self.assertEqual(workflow_count, 2)
+        self.assertEqual(workflow_count, 3)
 
     def test_compose_image_missing_from_either_publisher_is_rejected(self) -> None:
         for workflow in ("publish-testing.yml", "publish-images.yml"):
             with self.subTest(workflow=workflow):
                 def remove_control_web(root: Path, name: str = workflow) -> None:
-                    path = root / ".github/workflows" / name
-                    path.write_text(path.read_text().replace(
-                        "{ name: aimee-control-web, dockerfile: Dockerfile.control-web }",
-                        "{ name: omitted-control-web, dockerfile: Dockerfile.control-web }",
-                        1,
-                    ))
+                    if name == "publish-testing.yml":
+                        path = root / "scripts/publish_testing_plan.py"
+                        old = 'Image("aimee-control-web", "Dockerfile.control-web")'
+                        new = 'Image("omitted-control-web", "Dockerfile.control-web")'
+                    else:
+                        path = root / ".github/workflows" / name
+                        old = "{ name: aimee-control-web, dockerfile: Dockerfile.control-web }"
+                        new = "{ name: omitted-control-web, dockerfile: Dockerfile.control-web }"
+                    path.write_text(path.read_text().replace(old, new, 1))
 
                 self.assert_rejected(remove_control_web, "does not publish aimee-control-web")
+
+    def test_testing_workflow_must_invoke_the_planner(self) -> None:
+        def disconnect_planner(root: Path) -> None:
+            path = root / ".github/workflows/publish-testing.yml"
+            path.write_text(
+                path.read_text().replace(
+                    "scripts/publish_testing_plan.py", "scripts/disconnected_plan.py"
+                )
+            )
+
+        self.assert_rejected(disconnect_planner, "does not invoke")
 
     def test_weightless_image_is_rejected_for_bekko_topologies(self) -> None:
         def select_weightless(root: Path) -> None:

--- a/scripts/tests/test_publish_testing_plan.py
+++ b/scripts/tests/test_publish_testing_plan.py
@@ -96,9 +96,16 @@ def main() -> None:
         "tests are not runtime inputs",
     )
     failures += expect(
-        [".github/workflows/publish-testing.yml", "scripts/publish_testing_plan.py"],
+        [
+            ".github/workflows/ci.yml",
+            ".github/workflows/publish-testing.yml",
+            "scripts/check-published-compose-images.py",
+            "scripts/publish_testing_plan.py",
+            "scripts/tests/test_check_published_compose_images.py",
+            "scripts/tests/test_publish_testing_plan.py",
+        ],
         set(),
-        "publication orchestration is not image content",
+        "this publication-only PR does not rebuild runtime images",
     )
     failures += expect(["new/runtime/input"], all_images, "unknown input fails safe")
 

--- a/scripts/tests/test_publish_testing_plan.py
+++ b/scripts/tests/test_publish_testing_plan.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Regression tests for selective testing-image publication."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "publish_testing_plan.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-testing.yml"
+MAKEFILE = ROOT / "src" / "Makefile"
+
+spec = importlib.util.spec_from_file_location("publish_testing_plan", SCRIPT)
+if spec is None or spec.loader is None:
+    sys.exit("cannot load publish_testing_plan.py")
+planner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = planner
+spec.loader.exec_module(planner)
+
+
+def rebuilt(paths: list[str]) -> set[str]:
+    return {item["name"] for item in planner.plan(paths) if item["rebuild"]}
+
+
+def expect(paths: list[str], want: set[str], why: str) -> int:
+    got = rebuilt(paths)
+    ok = got == want
+    print(("  ok    " if ok else "  FAIL  ") + f"{why}: {sorted(got)}")
+    if not ok:
+        print(f"        expected: {sorted(want)}")
+    return 0 if ok else 1
+
+
+def dockerfile_container_inputs(path: pathlib.Path) -> set[str]:
+    """Literal deploy/container inputs copied by a Dockerfile."""
+
+    found: set[str] = set()
+    instructions: list[str] = []
+    current = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        current = f"{current} {line.strip()}".strip()
+        if current.endswith("\\"):
+            current = current[:-1]
+            continue
+        instructions.append(current)
+        current = ""
+    if current:
+        instructions.append(current)
+    for instruction in instructions:
+        if not instruction.startswith("COPY "):
+            continue
+        found.update(re.findall(r"deploy/container/[A-Za-z0-9_.-]+", instruction))
+    return found
+
+
+def main() -> None:
+    failures = 0
+    all_images = set(planner.ALL)
+    kb = set(planner.KB)
+
+    # The reported incident: a server-side KB client diagnostic and a test must not
+    # rebuild any KB image, especially the multi-gigabyte A25M/Nomic variants.
+    failures += expect(
+        ["src/modules/kb_client/kb_client_mtls.c", "src/tests/test_audit_worm.c"],
+        set(planner.SERVER),
+        "#2887 server-only change",
+    )
+    failures += expect(
+        ["src/kb/kb_service.c"],
+        set(planner.SERVER | planner.KB | planner.AUTHORITY),
+        "shared C source is conservative",
+    )
+    failures += expect(
+        ["frontend/src/App.tsx"],
+        set(planner.SERVER | planner.CONTROL),
+        "shared browser frontend",
+    )
+    failures += expect(
+        ["control-web/main.go"], set(planner.CONTROL), "control console only"
+    )
+    failures += expect(
+        ["deploy/container/aimee-kb-entrypoint.sh"], kb, "KB entrypoint only"
+    )
+    failures += expect(
+        ["deploy/container/module-supervisor.sh"],
+        set(planner.SERVER | planner.KB),
+        "shared container supervisor",
+    )
+    failures += expect(
+        ["src/tests/test_kb_http.c", "scripts/tests/test_bake_embedder.py"],
+        set(),
+        "tests are not runtime inputs",
+    )
+    failures += expect(
+        [".github/workflows/publish-testing.yml", "scripts/publish_testing_plan.py"],
+        set(),
+        "publication orchestration is not image content",
+    )
+    failures += expect(["new/runtime/input"], all_images, "unknown input fails safe")
+
+    forced = {item["name"] for item in planner.plan([], force_all=True) if item["rebuild"]}
+    if forced != all_images:
+        print(f"  FAIL  manual recovery: {sorted(forced)}")
+        failures += 1
+    else:
+        print("  ok    manual recovery rebuilds all images")
+
+    # Enforce the ownership fact that makes the narrow kb_client rule safe.
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    # The aggregate may appear elsewhere under its server-owned alias, but the raw
+    # object group must have exactly one consumer: SERVER_KB_CLIENT_OBJS.  A KB target
+    # taking it directly makes this fail until the image contract is widened.
+    raw_consumers = re.findall(r"^.*\$\(KB_CLIENT_OBJS\).*$", makefile, re.M)
+    want_consumer = ["SERVER_KB_CLIENT_OBJS = $(KB_CLIENT_OBJS)"]
+    if raw_consumers != want_consumer:
+        print(f"  FAIL  KB_CLIENT_OBJS gained a new consumer: {raw_consumers}")
+        failures += 1
+    else:
+        print("  ok    KB_CLIENT_OBJS remains server-owned")
+
+    # If a Dockerfile starts copying another container file, the contract must be
+    # updated in the same change.  This prevents selective publishing from drifting.
+    docker_contracts = (
+        ("Dockerfile", planner.KB_CONTAINER_FILES),
+        ("Dockerfile.server", planner.SERVER_CONTAINER_FILES),
+        ("Dockerfile.authority-bootstrap", planner.AUTHORITY_CONTAINER_FILES),
+    )
+    for filename, declared in docker_contracts:
+        actual = dockerfile_container_inputs(ROOT / filename)
+        missing = actual - set(declared)
+        if missing:
+            print(f"  FAIL  {filename} has undeclared container inputs: {sorted(missing)}")
+            failures += 1
+        else:
+            print(f"  ok    {filename} container inputs are declared")
+
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    required_workflow_fragments = (
+        "scripts/publish_testing_plan.py --null",
+        "docker manifest inspect",
+        "docker buildx imagetools create",
+        "steps.have.outputs.exists != 'true'",
+        "steps.have.outputs.exists == 'true'",
+    )
+    for fragment in required_workflow_fragments:
+        if fragment not in workflow:
+            print(f"  FAIL  workflow does not enforce {fragment!r}")
+            failures += 1
+        else:
+            print(f"  ok    workflow contains {fragment!r}")
+
+    if failures:
+        sys.exit(f"test_publish_testing_plan: {failures} failure(s)")
+    print("test_publish_testing_plan: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- add a source-controlled image-input contract for the testing channel
- rebuild only images whose declared inputs changed
- reuse unchanged `:testing` manifests registry-side while still publishing a complete immutable `testing-<sha>` tag set
- fail conservative for unknown inputs and rebuild a missing registry image as a bootstrap recovery
- add contract tests for the exact #2887 regression, Makefile ownership, Dockerfile input drift, workflow promotion, and force rebuilds

This means #2887's `src/modules/kb_client/kb_client_mtls.c` plus test-only change rebuilds `aimee-server` only. `aimee-kb`, A25M, Nomic, control-web, and authority-bootstrap are reused without pulling or rebuilding their layers.

## Validation

- `python3 -I scripts/tests/test_publish_testing_plan.py`
- `python3 -I -S scripts/check_tests_are_run.py`
- `actionlint .github/workflows/ci.yml .github/workflows/publish-testing.yml`
- PyYAML parse of both changed workflows
- `git diff --check`
- repeated the planner contract test on `.252`
- on `.252`, read-only inspected all three current KB `:testing` manifests with Docker Buildx, including raw-manifest digest calculation used by the promotion check

The repository-wide `make -C src script-tests` reaches and passes the new test, then fails in the pre-existing `test_check_background_skill_curator_absence.py` fixture because it tries to copy the already-absent `src/modules/db1/maintenance.c`; this branch does not alter that test or path.
