### PR TITLE
fix(cli): run documented bare default actions

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -653,6 +653,21 @@ static int client_command_has_subcommands(const char *cmd)
    return 0;
 }
 
+static int client_command_has_bare_default(const char *cmd)
+{
+   if (!cmd)
+      return 0;
+   const cJSON *row = NULL;
+   cJSON_ArrayForEach(row, cli_v1_manifest_commands())
+   {
+      const cJSON *name = cJSON_GetObjectItemCaseSensitive(row, "name");
+      if (!cJSON_IsString(name) || strcmp(cmd, name->valuestring) != 0)
+         continue;
+      return cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(row, "bare_default"));
+   }
+   return 0;
+}
+
 static int wants_subcommand_help(int sub_argc, char **sub_argv)
 {
    if (sub_argc < 1)
@@ -2230,7 +2245,8 @@ int main(int argc, char **argv)
       return 0;
    }
 
-   if (client_command_has_subcommands(cmd) && wants_subcommand_help(sub_argc, sub_argv))
+   if (client_command_has_subcommands(cmd) && wants_subcommand_help(sub_argc, sub_argv) &&
+       !(sub_argc == 0 && client_command_has_bare_default(cmd)))
    {
       char *help_arg[] = {(char *)cmd};
       (void)json_output;

--- a/src/server/cli_command_defs.c
+++ b/src/server/cli_command_defs.c
@@ -20,6 +20,7 @@
 #include "cJSON.h"
 
 #include <stddef.h>
+#include <string.h>
 
 typedef struct
 {
@@ -53,6 +54,14 @@ static const char *tier_name(aimee_cmd_tier_t t)
    return "core";
 }
 
+/* The display catalogue's `subcommands` field also carries flag and positional
+ * usage text, so it cannot by itself tell the client whether an empty argv is
+ * valid. Keep that routing semantic explicit in the served manifest. */
+static int command_has_bare_default(const char *name)
+{
+   return name && (strcmp(name, "presence") == 0 || strcmp(name, "primary") == 0);
+}
+
 size_t cli_command_defs_count(void)
 {
    return sizeof(g_cli_commands) / sizeof(g_cli_commands[0]);
@@ -80,6 +89,8 @@ cJSON *cli_command_defs_to_json(void)
          cJSON_AddBoolToObject(row, "hidden_default", 1);
       if (c->subcommands && c->subcommands[0])
          cJSON_AddStringToObject(row, "subcommands", c->subcommands);
+      if (command_has_bare_default(c->name))
+         cJSON_AddBoolToObject(row, "bare_default", 1);
       cJSON_AddItemToArray(arr, row);
    }
    return arr;

--- a/src/tests/test_cli.sh
+++ b/src/tests/test_cli.sh
@@ -122,6 +122,17 @@ check "version" $AIMEE version
 check "version flag" $AIMEE --version
 check_output "version --json" "\"version\"" $AIMEE --json version
 
+# Flag/argument help is displayed in the same manifest field as real
+# subcommands. These two commands explicitly declare a bare default action, so
+# an empty argv must dispatch rather than being intercepted by group help.
+check_output "bare presence dispatches its default list" "[" $AIMEE --json presence
+check_output_not_contains "bare presence does not print help" "Subcommands:" \
+    $AIMEE presence
+check_output "bare primary dispatches its default get" "\"agent\"" \
+    $AIMEE --json primary
+check_output_not_contains "bare primary does not print help" "Subcommands:" \
+    $AIMEE primary
+
 # --- Unknown commands ---
 # A typo used to take the same fallback as a genuine routing gap and answer
 # "command 'foobarbaz' has no /v1 route", pointing at the route table for a word

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1209,6 +1209,26 @@ for r in (doc.get('marshal') or []):
 check_output "a served spec arrives with its fields" "capability,json,open_weights_only" \
     echo "$CATALOG_SPEC"
 
+# The display text for these commands looks like a subcommand group, but their
+# empty argv has documented behavior. The manifest must carry that semantic so
+# the thin client does not replace a valid request with help before dispatch.
+BARE_DEFAULTS=$(printf '%s' "$MANIFEST" | python3 -c "
+import json, sys
+try:
+    doc = json.load(sys.stdin)
+except Exception:
+    raise SystemExit
+print(','.join(sorted(r.get('name', '') for r in (doc.get('commands') or [])
+                      if r.get('bare_default') is True)))
+" 2>/dev/null) || true
+check_output "manifest identifies bare default actions" "presence,primary" \
+    echo "$BARE_DEFAULTS"
+
+RESP=$($AIMEE --json presence 2>&1) || true
+check_output "bare presence executes instead of printing help" "[" echo "$RESP"
+RESP=$($AIMEE --json primary 2>&1) || true
+check_output "bare primary executes its documented default get" '"agent"' echo "$RESP"
+
 # ============================================================
 # 4. Session management
 # ============================================================


### PR DESCRIPTION
## Summary

- mark `presence` and `primary` as commands with valid bare default actions in the server-owned CLI manifest
- let the thin client dispatch those empty-argv commands instead of intercepting them as group help
- cover both the manifest contract and the actual client/server dispatch path

## Published release reproduction

Against the exact current `:testing` artifacts on isolated `.252` CT9135 (`testing-1a2d14f`):

- `aimee --json presence` prints command help and exits 0
- `aimee --json presence --owner release-e2e` correctly returns `[]`
- `aimee --json primary` prints command help and exits 0
- `aimee --json primary --show` correctly returns `{\"agent\":\"\"}`

The server routes and flagged forms work; the client's pre-dispatch help gate was swallowing the documented bare actions.

## Validation

- shipping `aimee` and `aimee-server` build with warnings-as-errors
- focused real client/server integration: **86/86 passed**, including new bare-action assertions
- `build-integrity`: passed
- shell syntax and `git diff --check`: passed

## Stack

Temporarily based on #2913 so this PR does not duplicate the current `testing` branch's known Cppcheck blocker. Retarget to `testing` after #2913 merges.
