### PR TITLE
docs: diagram verification harness and event bus

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,16 +10,38 @@ module events through one bounded bus.
 flowchart LR
     T[AI tool] -->|hooks / MCP / ACP| C[aimee thin client]
     B[Browser] --> W[aimee-runtime-web]
-    C -->|local UDS or authenticated /v1| S[aimee-server]
+
+    subgraph RUNTIME[Server container]
+        S[aimee-server resource plane]
+        F[aimee-wfe workflow harness]
+        SB[server event-bus host]
+        SM[supervised process modules]
+        M[aimee store module]
+        PG[postgres module]
+
+        S <--> SB
+        F -->|typed DB1 calls| SB
+        SB <--> SM
+        SB <--> M
+        M --> PG
+    end
+
+    subgraph KNOWLEDGE[KB container]
+        K[aimee-kb resource plane]
+        KB[kb event-bus host]
+        KM[supervised process modules]
+        K <--> KB
+        KB <--> KM
+    end
+
+    C -->|local UDS or authenticated /v1| S
     W -->|authenticated /v1| S
-    W -->|workflow API| F[aimee-wfe]
+    W -->|workflow API| F
     F -->|typed resource calls| S
-    S -->|typed /v1| K[aimee-kb, one-KB profile]
+    S -->|typed /v1| K
     S -->|provider API| P[model providers]
     K -->|local sidecar or remote synthesis endpoint| X[synthesis model]
-    S -->|module bus| M[aimee store module]
-    F -->|module bus| M
-    M -->|postgres module| D1[(DB1 PostgreSQL)]
+    PG --> D1[(DB1 PostgreSQL)]
     K --> D2[(DB2 PostgreSQL + pgvector)]
 ```
 
@@ -102,12 +124,19 @@ module](proposals/pending/module-egress-single-point.md).
 
 ```mermaid
 flowchart LR
-    P[producer] --> O[private outbound ring]
+    P[producer or module bridge] --> O[private outbound ring]
     O --> H[bus host]
     H --> I[private inbound ring]
     I --> C[consumer]
-    H --> A[ordered audit / capture tap]
+    H --> T[ordered full-stream tap]
     H <--> R[shared payload arena]
+    T --> CAP[diagnostic capture]
+    T --> OBS[authorized observability drain]
+    P -. declared ledger metadata event .-> O
+    H --> DS[durability sink consumer]
+    DS --> WORM[(daemon WORM ledger)]
+    H -. overflow / producer-reap facts .-> WORM
+    CAP -. gap / prune facts .-> WORM
 ```
 
 Each daemon creates one host. Admitted clients receive a read-only control region, their own queue
@@ -124,9 +153,11 @@ The current load-bearing consumer is observability:
 - MCP and tool-call activity;
 - tool completion outcomes.
 
-The host tap writes its own ordered observability stream. WORM evidence uses a
-separate producer/outbox path and does not run on, call, or depend on the tap;
-this makes compromise of either side independently detectable.
+The host tap writes its own ordered diagnostic stream. Ledger-classified module
+calls emit bounded intent/reply metadata through the durable emitter, while
+capture gaps, pruning, overflow, and producer reap use direct rare-event sinks.
+Those WORM paths do not depend on capture being healthy. Capture can therefore
+remain prunable without making an absent interval look idle.
 
 Small events are inline. Large events use generation-checked arena leases. Backpressure is bounded;
 a producer blocks or receives `would_block`, and shed delivery is represented by an overflow event.

--- a/docs/EVENT_BUS.md
+++ b/docs/EVENT_BUS.md
@@ -12,13 +12,46 @@ implementation details.
 Before the bus, every new module needed its own queue, callback, logging path, and shutdown rules.
 Completeness depended on finding every call site.
 
-The bus gives each daemon one host and one full-stream tap:
+The bus gives each daemon one host, one private queue pair per client, and one
+full-stream tap. The data plane and evidence plane are related but not the same
+record:
 
-```text
-producer -> private outbound ring -> host -> private inbound ring -> consumer
-                                  |
-                                  +-> ordered capture and audit tap
+```mermaid
+flowchart LR
+    subgraph CLIENT_A[Producer client]
+        P[producer / request bridge]
+        O[private outbound ring]
+        P --> O
+    end
+
+    subgraph CORE[Daemon-owned core]
+        H[bus host<br/>admit, sequence, correlate, route]
+        A[shared payload arena]
+        T[ordered full-stream tap]
+        H <--> A
+        H --> T
+    end
+
+    subgraph CLIENT_B[Authorized consumer]
+        I[private inbound ring]
+        C[notification consumer<br/>or module handler]
+        I --> C
+    end
+
+    O --> H --> I
+    T --> CAP[prunable capture session]
+    T --> OBS[observability drain]
+    P -. ledger-classified metadata event .-> O
+    H --> DS[durability sink consumer]
+    DS --> WORM[(daemon WORM ledger)]
+    H -. overflow and producer-reap facts .-> WORM
+    CAP -. gap and prune facts .-> WORM
 ```
+
+The tap materializes the accepted stream for diagnostics. It is not the WORM
+writer. Ledger-classified module calls and rare loss/capture-state facts reach
+the durable sink through bounded paths that remain available when capture is
+missing or broken.
 
 That buys us:
 
@@ -32,14 +65,15 @@ That buys us:
 
 The last item is an extension surface, not a claim that every subsystem has moved already.
 
-Eighteen production C-to-Go process batches now cover every supervised process:
-`memory`, `learning`,
-`routing`, `delegates`, `tools`, `workspace`, `git`, `skills`,
-`response-composition`, `execution-policy`, `governance`, `workflows`, `roundtable`, `kb-synthesis`,
-`runtime-web`, `control-web`, and `benchmarks`.
+Twenty-three process identities now run in the Go multicall executable:
+`config`, `memory`, `learning`, `routing`, `delegates`, `tools`, `workspace`,
+`git`, `skills`, `response-composition`, `execution-policy`, `governance`,
+`workflows`, `roundtable`, `kb-synthesis`, `runtime-web`, `control-web`,
+`benchmarks`, `sandbox`, `economizer`, `postgres`, `aimee`, and `egress`.
 Each keeps its existing event kind and AMOD body contract, but the supervisor now
 starts an authenticated Go process for that identity. C adapters serve as parity
-fixtures.
+fixtures. DB2 remains the separately supervised C process in the current catalog;
+it uses the same admitted bus contract rather than an in-process exception.
 
 A moved stage is a bounded decision, and the storage-heavy or daemon
 orchestration code around it stays where it was. The memory rerank, the
@@ -129,6 +163,34 @@ kind. Wire version 3 permits a correlated request or reply to span ordered inlin
 message. The host keeps the route pending until the request is complete, and cancellation retires
 any partial request or reply.
 
+```mermaid
+sequenceDiagram
+    participant Caller as C caller or Go client
+    participant CallerOut as Caller outbound ring
+    participant Host as Bus host
+    participant ModuleIn as Module inbound ring
+    participant Module as Supervised module handler
+    participant ModuleOut as Module outbound ring
+    participant CallerIn as Caller inbound ring
+    participant Tap as Ordered tap
+
+    Caller->>CallerOut: request(kind, stage, correlation, deadline)
+    CallerOut->>Host: one frame or BUS_F_MORE fragments
+    Host->>Tap: accepted frames in host sequence
+    Host->>ModuleIn: route only after complete request
+    ModuleIn->>Module: bounded AMOD request body
+    Module->>ModuleOut: correlated reply or typed failure
+    ModuleOut->>Host: one frame or BUS_F_MORE fragments
+    Host->>Tap: accepted reply frames
+    Host->>CallerIn: reply only to original requester
+    CallerIn-->>Caller: success, timeout, cancellation, or capability error
+```
+
+The sequence diagram shows transport completion, not business durability.
+`publish` means the outbound ring accepted a frame; a synchronous module call
+completes only when the correlated reply is reassembled and validated. Declared
+ledger metadata is emitted beside this path without retaining raw bodies.
+
 Each client has its own queue pair. One slow consumer does not create an unbounded host queue.
 Kinds declare whether they block or may shed under pressure. Sheds become typed overflow records in
 the ordered tap and rare durable `bus.overflow` rows. Reaping a producer with blocked work similarly
@@ -200,6 +262,18 @@ A module process is not admitted because it connected. The host reads a policy d
 `<config dir>/modules.d/<daemon>` and admits only principals granted there, so a module started
 against a daemon with no matching grant is refused with `bus: attach denied` and never serves a
 stage. Each grant is one `*.grant` file (any other suffix is ignored) of `key=value` lines:
+
+```mermaid
+flowchart LR
+    M[module process] -->|SOCK_SEQPACKET attach| H[daemon bus host]
+    G[grant file] --> V[admission checks]
+    E[SO_PEERCRED and /proc executable] --> V
+    H --> V
+    V -->|deny| D[no mappings<br/>no stage service]
+    V -->|admit| F[pass control, queue-pair,<br/>and arena descriptors]
+    F --> R[read-only control region<br/>private rings + shared arena]
+    R --> HB[heartbeats, deadlines,<br/>cancellation, and reap]
+```
 
 | Key | Meaning |
 | --- | --- |

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -28,14 +28,40 @@ confidence, class, time, and review state.
 
 ## Ingest and curation
 
-```text
-content -> validate -> store source -> chunk/index -> extract candidates
-        -> resolve/link -> contradict/dedupe -> review/promote -> maintain/decay
+```mermaid
+flowchart LR
+    U[uploaded bytes] --> V[request, scope, size,<br/>and content-hash validation]
+    V --> P{PDF?}
+    P -->|yes| PDF[structured PDF ingest]
+    P -->|no| E{AIMEE_KB_DOCUMENT_INSPECTION enabled?}
+    E -->|no| N[normalize / convert]
+    E -->|yes| I[bounded in-process inspection<br/>HTML, DOCX, PPTX, XLSX, or plain]
+    I --> D{disposition}
+    D -->|clean| N
+    D -->|review, reject, invalid,<br/>unsupported, or resource limit| STOP[stop before conversion<br/>and before any DB2 row]
+    PDF --> S[(store source and<br/>lexical evidence in DB2)]
+    N --> S
+    S --> C[chunk and index]
+    C --> X[extract candidates]
+    X --> R[resolve and link]
+    R --> Q[contradict and dedupe]
+    Q --> G[review and promote]
+    G --> M[maintain and decay]
 ```
 
 The fast path commits usable source and lexical evidence. Background workers add embeddings, typed
 artifacts, links, contradiction checks, and synthesis. Workers claim durable DB2 queue rows, so a
 restart or second KB process does not duplicate the same unit.
+
+When structural inspection is enabled, it runs on raw non-PDF bytes before a
+converter can erase hidden channels. The inspector bounds package members,
+expanded bytes, compression ratio, markup nodes, and extracted text; compares
+ZIP central and local metadata; and detects hidden text, comments, notes,
+metadata, active content, external relationships, nested archives, and traversal.
+Hidden lexical content also crosses the existing integrity gate. A non-clean
+disposition returns an explicit HTTP error and digest-bearing diagnostic without
+creating a staged document row. The flag is off by default while rollout evidence
+is collected.
 
 Curator stages are independently enabled and split between model-bound and index-bound lanes. A
 missing optional model degrades that stage; it does not relabel unprocessed content as curated.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -54,6 +54,64 @@ The canvas renders `next` in gray, `on_pass` in green, `on_fail` in red, and inp
 lighter dotted line. Dragging a card only changes the current canvas layout. Coordinates are not part
 of the definition, so the editor lays out the graph again when it is reopened.
 
+## Execution and verification harness
+
+The workflow harness owns orchestration, not model credentials or module policy.
+It persists the pinned definition and transition state, dispatches work through
+the server resource plane, confines mutations to a worktree, and refuses to
+advance an implementation node until its configured verification path returns.
+
+```mermaid
+flowchart TB
+    START[trigger or API admission]
+
+    subgraph WFE[aimee-wfe workflow harness]
+        ADMIT[validate and pin input,<br/>definition, and block catalog]
+        SCHED[durable scheduler]
+        RUN[NativeRunner implementation step]
+        WT[isolated branch and worktree]
+        VERIFY[repository verifier]
+        SELECT[admitted-regression selector<br/>exact-path-v1]
+        MANIFEST[revision + diff digest +<br/>selected/excluded reasons]
+        TEMP[temporary suites containing<br/>ledger-matching task bytes only]
+        EVAL[existing eval runner]
+        RESULT[typed step result<br/>advance, changes, pending, or error]
+    end
+
+    subgraph SERVER[aimee-server daemon]
+        RESOURCE[typed agent / roundtable<br/>resource operations]
+        BUS[server event-bus host]
+        MODS[supervised policy and<br/>resource modules]
+        STORE[aimee store module]
+    end
+
+    DB1[(DB1 workflow, lifecycle,<br/>and eval-candidate rows)]
+
+    START --> ADMIT -->|persist before dispatch| BUS
+    BUS <--> STORE --> DB1
+    ADMIT --> SCHED --> RUN
+    RUN --> WT
+    RUN -->|delegate and review work| RESOURCE <--> BUS
+    BUS <--> MODS
+    WT --> VERIFY --> SELECT
+    SELECT -->|read admitted candidates| BUS
+    SELECT --> MANIFEST
+    MANIFEST -->|observe: attach evidence only| RESULT
+    MANIFEST -->|enforce: complete selection required| TEMP --> EVAL --> RESULT
+    RUN --> RESULT
+    RESULT -->|atomic lifecycle transition| BUS
+```
+
+The standard repository verifier runs first. `admitted_regressions: observe`
+then records a deterministic selection manifest without changing routing. In
+`enforce`, a truncated candidate scan, stale admitted bytes, invalid task, runner
+failure, or failed selected suite returns requested changes instead of advancing.
+No unselected task is copied into the temporary suite.
+
+The event bus in this diagram carries typed state and resource calls. Repository
+diffs, worktree files, and evaluation case bodies remain in the harness-owned
+filesystem boundary; they are not published as bus event bodies.
+
 ## Build a graph in the browser
 
 1. **Open the graph.** Open a saved workflow or select **+ New**.
@@ -148,6 +206,40 @@ When a review or roundtable keeps requesting changes, exhaustion parks the run a
 exhausted. A runner error, terminal block failure, or pending external condition can park or reject
 without following `on_fail`, so `on_fail` is not a general exception handler. Run-level spend, turn,
 wall-clock, concurrency, and resume limits remain additional backstops.
+
+Blocker-set comparison is versioned and deterministic. Finding IDs are excluded;
+the gate, persona, severity, location, and summary are normalized, hashed, sorted,
+and deduplicated. This lets the lifecycle distinguish strict progress from a
+renumbered or reordered review.
+
+```mermaid
+flowchart TD
+    F[requested-change feedback] --> N[normalize blocker fingerprints<br/>plus artifact and feedback hashes]
+    N --> P[load prior convergence row]
+    P --> B{both blocker sets valid?}
+    B -->|no| L[legacy exact artifact +<br/>feedback hash comparison]
+    B -->|yes| C[classify strict subset, equal,<br/>superset, or churn]
+    C --> M{mode is enforce?}
+    M -->|no: observe| L
+    M -->|yes| S{strict subset?}
+    S -->|yes: progress| R[reset consecutive repeats]
+    S -->|no| I[increment consecutive repeats]
+    L --> H{exact hashes repeated?}
+    H -->|yes| I
+    H -->|no| R
+    R --> W[persist current hashes, set,<br/>relationship, and counters]
+    I --> W
+    W --> Q{repeat or round limit reached?}
+    Q -->|repeat limit| NP[park: convergence_no_progress]
+    Q -->|round limit| CL[park: convergence_limit]
+    Q -->|neither| LOOP[follow requested-change edge]
+```
+
+The shipped workflows currently use `blocker_convergence: observe`: relationships
+are recorded for calibration while the established exact-hash rule still decides
+the repeat counter. Enforcement can be enabled per node after that evidence shows
+the normalized set is stable enough; if either round lacks a structured set, the
+legacy rule remains authoritative.
 
 ## Compose a graph from child workflows
 

--- a/docs/architecture/turn-integrity.md
+++ b/docs/architecture/turn-integrity.md
@@ -9,6 +9,25 @@ The server installs a bridge from the observation hook to the durable event bus.
 Other binaries can use the same state machine without linking server or audit
 dependencies.
 
+```mermaid
+flowchart LR
+    CALLER[turn owner] --> CORE[protocol-neutral<br/>turn-integrity state machine]
+    CORE --> BIND[bind identity, configuration,<br/>toolset, route, policy, and context]
+    BIND --> TRANS[monotonic typed transitions]
+    TRANS --> HOOK[optional bounded observation hook]
+    HOOK -->|server build only| BRIDGE[turn-integrity audit bridge]
+    BRIDGE --> BUS[durability event on<br/>server event bus]
+    BUS --> CAP[ordered diagnostic capture]
+    BUS --> SINK[(configured daemon WORM sink)]
+    CORE --> RESULT[caller-owned control result]
+    BUS -. never authorizes .-> RESULT
+```
+
+The callback exports bounded transition metadata, not prompts, arguments, tool
+results, or model responses. Its bus and WORM paths make the transition
+observable; they do not participate in the authorization decision or permit a
+terminal state to reopen.
+
 ## Invariants
 
 - A turn identity exists before work is dispatched.

--- a/docs/core/event-bus.md
+++ b/docs/core/event-bus.md
@@ -8,6 +8,31 @@
 the modules in its own container. The thin client does not link it, and the bus
 never carries server-to-KB or thinclient-to-server traffic.
 
+```mermaid
+flowchart LR
+    TC[thin client] -->|UDS or authenticated /v1| SR[server resource plane]
+
+    subgraph SERVER[aimee-server daemon]
+        SR <--> SB[server bus host]
+        SB <--> S1[private queue pair<br/>module A]
+        SB <--> S2[private queue pair<br/>module B]
+        SB --> ST[server full-stream tap]
+    end
+
+    SR -->|authenticated typed /v1| KR
+
+    subgraph KB[aimee-kb daemon]
+        KR[KB resource plane] <--> KBH[KB bus host]
+        KBH <--> K1[private queue pair<br/>module A]
+        KBH <--> K2[private queue pair<br/>module B]
+        KBH --> KT[KB full-stream tap]
+    end
+```
+
+The two hosts use the same library and wire contract but share no rings, arena,
+sequence, or tap. Crossing the daemon boundary returns to authenticated network
+transport through the resource planes.
+
 ## Owns
 
 - wire frame and version negotiation;
@@ -57,15 +82,17 @@ policies at `<config>/modules.d/<daemon>`; the environment can override those
 with `AIMEE_MODULE_BUS_SOCKET` and `AIMEE_MODULE_POLICY_DIR`.
 
 `src/modules/process-contracts.json` is also the implementation-language switch
-for supervised processes. Across sixteen migrated batches, every process identity
-moved to the Go multicall executable in `server-go/cmd/aimee-module`: `memory`,
-`learning`, `routing`, `delegates`, `tools`, `workspace`, `git`, `skills`,
-`response-composition`, `governance`, `workflows`, `roundtable`, `kb-synthesis`,
-`runtime-web`, `control-web`, and `benchmarks`. Its basename selects an isolated
-identity and one module package under `server-go/modules`. The runtime bundle emits no C process
-source for those entries. Their C `module_adapter.c` files serve only as
-wire-parity fixtures while the deeper module-owned C surfaces are migrated in
-later batches.
+for supervised processes. Twenty-three identities run in the Go multicall
+executable in `server-go/cmd/aimee-module`: `config`, `memory`, `learning`,
+`routing`, `delegates`, `tools`, `workspace`, `git`, `skills`,
+`response-composition`, `execution-policy`, `governance`, `workflows`,
+`roundtable`, `kb-synthesis`, `runtime-web`, `control-web`, `benchmarks`,
+`sandbox`, `economizer`, `postgres`, `aimee`, and `egress`. Its basename selects
+an isolated identity and one module package under `server-go/modules`. The runtime
+bundle emits no C process source for those entries. Their C `module_adapter.c`
+files serve only as wire-parity fixtures while the deeper module-owned C surfaces
+are migrated in later batches. DB2 remains the separately supervised C process
+in the current catalog and crosses the same bus admission and wire boundary.
 
 Each migrated process owns one bounded decision and nothing around it:
 

--- a/docs/modules/skills.md
+++ b/docs/modules/skills.md
@@ -77,6 +77,37 @@ and trial-manifest digests. It is deliberately a pilot: it attributes tokens, la
 provider cost, fails inconclusive on route drift, unknown cost, denied effects, runner failure, or
 budget excess, and does not feed promotion automatically.
 
+```mermaid
+flowchart TB
+    SKILL[locally resolved and approved SKILL.md] --> HASH[skill digest]
+    CASES[operator-held cases<br/>.aimee/skill-evals/name/*.json] --> SAFE[path containment, regular-file,<br/>count, and size checks]
+    SAFE --> CASEHASH[ordered case-set digest]
+    POLICY[fixed read-only, tool-free policy] --> POLICYHASH[policy digest]
+    ROUTE[frozen agent route, repeats,<br/>token cap, delta, and cost budgets] --> MANIFEST[trial manifest digest]
+    HASH --> MANIFEST
+    CASEHASH --> MANIFEST
+    POLICYHASH --> MANIFEST
+    MANIFEST --> ORDER[balanced AB / BA ordering<br/>for every case and repeat]
+    ORDER --> BASE[baseline: fixed policy only]
+    ORDER --> TREAT[treatment: fixed policy + skill]
+    BASE --> RUN[one tool-free agent_generate route]
+    TREAT --> RUN
+    RUN --> GUARD{route stable, known cost,<br/>no tool/effect attempt,<br/>within token and cost budgets?}
+    GUARD -->|no| INC[inconclusive / fail closed]
+    GUARD -->|yes| GRADE[deterministic compliance<br/>and violation checks]
+    GRADE --> AGG[paired improvements, regressions,<br/>usage, latency, cost, and delta]
+    AGG --> PASS{baseline violates every pair,<br/>treatment complies every pair,<br/>no regression, minimum delta met?}
+    PASS -->|yes| REPORT[pass report with all digests]
+    PASS -->|no| FAIL[failed trial]
+    REPORT -. operator review only .-> NOPROMO[no automatic promotion]
+```
+
+The baseline is intentionally required to exhibit the targeted violation. A
+case the base route already solves cannot manufacture a skill win, and a skill
+with no measured effect cannot pass. Every run reports enough identity to compare
+only trials with the same skill bytes, case bytes, policy, route, ordering
+contract, and budgets.
+
 ## Data and migrations
 
 Skill bodies, support files, and operator-held executable-eval cases are filesystem data; usage,

--- a/docs/proposals/pending/verification-last-mile-net-assessment.md
+++ b/docs/proposals/pending/verification-last-mile-net-assessment.md
@@ -39,6 +39,38 @@ verdict bus, another memory layer, or fleet-coordination machinery. Aimee alread
 has the governing lifecycle and evidence substrate. Duplicating it would add
 reconciliation failure modes without improving the decision boundary.
 
+### Integration map
+
+Each control terminates in an existing owner. None introduces a parallel
+scheduler, bus, audit history, or memory system.
+
+```mermaid
+flowchart TB
+    subgraph WORKFLOW[Existing workflow and DB1 lifecycle]
+        RF[review feedback] --> BS[normalized blocker set]
+        BS --> CR[compare prior round]
+        CR --> LP[existing loop or park transition]
+
+        CP[changed paths] --> RS[relevant admitted-regression selector]
+        EL[(existing eval-candidate ledger)] --> RS
+        RS --> MF[revision-bound selection manifest]
+        MF --> OE[observe evidence or enforce<br/>through existing eval runner]
+    end
+
+    subgraph KB[Existing KB ingress and DB2]
+        DOC[raw rich-document bytes] --> INS[bounded structural inspection]
+        INS -->|clean| NORM[existing normalizer and ingest]
+        INS -->|non-clean| STOP[stop before persistence]
+        NORM --> DB2[(existing DB2 document lifecycle)]
+    end
+
+    subgraph SKILLS[Existing skills owner]
+        SK[resolved skill + held-out cases] --> AB[paired baseline / treatment trials]
+        AB --> REP[digest- and budget-bound report]
+        REP --> OP[operator review<br/>no automatic promotion]
+    end
+```
+
 ## Net assessment
 
 The transferable value is **real but not foundational**. The useful residue is

--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -34,12 +34,12 @@ int kb_http_search_project_scope(const char *body, char *project, size_t project
       return kbhs_error(out_buf, out_cap, 400, "invalid json");
    const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
    if (js && !cJSON_IsString(js))
    {
       cJSON_Delete(root);
       return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
    }
+   const char *scope = js ? js->valuestring : "current";
    if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
    {
       cJSON_Delete(root);


### PR DESCRIPTION
## Summary

- update the top-level process topology to show the workflow harness, independent server/KB event-bus hosts, supervised process modules, and the DB1 store path
- replace the minimal event-bus sketch with data/evidence-plane, correlated request/reply, module-admission, and per-daemon placement diagrams
- document the workflow execution harness, admitted-regression observe/enforce path, and blocker-set convergence routing
- add rich-document pre-persistence inspection, executable skill A/B trial, and turn-integrity audit-bridge diagrams
- add a compact integration map to the verification last-mile proposal
- reconcile stale process-language counts with the current catalog: 23 Go identities plus supervised C DB2

This follows the implementation merged in #2897. That PR merged while this documentation pass was being validated, so the diagrams are isolated here as one docs-only commit on the resulting `testing` tip.

## Validation

- Mermaid parser accepted all 12 diagrams across the affected documents
- `python3 scripts/check-docs.py`
- `python3 scripts/check-proposal-links.py`
- `python3 scripts/check-proposal-reconcile.py` (exit 0; unrelated report-only warnings remain)
- `make -C src docs-check`
- `git diff --check origin/testing...HEAD`
