### PR TITLE
fix(kb): satisfy search scope static analysis

### DIFF
--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -34,11 +34,15 @@ int kb_http_search_project_scope(const char *body, char *project, size_t project
       return kbhs_error(out_buf, out_cap, 400, "invalid json");
    const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
-   if (js && !cJSON_IsString(js))
+   const char *scope = "current";
+   if (js)
    {
-      cJSON_Delete(root);
-      return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
+      if (!cJSON_IsString(js))
+      {
+         cJSON_Delete(root);
+         return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
+      }
+      scope = js->valuestring;
    }
    if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
    {


### PR DESCRIPTION
## Summary

- validate an optional search `scope` node before reading its string value
- preserve the existing default (`current`) and invalid-type response
- clear the `nullPointerRedundantCheck` diagnostic introduced by #2906, which currently fails the static-analysis ratchet on `testing` and all dependent PRs

## Validation

- focused `unit-test-kb-http-routes` passes
- formatting and `git diff --check` pass
- exact failing cppcheck expression is removed; CI will run the pinned cppcheck 2.13.0 ratchet