### PR TITLE
fix(server): validate Anthropic request shapes

### DIFF
--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -469,7 +469,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
                             "max_tokens is required and must be a positive integer", 0);
       }
       const cJSON *jmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
-      if (jmsgs && (!cJSON_IsArray(jmsgs) || cJSON_GetArraySize(jmsgs) == 0))
+      if (!cJSON_IsArray(jmsgs) || cJSON_GetArraySize(jmsgs) == 0)
       {
          cJSON_Delete(req);
          return write_error(resp, cap, 400, "invalid_request_error",

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -1562,7 +1562,22 @@ cleanup:
 static int count_tokens(const char *body, char *resp, int cap)
 {
    cJSON *req = cJSON_Parse((body && body[0]) ? body : "{}");
-   const char *model = req ? jo_cstr(req, "model") : "";
+   if (!req)
+      return write_error(resp, cap, 400, "invalid_request_error", "invalid JSON body", 0);
+   if (!cJSON_IsObject(req))
+   {
+      cJSON_Delete(req);
+      return write_error(resp, cap, 400, "invalid_request_error",
+                         "request body must be a JSON object", 0);
+   }
+   cJSON *request_messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   if (!cJSON_IsArray(request_messages))
+   {
+      cJSON_Delete(req);
+      return write_error(resp, cap, 400, "invalid_request_error",
+                         "messages is required and must be an array", 0);
+   }
+   const char *model = jo_cstr(req, "model");
 
    /* Proxy to Anthropic's real /v1/messages/count_tokens so Claude Code's
     * context-budget math matches api.anthropic.com, not a local estimate — only
@@ -1604,9 +1619,7 @@ static int count_tokens(const char *body, char *resp, int cap)
    }
 
    char *system_text = req ? anthropic_system_to_text(req) : NULL;
-   cJSON *messages = req ? anthropic_messages_to_openai(
-                               cJSON_GetObjectItemCaseSensitive(req, "messages"), system_text)
-                         : NULL;
+   cJSON *messages = anthropic_messages_to_openai(request_messages, system_text);
    int n = messages ? session_compact_estimate_tokens(messages) : 0;
    cJSON *out = cJSON_CreateObject();
    int status;

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -1207,6 +1207,20 @@ static void test_count_tokens_validates_request_shape(void)
    PASS("count_tokens_validates_request_shape");
 }
 
+static void test_messages_buffered_rejects_missing_messages(void)
+{
+   const delegate_driver_t openai = {.name = "openai", .build_request = openai_driver_build};
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &openai;
+   assert(messages_buffered("{\"max_tokens\":16}", resp, sizeof(resp)) == 400);
+   assert(strstr(resp, "messages must be a non-empty array") != NULL);
+   assert(g_last_body == NULL);
+   reset_capture();
+   PASS("messages_buffered_rejects_missing_messages");
+}
+
 int main(void)
 {
    test_explicit_unknown_model_is_rejected();
@@ -1229,6 +1243,7 @@ int main(void)
    test_messages_stream_chatgpt_buffered_replays_responses();
    test_proof_gated_ingress_wire_parity();
    test_count_tokens_validates_request_shape();
+   test_messages_buffered_rejects_missing_messages();
    printf("anthropic_http: OK\n");
    return 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -1183,6 +1183,30 @@ static void test_proof_gated_ingress_wire_parity(void)
    PASS("proof_gated_ingress_wire_parity");
 }
 
+static void test_count_tokens_validates_request_shape(void)
+{
+   const delegate_driver_t openai = {.name = "openai", .build_request = openai_driver_build};
+   static const char *const invalid[] = {
+       "{", "[]", "null", "{}", "{\"messages\":\"not-an-array\"}", NULL,
+   };
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &openai;
+   for (int i = 0; invalid[i]; i++)
+   {
+      assert(count_tokens(invalid[i], resp, sizeof(resp)) == 400);
+      assert(strstr(resp, "invalid_request_error") != NULL);
+   }
+   assert(count_tokens("{\"messages\":[]}", resp, sizeof(resp)) == 200);
+   assert(strcmp(resp, "{\"input_tokens\":0}") == 0);
+   assert(count_tokens("{\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}", resp,
+                       sizeof(resp)) == 200);
+   assert(strcmp(resp, "{\"input_tokens\":1}") == 0);
+   reset_capture();
+   PASS("count_tokens_validates_request_shape");
+}
+
 int main(void)
 {
    test_explicit_unknown_model_is_rejected();
@@ -1204,6 +1228,7 @@ int main(void)
    test_messages_stream_openai_family_translates();
    test_messages_stream_chatgpt_buffered_replays_responses();
    test_proof_gated_ingress_wire_parity();
+   test_count_tokens_validates_request_shape();
    printf("anthropic_http: OK\n");
    return 0;
 }


### PR DESCRIPTION
## What

Harden two Anthropic-compatible ingress validators:

- POST /v1/messages/count_tokens rejects malformed JSON, non-object bodies, and missing or non-array messages with 400 invalid_request_error responses. Valid arrays retain the existing estimate/proxy behavior.
- POST /v1/messages enforces its documented non-empty messages requirement when the field is absent, preventing a max_tokens-only request from reaching a provider.

## Why

Exploratory testing on the published testing appliance found malformed and structurally invalid count-token requests returning HTTP 200 with input_tokens: 0. Inspection of the adjacent Messages validator found that it rejected an invalid messages field only when present, despite its handler contract requiring it.

## Verification

- Focused unit-test-anthropic-http passes with invalid/valid count-token shapes and provider-nonexecution coverage for missing Messages turns
- make -C src lint: all 76 checks passed after both fixes
- make -C src all and build-integrity passed
- clang-format-19 dry-run and git diff --check passed
- Count-token candidate image was live-tested in isolated CT121; invalid shapes returned 400, valid shapes returned 200 estimates, readiness stayed green

Published defect reproduced on testing commit 1a2d14ff3cb6640db22e0b876ffbd61d7cb656fd.