### PR TITLE
fix(cli): stop the positional join dropping the text it was given

### DIFF
--- a/src/cli_argspec.c
+++ b/src/cli_argspec.c
@@ -411,21 +411,42 @@ static const char *field_value(const cJSON *field, const cli_args_t *opts, const
       int start = cJSON_IsNumber(fi) ? (int)fi->valuedouble : 0;
       if (opts->pos_count <= start)
          return NULL;
-      static char joined_pos[8192];
+      /* Sized to the join, not to a guess. This was a fixed 8 KiB buffer whose
+       * loop broke once the next word would not fit, which silently discarded
+       * the rest of the user's text: `aimee memory store k <8 KiB or more>`
+       * stored a truncated note with no warning, and when the FIRST word alone
+       * exceeded the buffer the join came out empty, so the server refused it
+       * with "requires a non-empty key and content" -- blaming the caller for
+       * text it had just dropped. Measured boundary: 8191 bytes stored, 8192
+       * reported as empty.
+       *
+       * Ownership is unchanged: the result stays valid until the next call, the
+       * same contract the static array gave, so callers need no edit. */
+      static char *joined_pos = NULL;
+      static size_t joined_cap = 0;
+      size_t need = 1;
+      for (int i = start; i < opts->pos_count; i++)
+         need += (opts->positional[i] ? strlen(opts->positional[i]) : 0) + (i > start ? 1 : 0);
+      if (need > joined_cap)
+      {
+         char *grown = realloc(joined_pos, need);
+         if (!grown)
+            return NULL;
+         joined_pos = grown;
+         joined_cap = need;
+      }
       size_t at = 0;
       joined_pos[0] = '\0';
       for (int i = start; i < opts->pos_count; i++)
       {
          const char *w = opts->positional[i] ? opts->positional[i] : "";
          size_t wl = strlen(w);
-         if (at + wl + (at ? 1 : 0) >= sizeof(joined_pos))
-            break;
          if (at)
             joined_pos[at++] = ' ';
          memcpy(joined_pos + at, w, wl);
          at += wl;
-         joined_pos[at] = '\0';
       }
+      joined_pos[at] = '\0';
       /* An empty join is still a JOIN: `memory store k ""` has a positional at
        * index 1, and positionals_joined returns "" rather than NULL, so the
        * marshaller sends content:"". Returning NULL here fell through to

--- a/src/tests/test_cli_argspec.c
+++ b/src/tests/test_cli_argspec.c
@@ -2290,6 +2290,73 @@ static void test_number_is_refused_not_coerced(void)
    cJSON_Delete(spec);
 }
 
+/* A positional join must carry the whole argument, however long it is. This was
+ * a fixed 8 KiB buffer whose loop stopped once the next word would not fit, so
+ * `aimee memory store <key> <long note>` silently dropped the tail -- and when
+ * the first word alone exceeded the buffer the join came out EMPTY, which the
+ * server then refused as "requires a non-empty key and content", blaming the
+ * caller for text the client had discarded. Measured boundary before the fix:
+ * 8191 bytes stored, 8192 reported as empty. */
+static void test_positional_join_is_not_truncated(void)
+{
+   cJSON *spec = cJSON_Parse("{\"usage\":\"u\",\"fields\":["
+                             "{\"json\":\"key\",\"from\":\"positional\",\"index\":0},"
+                             "{\"json\":\"content\",\"from\":\"positional_join\","
+                             "\"from_index\":1}]}");
+   if (!spec)
+   {
+      fail("join", "could not parse the probe spec");
+      return;
+   }
+
+   const size_t sizes[] = {8191, 8192, 40000};
+   for (size_t s = 0; s < sizeof(sizes) / sizeof(sizes[0]); s++)
+   {
+      const size_t n = sizes[s];
+      char *big = malloc(n + 1);
+      if (!big)
+      {
+         fail("join", "allocation for the probe argument failed");
+         break;
+      }
+      memset(big, 'x', n);
+      big[n] = '\0';
+
+      char *argv[] = {(char *)"k", big};
+      cJSON *req = cli_argspec_build("memory.store", spec, 2, argv);
+      if (!req)
+         fail("join", "refused a request it should have built");
+      else
+      {
+         const cJSON *c = cJSON_GetObjectItemCaseSensitive(req, "content");
+         if (!cJSON_IsString(c))
+            fail("join", "content was not emitted as a string");
+         else if (strlen(c->valuestring) != n)
+            fail("join", "content was truncated or padded");
+         cJSON_Delete(req);
+      }
+      free(big);
+   }
+
+   /* Multiple positionals still join with single spaces, across the old limit. */
+   {
+      char *word = malloc(5001);
+      if (word)
+      {
+         memset(word, 'y', 5000);
+         word[5000] = '\0';
+         char *argv[] = {(char *)"k", word, word};
+         cJSON *req = cli_argspec_build("memory.store", spec, 3, argv);
+         const cJSON *c = req ? cJSON_GetObjectItemCaseSensitive(req, "content") : NULL;
+         if (!cJSON_IsString(c) || strlen(c->valuestring) != 5000 + 1 + 5000)
+            fail("join", "multi-word join lost bytes across the old 8 KiB limit");
+         cJSON_Delete(req);
+         free(word);
+      }
+   }
+   cJSON_Delete(spec);
+}
+
 int main(void)
 {
    /* The session source resolves --session, then $AIMEE_SESSION_ID, then the
@@ -2308,6 +2375,7 @@ int main(void)
    for (size_t i = 0; i < sizeof(SAMPLES) / sizeof(SAMPLES[0]); i++)
       check_same(&SAMPLES[i]);
    test_refuses_what_it_cannot_build();
+   test_positional_join_is_not_truncated();
    test_number_is_refused_not_coerced();
 
    if (g_fail == 0)


### PR DESCRIPTION
Found doing exhaustive e2e against `:testing` on a live managed stack.

## What happens

`aimee memory store <key> <note>` silently loses the caller's text once the note
reaches 8 KiB. `SRC_POSITIONAL_JOIN` builds the value in a fixed
`char joined_pos[8192]` and breaks out of the loop as soon as the next word will not
fit, so a long note is stored **truncated, with nothing said about it**.

When the *first* word alone exceeds the buffer the loop breaks on its first iteration
and the join comes out empty. The client then sends `content:""` and the server refuses
it with:

```text
aimee: memory.store requires a non-empty key and content
```

which blames the caller for text the client had just discarded.

## Measured on a live stack

```text
8190   -> stored memory 15
8191   -> stored memory 16
8192   -> aimee: memory.store requires a non-empty key and content
10000  -> aimee: memory.store requires a non-empty key and content

--content=<10000 chars>  -> stored memory 17     (the flag form was never affected)
12 KB multi-word note    -> stored nothing at all
```

After the fix, the same stack stores 8192, 20000 and 100000 bytes.

## The change

The join is sized to its input instead of to a guess. Ownership is unchanged — the
result stays valid until the next call, exactly the contract the static array gave — so
no caller needs editing.

The new test covers 8191, 8192 and 40000 bytes plus a multi-word join spanning the old
limit. Reverting the fix fails it on all four.

## Not fixed here

The same run found a **second, independent truncation at 2047 bytes**, inside
`memory_insert_epistemic_ex` (`memory_core_crud.c`): the content-safety scan copies into
`char safe_content[2048]` and then assigns `content = safe_content`, so the truncated
copy is what gets persisted. Confirmed directly against DB2 — a 3000 and a 5000 byte
value both stored `content_len = 2047`.

That one has a second consequence worth separating out: the redact/block scan only ever
inspects the first 2047 bytes, so a secret past that point is neither redacted nor
blocked. It sits in a hot, security-relevant path with many return points, so it wants
its own change rather than being folded in here.
