### PR TITLE
fix(json): preserve exact numeric round trips

### DIFF
--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -292,10 +292,10 @@ int memory_request_positive_id(cJSON *req, const char *field, int64_t *out)
 {
    cJSON *item = cJSON_GetObjectItemCaseSensitive(req, field);
    if (!cJSON_IsNumber(item) || !isfinite(item->valuedouble) || item->valuedouble <= 0.0 ||
-       item->valuedouble > 9007199254740991.0 || floor(item->valuedouble) != item->valuedouble)
+       item->valuedouble >= 9223372036854775808.0 || floor(item->valuedouble) != item->valuedouble)
       return -1;
    *out = (int64_t)item->valuedouble;
-   return 0;
+   return *out <= INT64_C(9007199254740991) ? 0 : -1;
 }
 
 /* Replace a memory with a corrected one, linking the two.

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1345,6 +1345,12 @@ check_output "memory.get rejects fractional ids" '"kind":"invalid_argument"' ech
 RESP=$(http_call POST /v1/memory/get '{"id":1e30}') || true
 check_output "memory.get rejects unrepresentable ids" '"kind":"invalid_argument"' echo "$RESP"
 
+RESP=$(http_call POST /v1/memory/get '{"id":9007199254740992}') || true
+check_output "memory.get rejects ids above the JSON safe integer range" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call POST /v1/memory/get '{"id":9007199254740993}') || true
+check_output "memory.get rejects ids rounded onto the JSON safe integer boundary" '"kind":"invalid_argument"' echo "$RESP"
+
 RESP=$(http_call POST /v1/memory/user_capture '{}') || true
 check_output "memory.user_capture missing fields stays typed" '"kind":"invalid_argument"' echo "$RESP"
 if echo "$RESP" | grep -q '"http_status":400'; then

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -484,8 +484,27 @@ static void test_sse_keepalive_slow_generation(void)
    assert(strstr(buf, "keep-alive") != NULL);
 }
 
+static void test_json_number_serialization_is_exact(void)
+{
+   const char *cases[] = {"9007199254740991", "9007199254740992", "9007199254740993"};
+   for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++)
+   {
+      cJSON *before = cJSON_Parse(cases[i]);
+      assert(cJSON_IsNumber(before));
+      char *encoded = cJSON_PrintUnformatted(before);
+      assert(encoded != NULL);
+      cJSON *after = cJSON_Parse(encoded);
+      assert(cJSON_IsNumber(after));
+      assert(after->valuedouble == before->valuedouble);
+      cJSON_Delete(after);
+      free(encoded);
+      cJSON_Delete(before);
+   }
+}
+
 int main(void)
 {
+   test_json_number_serialization_is_exact();
    test_role_template_show_reports_what_the_role_came_to();
    printf("server_http: ");
 

--- a/src/vendor/cJSON.c
+++ b/src/vendor/cJSON.c
@@ -630,7 +630,10 @@ static cJSON_bool print_number(const cJSON *const item, printbuffer *const outpu
       length = sprintf((char *)number_buffer, "%1.15g", d);
 
       /* Check whether the original double can be recovered */
-      if ((sscanf((char *)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+      /* Serialization is a transport boundary, so approximate equality is not
+       * enough here. In particular, treating a two-unit difference near 2^53
+       * as equal can rewrite one integer ID into another before dispatch. */
+      if ((sscanf((char *)number_buffer, "%lg", &test) != 1) || test != d)
       {
          /* If not, print with 17 decimal places of precision */
          length = sprintf((char *)number_buffer, "%1.17g", d);


### PR DESCRIPTION
## Summary

- require exact double round trips when cJSON serializes numbers
- reject memory IDs above the JSON safe-integer limit after conversion
- cover both sides of the 2^53 boundary in unit and integration tests

## Root cause

The generic dispatch path parses and reprints request JSON. cJSON used approximate floating-point equality to decide whether 15 digits were enough. Near 2^53, that could serialize one representable integer as a neighboring value before request validation, allowing an unsafe ID through or changing the largest valid ID.

## Validation

- make lint (all 76 checks passed)
- warnings-as-errors server build
- unit-test-server-http
- test_integration.sh (83/83 passed; 69 expected service skips)

This is a follow-up discovered during live exploratory testing after #2890.