### PR TITLE
fix(kb): validate search scope before dereference

### DIFF
--- a/src/kb/http/kb_http_search.c
+++ b/src/kb/http/kb_http_search.c
@@ -34,12 +34,12 @@ int kb_http_search_project_scope(const char *body, char *project, size_t project
       return kbhs_error(out_buf, out_cap, 400, "invalid json");
    const cJSON *jp = cJSON_GetObjectItemCaseSensitive(root, "project");
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "scope");
-   const char *scope = cJSON_IsString(js) ? js->valuestring : "current";
    if (js && !cJSON_IsString(js))
    {
       cJSON_Delete(root);
       return kbhs_error(out_buf, out_cap, 400, "scope must be current or all");
    }
+   const char *scope = js ? js->valuestring : "current";
    if (strcmp(scope, "current") != 0 && strcmp(scope, "all") != 0)
    {
       cJSON_Delete(root);


### PR DESCRIPTION
## What

Validate an optional search scope value before dereferencing it, then select either the validated string or the existing current-scope default. Runtime behavior is unchanged.

## Why

The testing head introduced a cppcheck nullPointerRedundantCheck diagnostic in kb_http_search.c. The static-analysis ratchet fails every PR rebased onto testing until the base warning is resolved.

## Verification

- Exact pinned Cppcheck 2.13.0 ratchet on kb/http/kb_http_search.c: 0 known diagnostics, no increase
- KB shipping object compiled with warnings as errors
- clang-format-19 dry-run passed
- git diff --check passed

Reproduced from failed CI job 99075530556 after testing commit 1a2d14ff3cb6640db22e0b876ffbd61d7cb656fd.