### PR TITLE
test(deploy): compare first staged compose up

### DIFF
--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -29,7 +29,11 @@ for smoke_spec in \
     smoke_bootstrap_line=$(grep -nF \
         "scripts/aimee-compose-vault-bootstrap.sh -f \"\$bootstrap_compose\" $bootstrap_target" \
         "$smoke_script" | cut -d: -f1)
-    smoke_up_line=$(grep -nF '"${DC[@]}" up -d --no-build' "$smoke_script" | cut -d: -f1)
+    # The full-stack smoke intentionally has two staged `up` calls. Compare the
+    # bootstrap against the first one; passing both line numbers to `[` makes
+    # the integer comparison error and silently treats a broken ordering as OK.
+    smoke_up_line=$(grep -nF '"${DC[@]}" up -d --no-build' "$smoke_script" | \
+        head -1 | cut -d: -f1)
     if [ -z "$smoke_build_line" ] || [ -z "$smoke_bootstrap_line" ] || [ -z "$smoke_up_line" ] ||
        [ "$smoke_build_line" -ge "$smoke_bootstrap_line" ] ||
        [ "$smoke_bootstrap_line" -ge "$smoke_up_line" ] ||


### PR DESCRIPTION
## Finding

`make build-integrity` emitted `integer expression expected` but still reported the Docker bootstrap ordering check as passing. The full-stack smoke has two deliberate staged `up --no-build` calls; both line numbers were passed to one integer comparison, so the assertion was not actually enforced.

## Fix

Compare bootstrap ordering to the first long-lived Compose `up`, which is the security boundary the test documents.

## Verification

- Reproduced on immutable `:testing` (`c4fb95f`)
- Focused full integrity script no longer emits the integer-comparison warning
- Bootstrap ordering assertion reports PASS
- `bash -n` and `git diff --check` pass