### PR TITLE
fix(ci): derive testing image inputs from build graph

### DIFF
--- a/scripts/publish_testing_plan.py
+++ b/scripts/publish_testing_plan.py
@@ -13,7 +13,11 @@ That makes adding a new build input expensive until it is classified, never sile
 from __future__ import annotations
 
 import argparse
+import functools
 import json
+import pathlib
+import re
+import subprocess
 import sys
 from dataclasses import dataclass
 
@@ -44,19 +48,147 @@ CONTROL = frozenset(("aimee-control-web",))
 KB = frozenset(("aimee-kb", "aimee-kb-a25m", "aimee-kb-nomic"))
 AUTHORITY = frozenset(("aimee-authority-bootstrap",))
 
-# The KB link target deliberately reuses these leaf implementations from the
-# server directory.  scripts/tests/test_publish_testing_plan.py expands the real
-# Make graph and requires this declaration to match it exactly, so a new KB
-# consumer cannot silently inherit server-only classification.
-KB_SHARED_SERVER_C = frozenset(
-    (
-        "src/server/embedder_probe.c",
-        "src/server/failover.c",
-        "src/server/http_retry.c",
-        "src/server/oauth_pkce.c",
-        "src/server/osv_check.c",
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+@functools.lru_cache(maxsize=1)
+def _shipping_object_closures() -> dict[str, frozenset[str]] | None:
+    """Expand the transitive C link graph for every published runtime image."""
+
+    try:
+        proc = subprocess.run(
+            ["make", "-C", str(ROOT / "src"), "-pnRrq"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if not proc.stdout:
+        return None
+
+    rules: dict[str, set[str]] = {}
+    assignments = {"=", ":=", "::=", "?=", "+="}
+    for line in proc.stdout.splitlines():
+        if not line or line[0].isspace() or line.startswith("#") or ":" not in line:
+            continue
+        left, right = line.split(":", 1)
+        prerequisites = right.split("|", 1)[0].split()
+        if any(token in assignments for token in prerequisites):
+            continue
+        for target in left.split():
+            rules.setdefault(target, set()).update(prerequisites)
+
+    roots = {
+        "aimee-server": ("../aimee-server",),
+        "aimee-kb": ("../aimee-kb", "../aimee-kb-worm"),
+        "aimee-kb-a25m": ("../aimee-kb", "../aimee-kb-worm"),
+        "aimee-kb-nomic": ("../aimee-kb", "../aimee-kb-worm"),
+        "aimee-authority-bootstrap": (
+            "../aimee-kb-token-roots-provision",
+            "../aimee-kb-jwks-publish",
+        ),
+    }
+    closures: dict[str, frozenset[str]] = {}
+    for image, image_roots in roots.items():
+        seen: set[str] = set()
+        pending = list(image_roots)
+        while pending:
+            target = pending.pop()
+            if target in seen:
+                continue
+            seen.add(target)
+            pending.extend(rules.get(target, ()))
+        closures[image] = frozenset(item for item in seen if item.endswith(".o"))
+    if any(not closures[image] for image in roots):
+        return None
+    return closures
+
+
+def _c_source_consumers(path: str) -> frozenset[str]:
+    """Map a C source to images containing any of its compiled object variants."""
+
+    closures = _shipping_object_closures()
+    if closures is None:
+        return ALL
+    stem = path.removeprefix("src/").removesuffix(".c")
+    candidates = {
+        f"build/obj/{stem}.o",
+        f"build/obj/server/{stem}.o",
+        f"build/obj/kb/{stem}.o",
+    }
+    return frozenset(
+        image for image, objects in closures.items() if not candidates.isdisjoint(objects)
     )
-)
+
+
+@functools.lru_cache(maxsize=1)
+def _shipping_header_consumers() -> dict[str, frozenset[str]]:
+    """Attribute checked-in headers through the shipping source include graph.
+
+    Ambiguous include names are deliberately resolved to every matching header,
+    which can cause an extra rebuild but cannot omit a real consumer.
+    """
+
+    source_root = ROOT / "src"
+    files = sorted(source_root.rglob("*.c")) + sorted(source_root.rglob("*.h"))
+    relative = {path: path.relative_to(source_root).as_posix() for path in files}
+    aliases: dict[str, set[str]] = {}
+    for path, rel in relative.items():
+        if path.suffix != ".h":
+            continue
+        aliases.setdefault(rel, set()).add(rel)
+        aliases.setdefault(path.name, set()).add(rel)
+        if "/include/" in rel:
+            aliases.setdefault(rel.split("/include/", 1)[1], set()).add(rel)
+
+    include_re = re.compile(r'^\s*#\s*include\s*[<"]([^">]+)[">]', re.MULTILINE)
+    edges: dict[str, set[str]] = {}
+    for path, rel in relative.items():
+        try:
+            names = include_re.findall(path.read_text(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+        resolved: set[str] = set()
+        for name in names:
+            local = (path.parent / name).resolve()
+            try:
+                if local.is_file() and local.is_relative_to(source_root):
+                    resolved.add(local.relative_to(source_root).as_posix())
+            except OSError:
+                pass
+            resolved.update(aliases.get(name, ()))
+        edges[rel] = resolved
+
+    consumers: dict[str, set[str]] = {}
+    for path, rel in relative.items():
+        if path.suffix != ".c":
+            continue
+        images = _c_source_consumers(f"src/{rel}")
+        if not images:
+            continue
+        seen: set[str] = set()
+        pending = list(edges.get(rel, ()))
+        while pending:
+            header = pending.pop()
+            if header in seen:
+                continue
+            seen.add(header)
+            pending.extend(edges.get(header, ()))
+        for header in seen:
+            consumers.setdefault(f"src/{header}", set()).update(images)
+    return {path: frozenset(images) for path, images in consumers.items()}
+
+
+def _header_consumers(path: str) -> frozenset[str]:
+    consumers = _shipping_header_consumers()
+    if path in consumers:
+        return consumers[path]
+    # A present header with no include edge is not an image input. A deleted or
+    # otherwise unresolved header fails closed because its former edges are gone.
+    return frozenset() if (ROOT / path).is_file() else ALL
 
 # Files that define publication, not image bytes.  Keeping these out of every image
 # is important: fixing this planner must not itself trigger six unrelated rebuilds.
@@ -148,25 +280,23 @@ def consumers(path: str) -> frozenset[str]:
             out |= CONTROL
         return out
 
+    if path.endswith(".c") and path.startswith("src/"):
+        return _c_source_consumers(path)
+    if path.endswith(".h") and path.startswith("src/"):
+        return _header_consumers(path)
     if path.startswith("src/modules/kb_client/"):
-        # Makefile's KB_CLIENT_OBJS are linked only into aimee-server.  A regression
-        # test enforces that this directory never enters an aimee-kb target unnoticed.
+        # Non-C files in the thin KB client are server-owned. C ownership comes
+        # from the expanded shipping link graph above.
         return SERVER
-    if path in KB_SHARED_SERVER_C:
-        return SERVER | KB
     if path.startswith("src/server/"):
-        # C implementations under server/ are server-owned except for the exact
-        # KB leaf closure above.  Headers remain conservative because a shared
-        # leaf can include them transitively without appearing as a link object.
-        return SERVER | KB if path.endswith(".h") else SERVER
+        return SERVER
     if path == "src/gen_openapi_server.py":
         return SERVER
     if path == "src/gen_openapi.py":
         return KB
     if path.startswith("src/"):
-        # The C make graph has broad shared closures.  Until a narrower ownership
-        # boundary is mechanically proven, source outside the two exclusions above
-        # invalidates every C image.  This is conservative, not a guessed omission.
+        # Header and generated-input dependencies are not fully represented by
+        # link objects, so non-C source inputs remain conservative.
         return SERVER | KB | AUTHORITY
 
     if path in KB_CONTAINER_FILES:

--- a/scripts/publish_testing_plan.py
+++ b/scripts/publish_testing_plan.py
@@ -44,6 +44,20 @@ CONTROL = frozenset(("aimee-control-web",))
 KB = frozenset(("aimee-kb", "aimee-kb-a25m", "aimee-kb-nomic"))
 AUTHORITY = frozenset(("aimee-authority-bootstrap",))
 
+# The KB link target deliberately reuses these leaf implementations from the
+# server directory.  scripts/tests/test_publish_testing_plan.py expands the real
+# Make graph and requires this declaration to match it exactly, so a new KB
+# consumer cannot silently inherit server-only classification.
+KB_SHARED_SERVER_C = frozenset(
+    (
+        "src/server/embedder_probe.c",
+        "src/server/failover.c",
+        "src/server/http_retry.c",
+        "src/server/oauth_pkce.c",
+        "src/server/osv_check.c",
+    )
+)
+
 # Files that define publication, not image bytes.  Keeping these out of every image
 # is important: fixing this planner must not itself trigger six unrelated rebuilds.
 PUBLISH_TOOLING = frozenset(
@@ -117,6 +131,15 @@ def consumers(path: str) -> frozenset[str]:
     if path.startswith("config/"):
         return SERVER
 
+    if path == "api/openapi-server-v1.yaml":
+        return SERVER
+    if path == "api/openapi-v1.yaml":
+        return KB
+    if path.startswith("api/"):
+        # Generated SDKs and API documentation are publication artifacts, not
+        # inputs to any runtime image.
+        return frozenset()
+
     if path.startswith("server-go/"):
         out = SERVER | KB  # both images build the module multicall runtime
         if path in ("server-go/go.mod", "server-go/go.sum") or path.startswith(
@@ -129,6 +152,17 @@ def consumers(path: str) -> frozenset[str]:
         # Makefile's KB_CLIENT_OBJS are linked only into aimee-server.  A regression
         # test enforces that this directory never enters an aimee-kb target unnoticed.
         return SERVER
+    if path in KB_SHARED_SERVER_C:
+        return SERVER | KB
+    if path.startswith("src/server/"):
+        # C implementations under server/ are server-owned except for the exact
+        # KB leaf closure above.  Headers remain conservative because a shared
+        # leaf can include them transitively without appearing as a link object.
+        return SERVER | KB if path.endswith(".h") else SERVER
+    if path == "src/gen_openapi_server.py":
+        return SERVER
+    if path == "src/gen_openapi.py":
+        return KB
     if path.startswith("src/"):
         # The C make graph has broad shared closures.  Until a narrower ownership
         # boundary is mechanically proven, source outside the two exclusions above

--- a/scripts/tests/test_publish_testing_plan.py
+++ b/scripts/tests/test_publish_testing_plan.py
@@ -72,9 +72,10 @@ def main() -> None:
     )
     failures += expect(
         ["src/kb/kb_service.c"],
-        set(planner.SERVER | planner.KB | planner.AUTHORITY),
-        "shared C source is conservative",
+        kb,
+        "KB runtime C source",
     )
+    failures += expect(["src/cli_argspec.c"], set(), "thin-client-only C source")
     failures += expect(
         [
             "api/openapi-server-v1.yaml",
@@ -90,9 +91,19 @@ def main() -> None:
         "server leaf linked into KB",
     )
     failures += expect(
-        ["src/server/server_state.h"],
+        ["src/modules/memory/memory_core_search_c.c"],
         set(planner.SERVER | planner.KB),
-        "server header remains conservative",
+        "shared server and KB C source",
+    )
+    failures += expect(
+        ["src/kb/kb_mgmt_token_roots_provision_main.c"],
+        set(planner.AUTHORITY),
+        "authority-only C source",
+    )
+    failures += expect(
+        ["src/headers/server_skill.h"],
+        set(planner.SERVER),
+        "server-only header include closure",
     )
     failures += expect(
         ["api/openapi-v1.yaml", "src/gen_openapi.py"],
@@ -154,10 +165,8 @@ def main() -> None:
     else:
         print("  ok    KB_CLIENT_OBJS remains server-owned")
 
-    # Expand the actual shipping KB targets and compare every object linked from
-    # src/server/.  This is the mechanical ownership guard for the narrow
-    # server-source rule above; adding or removing a shared leaf requires the
-    # publication contract to move in the same commit.
+    # Independently expand the actual shipping KB targets and ensure every direct
+    # server leaf is classified as a KB consumer by the transitive graph.
     make_db = subprocess.run(
         ["make", "-C", str(ROOT / "src"), "-pnRrq"],
         check=False,
@@ -174,15 +183,17 @@ def main() -> None:
         f"src/server/{name}.c"
         for name in re.findall(r"build/obj/server/([A-Za-z0-9_./-]+)\.o", kb_target_lines)
     }
-    if linked_server_sources != set(planner.KB_SHARED_SERVER_C):
+    misclassified = sorted(
+        path for path in linked_server_sources if not planner.KB.issubset(planner.consumers(path))
+    )
+    if misclassified:
         print(
-            "  FAIL  KB-linked server sources drifted: "
-            f"actual={sorted(linked_server_sources)} "
-            f"declared={sorted(planner.KB_SHARED_SERVER_C)}"
+            "  FAIL  KB-linked server sources are not classified for KB: "
+            f"{misclassified}"
         )
         failures += 1
     else:
-        print("  ok    KB-linked server sources match the expanded Make graph")
+        print("  ok    KB-linked server sources are classified from the Make graph")
 
     # If a Dockerfile starts copying another container file, the contract must be
     # updated in the same change.  This prevents selective publishing from drifting.

--- a/scripts/tests/test_publish_testing_plan.py
+++ b/scripts/tests/test_publish_testing_plan.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import re
+import subprocess
 import sys
 
 
@@ -75,6 +76,30 @@ def main() -> None:
         "shared C source is conservative",
     )
     failures += expect(
+        [
+            "api/openapi-server-v1.yaml",
+            "src/server/server_state.c",
+            "src/tests/test_integration.sh",
+        ],
+        set(planner.SERVER),
+        "#2892 server and server OpenAPI change",
+    )
+    failures += expect(
+        ["src/server/oauth_pkce.c"],
+        set(planner.SERVER | planner.KB),
+        "server leaf linked into KB",
+    )
+    failures += expect(
+        ["src/server/server_state.h"],
+        set(planner.SERVER | planner.KB),
+        "server header remains conservative",
+    )
+    failures += expect(
+        ["api/openapi-v1.yaml", "src/gen_openapi.py"],
+        kb,
+        "KB OpenAPI inputs",
+    )
+    failures += expect(
         ["frontend/src/App.tsx"],
         set(planner.SERVER | planner.CONTROL),
         "shared browser frontend",
@@ -128,6 +153,36 @@ def main() -> None:
         failures += 1
     else:
         print("  ok    KB_CLIENT_OBJS remains server-owned")
+
+    # Expand the actual shipping KB targets and compare every object linked from
+    # src/server/.  This is the mechanical ownership guard for the narrow
+    # server-source rule above; adding or removing a shared leaf requires the
+    # publication contract to move in the same commit.
+    make_db = subprocess.run(
+        ["make", "-C", str(ROOT / "src"), "-pnRrq"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).stdout
+    kb_target_lines = "\n".join(
+        line
+        for line in make_db.splitlines()
+        if line.startswith("../aimee-kb:") or line.startswith("../aimee-kb-worm:")
+    )
+    linked_server_sources = {
+        f"src/server/{name}.c"
+        for name in re.findall(r"build/obj/server/([A-Za-z0-9_./-]+)\.o", kb_target_lines)
+    }
+    if linked_server_sources != set(planner.KB_SHARED_SERVER_C):
+        print(
+            "  FAIL  KB-linked server sources drifted: "
+            f"actual={sorted(linked_server_sources)} "
+            f"declared={sorted(planner.KB_SHARED_SERVER_C)}"
+        )
+        failures += 1
+    else:
+        print("  ok    KB-linked server sources match the expanded Make graph")
 
     # If a Dockerfile starts copying another container file, the contract must be
     # updated in the same change.  This prevents selective publishing from drifting.

--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -34,11 +34,15 @@ int kb_http_search_project_scope(const char *body, char *project, size_t project
       return kbhs_error(out_buf, out_cap, 400, "invalid json");
    const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
-   if (js && !cJSON_IsString(js))
+   const char *scope = "current";
+   if (js)
    {
-      cJSON_Delete(root);
-      return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
+      if (!cJSON_IsString(js))
+      {
+         cJSON_Delete(root);
+         return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
+      }
+      scope = js->valuestring;
    }
    if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
    {

--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -34,15 +34,11 @@ int kb_http_search_project_scope(const char *body, char *project, size_t project
       return kbhs_error(out_buf, out_cap, 400, "invalid json");
    const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = "current";
-   if (js)
+   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
+   if (js && !cJSON_IsString(js))
    {
-      if (!cJSON_IsString(js))
-      {
-         cJSON_Delete(root);
-         return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
-      }
-      scope = js->valuestring;
+      cJSON_Delete(root);
+      return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
    }
    if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
    {


### PR DESCRIPTION
## Summary

- derive C-source image ownership from the transitive Make link graph
- derive checked-in header ownership from shipping sources and their include closure
- keep unknown and unresolved inputs fail-closed while reusing images that do not consume a change
- retain explicit Dockerfile/container and API ownership contracts

## Release incidents

The `testing` publication for `c4fb95f` changed only server-owned inputs but rebuilt all six images, including Bekko and Nomic. More directly, `f3699ab` changed only `src/cli_argspec.c` plus its unit test; that C source is thin-client-only, yet the old planner rebuilt server, authority, weightless KB, Bekko, and Nomic.

The graph-derived planner classifies that exact `f3699ab` change as no runtime-image rebuilds. It classifies the live fixes precisely as well: PR #2906 rebuilds only the three KB variants, while PR #2907 rebuilds only `aimee-server`.

## Validation

- `python3 scripts/tests/test_publish_testing_plan.py`
- `python3 -m py_compile scripts/publish_testing_plan.py scripts/tests/test_publish_testing_plan.py`
- `git diff --check`
- replayed the `7774926..f3699ab` publication diff: all six runtime images reuse
- replayed PR #2906: KB variants only
- replayed PR #2907: server only
- independent expanded-Make check confirms every direct KB-linked `src/server/*.c` leaf is classified for KB