### PR TITLE
fix(kb): propagate ranked search backend failures

### DIFF
--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -345,88 +345,6 @@ static int qparam(const char *qs, const char *key, char *out, size_t out_cap)
 
 static int json_body_error(char *out_buf, int out_cap, int status, const char *message);
 
-/* Extract a JSON string field value from body into out. */
-
-/* Resolve POST /v1/search scope before either the facet or ranked branch.
- * Omission is local/current, never all: a verified project credential can
- * supply current; otherwise the caller must provide a stable project id.
- * Cross-project search remains available only as explicit scope=all. */
-static int kb_search_project_scope(const char *body, char *project, size_t project_cap,
-                                   int *all_projects, char *out_buf, int out_cap)
-{
-   project[0] = '\0';
-   *all_projects = 0;
-   cJSON *root = cJSON_Parse(body ? body : "{}");
-   if (!root)
-      return json_body_error(out_buf, out_cap, 400, "invalid json");
-   const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
-   const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
-   if (js && !cJSON_IsString(js))
-   {
-      cJSON_Delete(root);
-      return json_body_error(out_buf, out_cap, 400, "scope must be current or all");
-   }
-   if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
-   {
-      cJSON_Delete(root);
-      snprintf(out_buf, (size_t)out_cap,
-               "{\"error\":{\"type\":\"invalid_scope\",\"message\":\"scope must be current or "
-               "all\"}}");
-      return 400;
-   }
-   if (cJSON_IsString(jp) && jp->valuestring[0])
-   {
-      if (strlen(jp->valuestring) >= project_cap)
-      {
-         cJSON_Delete(root);
-         return json_body_error(out_buf, out_cap, 400, "project id is too long");
-      }
-      snprintf(project, project_cap, "%s", jp->valuestring);
-   }
-
-   const char *verified_kind = NULL;
-   const char *verified_id = NULL;
-   int verified = kb_reqctx_verified_scope(&verified_kind, &verified_id);
-   if (strcmp(scope, "all") == 0)
-   {
-      cJSON_Delete(root);
-      /* A service credential is the managed deployment's data-plane identity:
-       * it spans projects but remains tenant-bounded by the resolved caller
-       * context and is still excluded from administrative routes. */
-      if (verified && strcmp(verified_kind, KB_SCOPE_KIND_SERVICE) != 0)
-      {
-         snprintf(out_buf, (size_t)out_cap,
-                  "{\"error\":{\"type\":\"forbidden\",\"message\":\"a scoped credential "
-                  "cannot search all projects\"}}");
-         return 403;
-      }
-      *all_projects = 1;
-      return 0;
-   }
-
-   if (!project[0] && verified && strcmp(verified_kind, "project") == 0)
-      snprintf(project, project_cap, "%s", verified_id);
-   if (project[0] && verified && strcmp(verified_kind, "project") == 0 &&
-       strcmp(project, verified_id) != 0)
-   {
-      cJSON_Delete(root);
-      snprintf(out_buf, (size_t)out_cap,
-               "{\"error\":{\"type\":\"forbidden\",\"message\":\"project is outside the "
-               "verified credential scope\"}}");
-      return 403;
-   }
-   cJSON_Delete(root);
-   if (project[0])
-      return 0;
-   snprintf(out_buf, (size_t)out_cap,
-            "{\"error\":{\"type\":\"scope_required\",\"message\":\"no active project is "
-            "available; pass project or scope=all explicitly\"}}");
-   return 409;
-}
-
-/* Extract a JSON integer field from body. Returns default_val if not found. */
-
 static int json_body_error(char *out_buf, int out_cap, int status, const char *message)
 {
    snprintf(out_buf, (size_t)out_cap, "{\"error\":\"%s\"}", message);
@@ -1200,8 +1118,8 @@ int kb_http_route_ex_context_impl(const char *method, const char *path, const ch
 
       char project[256] = "";
       int all_projects = 0;
-      int scope_status =
-          kb_search_project_scope(body, project, sizeof(project), &all_projects, out_buf, out_cap);
+      int scope_status = kb_http_search_project_scope(body, project, sizeof(project), &all_projects,
+                                                      out_buf, out_cap);
       if (scope_status)
          return scope_status;
 
@@ -1244,30 +1162,12 @@ int kb_http_route_ex_context_impl(const char *method, const char *path, const ch
          return 503;
       }
 
-      /* The ranked backend returns a JSON error object for dependency and
-       * storage failures. Do not run that object through the hit reshaper: it
-       * has no results array, so doing so turns a failed embedding request into
-       * a misleading HTTP 200 with zero hits. */
-      cJSON *raw_json = cJSON_Parse(raw);
-      const cJSON *raw_error =
-          raw_json ? cJSON_GetObjectItemCaseSensitive(raw_json, "error") : NULL;
-      const cJSON *raw_results =
-          raw_json ? cJSON_GetObjectItemCaseSensitive(raw_json, "results") : NULL;
-      if (cJSON_IsString(raw_error))
+      int backend_status = kb_http_search_validate_backend(raw, out_buf, out_cap);
+      if (backend_status)
       {
-         snprintf(out_buf, (size_t)out_cap, "%s", raw);
-         cJSON_Delete(raw_json);
          free(raw);
-         return 503;
+         return backend_status;
       }
-      if (!cJSON_IsObject(raw_json) || !cJSON_IsArray(raw_results))
-      {
-         cJSON_Delete(raw_json);
-         free(raw);
-         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"invalid search backend response\"}");
-         return 503;
-      }
-      cJSON_Delete(raw_json);
 
       char used_mode[64] = "rrf";
       kb_http_json_str(raw, "fusion_mode", used_mode, sizeof(used_mode));

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1244,6 +1244,31 @@ int kb_http_route_ex_context_impl(const char *method, const char *path, const ch
          return 503;
       }
 
+      /* The ranked backend returns a JSON error object for dependency and
+       * storage failures. Do not run that object through the hit reshaper: it
+       * has no results array, so doing so turns a failed embedding request into
+       * a misleading HTTP 200 with zero hits. */
+      cJSON *raw_json = cJSON_Parse(raw);
+      const cJSON *raw_error =
+          raw_json ? cJSON_GetObjectItemCaseSensitive(raw_json, "error") : NULL;
+      const cJSON *raw_results =
+          raw_json ? cJSON_GetObjectItemCaseSensitive(raw_json, "results") : NULL;
+      if (cJSON_IsString(raw_error))
+      {
+         snprintf(out_buf, (size_t)out_cap, "%s", raw);
+         cJSON_Delete(raw_json);
+         free(raw);
+         return 503;
+      }
+      if (!cJSON_IsObject(raw_json) || !cJSON_IsArray(raw_results))
+      {
+         cJSON_Delete(raw_json);
+         free(raw);
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"invalid search backend response\"}");
+         return 503;
+      }
+      cJSON_Delete(raw_json);
+
       char used_mode[64] = "rrf";
       kb_http_json_str(raw, "fusion_mode", used_mode, sizeof(used_mode));
 

--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -6,6 +6,8 @@
  * built with cJSON so escaping is handled for us. */
 
 #include "kb_http_search.h"
+#include "kb_reqctx.h"
+#include "kb_scope.h"
 #include "modules/db2/c/artifacts.h"
 #include "modules/db2/c/kb_releases.h"
 #include "cJSON.h"
@@ -15,6 +17,103 @@
 #include <string.h>
 
 #define KBHS_MAX_HITS 100
+
+static int kbhs_error(char *out_buf, int out_cap, int status, const char *message)
+{
+   snprintf(out_buf, (size_t)out_cap, "{\"error\":\"%s\"}", message);
+   return status;
+}
+
+int kb_http_search_project_scope(const char *body, char *project, size_t project_cap,
+                                 int *all_projects, char *out_buf, int out_cap)
+{
+   project[0] = '\0';
+   *all_projects = 0;
+   cJSON *root = cJSON_Parse(body ? body : "{}");
+   if (!root)
+      return kbhs_error(out_buf, out_cap, 400, "invalid json");
+   const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
+   const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
+   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
+   if (js && !cJSON_IsString(js))
+   {
+      cJSON_Delete(root);
+      return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
+   }
+   if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
+   {
+      cJSON_Delete(root);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":{\"type\":\"invalid_scope\",\"message\":\"scope must be current or "
+               "all\"}}");
+      return 400;
+   }
+   if (cJSON_IsString(jp) && jp->valuestring[0])
+   {
+      if (strlen(jp->valuestring) >= project_cap)
+      {
+         cJSON_Delete(root);
+         return kbhs_error(out_buf, out_cap, 400, "project id is too long");
+      }
+      snprintf(project, project_cap, "%s", jp->valuestring);
+   }
+
+   const char *verified_kind = NULL;
+   const char *verified_id = NULL;
+   int verified = kb_reqctx_verified_scope(&verified_kind, &verified_id);
+   if (strcmp(scope, "all") == 0)
+   {
+      cJSON_Delete(root);
+      /* A service credential is the managed deployment's data-plane identity:
+       * it spans projects but remains tenant-bounded by the resolved caller
+       * context and is still excluded from administrative routes. */
+      if (verified && strcmp(verified_kind, KB_SCOPE_KIND_SERVICE) != 0)
+      {
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"error\":{\"type\":\"forbidden\",\"message\":\"a scoped credential "
+                  "cannot search all projects\"}}");
+         return 403;
+      }
+      *all_projects = 1;
+      return 0;
+   }
+
+   if (!project[0] && verified && strcmp(verified_kind, "project") == 0)
+      snprintf(project, project_cap, "%s", verified_id);
+   if (project[0] && verified && strcmp(verified_kind, "project") == 0 &&
+       strcmp(project, verified_id) != 0)
+   {
+      cJSON_Delete(root);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":{\"type\":\"forbidden\",\"message\":\"project is outside the "
+               "verified credential scope\"}}");
+      return 403;
+   }
+   cJSON_Delete(root);
+   if (project[0])
+      return 0;
+   snprintf(out_buf, (size_t)out_cap,
+            "{\"error\":{\"type\":\"scope_required\",\"message\":\"no active project is "
+            "available; pass project or scope=all explicitly\"}}");
+   return 409;
+}
+
+int kb_http_search_validate_backend(const char *body, char *out_buf, int out_cap)
+{
+   cJSON *root = cJSON_Parse(body);
+   const cJSON *error = root ? cJSON_GetObjectItemCaseSensitive(root, "error") : NULL;
+   const cJSON *results = root ? cJSON_GetObjectItemCaseSensitive(root, "results") : NULL;
+   int status = 0;
+   if (cJSON_IsString(error))
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", body);
+      status = 503;
+   }
+   else if (!cJSON_IsObject(root) || !cJSON_IsArray(results))
+      status = kbhs_error(out_buf, out_cap, 503, "invalid search backend response");
+   cJSON_Delete(root);
+   return status;
+}
 
 /* Pick a short excerpt from a known narrative field of the payload. */
 static void kbhs_excerpt(const char *payload_json, char *out, size_t out_cap)

--- a/src/kb/http/kb_http_search.h
+++ b/src/kb/http/kb_http_search.h
@@ -2,6 +2,8 @@
 #ifndef DEC_KB_HTTP_SEARCH_H
 #define DEC_KB_HTTP_SEARCH_H 1
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -15,6 +17,16 @@ extern "C"
     * the caller falls through to the default ranked search path. */
    int kb_http_search_facets(const char *body, const char *preferred_project, int all_projects,
                              char *out_buf, int out_cap);
+
+   /* Resolve the caller-bound project scope shared by the facet and ranked
+    * search paths. Returns zero on success or an HTTP status after writing the
+    * error response. */
+   int kb_http_search_project_scope(const char *body, char *project, size_t project_cap,
+                                    int *all_projects, char *out_buf, int out_cap);
+
+   /* Reject dependency/storage errors and malformed ranked-backend envelopes
+    * before the public route reshapes their results. */
+   int kb_http_search_validate_backend(const char *body, char *out_buf, int out_cap);
 
 #ifdef __cplusplus
 }

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -584,6 +584,7 @@ char *kb_service_ingest_status_json(void)
 static int g_test_search_populated = 0;
 static int g_test_search_scoped_all = 0;
 static int g_test_search_error = 0;
+static int g_test_search_malformed = 0;
 static char g_test_search_embedding[256];
 char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, const char *f)
 {
@@ -596,6 +597,8 @@ char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, cons
    if (g_test_search_error)
       src = "{\"error\":\"error: documentation query embedding failed; "
             "server-side embedding configuration is unavailable\"}";
+   else if (g_test_search_malformed)
+      src = "{\"fusion_mode\":\"rrf\"}";
    else if (g_test_search_populated)
       src = "{\"fusion_mode\":\"rrf\",\"results\":[{\"project\":\"proj-alpha\","
             "\"file_path\":\"docs/alpha.md\","
@@ -6917,6 +6920,19 @@ static void test_search_backend_error_is_503(void)
    assert(strstr(buf, "\"hits\"") == NULL);
 }
 
+static void test_search_malformed_backend_response_is_503(void)
+{
+   char buf[1024];
+   g_test_search_malformed = 1;
+   const char *body = "{\"query\":\"foo\",\"project\":\"proj-alpha\"}";
+   int s = kb_http_route_ex("POST", "/v1/search", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_test_search_malformed = 0;
+   assert(s == 503);
+   assert(strstr(buf, "invalid search backend response") != NULL);
+   assert(strstr(buf, "\"hits\"") == NULL);
+}
+
 /* A managed KB normally has no raw embedding_command in aimee.yaml: the
  * wizard supplies SYNTHESIS_ENDPOINT. Search must resolve that deployment default
  * before entering the ranked backend, or it silently queries a 1024-dim corpus
@@ -7497,6 +7513,7 @@ int main(void)
    test_search_ok();
    test_search_scope_all_keeps_active_project_first();
    test_search_backend_error_is_503();
+   test_search_malformed_backend_response_is_503();
    test_search_uses_managed_embedder();
    test_search_hits_tool_contract();
    test_search_503_while_reembed_in_progress();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -583,6 +583,7 @@ char *kb_service_ingest_status_json(void)
  * parses. Default 0 keeps every other test on the empty-results path. */
 static int g_test_search_populated = 0;
 static int g_test_search_scoped_all = 0;
+static int g_test_search_error = 0;
 static char g_test_search_embedding[256];
 char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, const char *f)
 {
@@ -591,11 +592,14 @@ char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, cons
    (void)m;
    (void)f;
    snprintf(g_test_search_embedding, sizeof(g_test_search_embedding), "%s", e ? e : "");
-   const char *src = g_test_search_populated
-                         ? "{\"fusion_mode\":\"rrf\",\"results\":[{\"project\":\"proj-alpha\","
-                           "\"file_path\":\"docs/alpha.md\","
-                           "\"content\":\"alpha excerpt body\",\"score\":0.875,\"doc_id\":4242}]}"
-                         : "{\"fusion_mode\":\"rrf\",\"results\":[]}";
+   const char *src = "{\"fusion_mode\":\"rrf\",\"results\":[]}";
+   if (g_test_search_error)
+      src = "{\"error\":\"error: documentation query embedding failed; "
+            "server-side embedding configuration is unavailable\"}";
+   else if (g_test_search_populated)
+      src = "{\"fusion_mode\":\"rrf\",\"results\":[{\"project\":\"proj-alpha\","
+            "\"file_path\":\"docs/alpha.md\","
+            "\"content\":\"alpha excerpt body\",\"score\":0.875,\"doc_id\":4242}]}";
    char *r = malloc(strlen(src) + 1);
    if (r)
       strcpy(r, src);
@@ -6900,6 +6904,19 @@ static void test_search_scope_all_keeps_active_project_first(void)
    assert(strstr(buf, "\"project\":\"proj-other\"") != NULL);
 }
 
+static void test_search_backend_error_is_503(void)
+{
+   char buf[1024];
+   g_test_search_error = 1;
+   const char *body = "{\"query\":\"foo\",\"project\":\"proj-alpha\"}";
+   int s = kb_http_route_ex("POST", "/v1/search", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_test_search_error = 0;
+   assert(s == 503);
+   assert(strstr(buf, "query embedding failed") != NULL);
+   assert(strstr(buf, "\"hits\"") == NULL);
+}
+
 /* A managed KB normally has no raw embedding_command in aimee.yaml: the
  * wizard supplies SYNTHESIS_ENDPOINT. Search must resolve that deployment default
  * before entering the ranked backend, or it silently queries a 1024-dim corpus
@@ -7479,6 +7496,7 @@ int main(void)
    test_invalidations_route();
    test_search_ok();
    test_search_scope_all_keeps_active_project_first();
+   test_search_backend_error_is_503();
    test_search_uses_managed_embedder();
    test_search_hits_tool_contract();
    test_search_503_while_reembed_in_progress();


### PR DESCRIPTION
## What changed

- validate the ranked search backend envelope before reshaping it
- return HTTP 503 with the backend's structured error when embedding or storage fails
- reject malformed/missing-results backend responses instead of manufacturing an empty success
- add a route-level regression proving an embedding failure cannot become HTTP 200 `hits: []`

## Release validation evidence

Reproduced against the immutable `aimee-kb:testing-c4fb95f` image on the isolated `.252` release host:

- external embedder healthy: all 8 weightless-image smoke checks passed
- external embedder stopped: KB logged `embedding HTTP request failed`
- affected endpoint incorrectly returned HTTP 200 with `{"hits":[]...}`
- KB process remained alive, isolating the defect to response propagation

## Tests

- `make -C src -j4 build/obj/tests/unit-test-kb-http-routes`
- `src/build/obj/tests/unit-test-kb-http-routes`
- `git diff --check`
