### PR TITLE
fix(http): classify rejected RPC payloads

### DIFF
--- a/server-go/modules/runtime-web/policy/status.go
+++ b/server-go/modules/runtime-web/policy/status.go
@@ -14,6 +14,8 @@ func HTTPStatusForRPCFault(kind string) int {
 		return http.StatusNotFound
 	case "permission_denied":
 		return http.StatusForbidden
+	case "payload_too_large":
+		return http.StatusRequestEntityTooLarge
 	case "unavailable":
 		return http.StatusServiceUnavailable
 	default:

--- a/server-go/modules/runtime-web/runtime_web_test.go
+++ b/server-go/modules/runtime-web/runtime_web_test.go
@@ -36,6 +36,7 @@ func TestRPCFaultStatusParity(t *testing.T) {
 		{"invalid_argument", 400},
 		{"not_found", 404},
 		{"permission_denied", 403},
+		{"payload_too_large", 413},
 		{"unavailable", 503},
 		{"", 502},
 		{"unknown", 502},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -337,6 +337,7 @@ int server_send_error(server_conn_t *conn, const char *message, const char *requ
 #define SERVER_ERR_NOT_FOUND         "not_found"         /* named thing does not exist */
 #define SERVER_ERR_PERMISSION_DENIED "permission_denied" /* caller not allowed */
 #define SERVER_ERR_UNAVAILABLE       "unavailable"       /* a dependency is down */
+#define SERVER_ERR_PAYLOAD_TOO_LARGE "payload_too_large" /* request exceeds method budget */
 
 /* The typed error as a VALUE, for commands that RETURN a result rather than write
  * one. jo_err is not a substitute: it omits `kind` and the derived `http_status`,

--- a/src/modules/runtime-web/include/aimee/runtime-web/module_api.h
+++ b/src/modules/runtime-web/include/aimee/runtime-web/module_api.h
@@ -86,8 +86,8 @@ static inline int aimee_runtime_web_request_decode(const uint8_t *in, size_t len
 
 static inline int aimee_runtime_web_status_valid(uint32_t status)
 {
-   return status == 400u || status == 403u || status == 404u || status == 502u ||
-          status == 503u;
+   return status == 400u || status == 403u || status == 404u || status == 413u ||
+          status == 502u || status == 503u;
 }
 
 static inline int aimee_runtime_web_response_encode(uint32_t status, uint8_t *out,

--- a/src/modules/runtime-web/module_adapter.c
+++ b/src/modules/runtime-web/module_adapter.c
@@ -13,6 +13,8 @@ static uint32_t rpc_fault_http_status(const char *kind)
       return 403u;
    if (strcmp(kind, "unavailable") == 0)
       return 503u;
+   if (strcmp(kind, "payload_too_large") == 0)
+      return 413u;
    return 502u;
 }
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1445,8 +1445,14 @@ int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, siz
       snprintf(errmsg, sizeof(errmsg),
                "PAYLOAD_TOO_LARGE: %zu bytes exceeds %zu limit for method '%s'", msg_len, limit,
                quick_method);
-      return server_send_error(conn, errmsg, NULL);
+      return server_send_error_kind(conn, SERVER_ERR_PAYLOAD_TOO_LARGE, errmsg, NULL);
    }
+
+   /* cJSON accepts arbitrary bytes inside quoted strings. Reject them before
+    * parsing so every JSON surface observes the same Unicode text contract. */
+   if (strlen(msg) != msg_len || !text_is_valid_utf8(msg))
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "invalid JSON: input is not valid UTF-8", NULL);
 
    cJSON *req = cJSON_Parse(msg);
    if (!req)
@@ -1456,7 +1462,8 @@ int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, siz
    if (json_check_depth(req, 0, JSON_MAX_DEPTH) != 0)
    {
       cJSON_Delete(req);
-      return server_send_error(conn, "PAYLOAD_MALFORMED: JSON exceeds depth/field limits", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "PAYLOAD_MALFORMED: JSON exceeds depth/field limits", NULL);
    }
 
    cJSON *method = cJSON_GetObjectItemCaseSensitive(req, "method");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2081,6 +2081,7 @@ $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o 
  $(OBJDIR)/platform_random.o \
  $(OBJDIR)/hook_session_token.o \
  $(OBJDIR)/linux/secret_store.o $(OBJDIR)/posix/util.o \
+ $(OBJDIR)/text.o \
  $(OBJDIR)/json_fluent.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_process_module_handlers.c
+++ b/src/tests/test_process_module_handlers.c
@@ -678,7 +678,8 @@ static void test_runtime_web(void)
       uint32_t status;
    } cases[] = {
        {"invalid_argument", 400u}, {"not_found", 404u}, {"permission_denied", 403u},
-       {"unavailable", 503u},      {"", 502u},          {"unknown", 502u},
+       {"unavailable", 503u},      {"payload_too_large", 413u},
+       {"", 502u},                 {"unknown", 502u},
    };
    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i)
    {

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1521,6 +1521,22 @@ static void test_invalid_json(void)
    free(ctx);
 }
 
+static void test_invalid_json_utf8(void)
+{
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+   static const char invalid[] = "{\"method\":\"status\",\"extra\":\"\xff\"}";
+   cJSON *json = dispatch_json(ctx, conn, invalid, sizeof(invalid) - 1);
+   assert(strcmp(cJSON_GetObjectItem(json, "message")->valuestring,
+                 "invalid JSON: input is not valid UTF-8") == 0);
+   assert(strcmp(cJSON_GetObjectItem(json, "kind")->valuestring,
+                 SERVER_ERR_INVALID_ARGUMENT) == 0);
+   cJSON_Delete(json);
+   free(conn);
+   free(ctx);
+}
+
 static void test_missing_method(void)
 {
    server_ctx_t *ctx = calloc(1, sizeof(*ctx));
@@ -1550,6 +1566,42 @@ static void test_oversized_payload(void)
    msg[size] = '\0';
    cJSON *json = dispatch_json(ctx, conn, msg, size);
    assert(strstr(cJSON_GetObjectItem(json, "message")->valuestring, "PAYLOAD_TOO_LARGE") != NULL);
+   assert(strcmp(cJSON_GetObjectItem(json, "kind")->valuestring,
+                 SERVER_ERR_PAYLOAD_TOO_LARGE) == 0);
+   cJSON_Delete(json);
+   free(msg);
+   free(conn);
+   free(ctx);
+}
+
+static void test_excessive_json_depth_is_invalid_argument(void)
+{
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+
+   const char *prefix = "{\"method\":\"status\",\"extra\":";
+   size_t depth = JSON_MAX_DEPTH + 2;
+   size_t size = strlen(prefix) + depth + 1 + depth + 1;
+   char *msg = malloc(size + 1);
+   assert(msg != NULL);
+   size_t off = 0;
+   memcpy(msg + off, prefix, strlen(prefix));
+   off += strlen(prefix);
+   memset(msg + off, '[', depth);
+   off += depth;
+   msg[off++] = '0';
+   memset(msg + off, ']', depth);
+   off += depth;
+   msg[off++] = '}';
+   msg[off] = '\0';
+   assert(off == size);
+
+   cJSON *json = dispatch_json(ctx, conn, msg, size);
+   assert(strstr(cJSON_GetObjectItem(json, "message")->valuestring, "PAYLOAD_MALFORMED") !=
+          NULL);
+   assert(strcmp(cJSON_GetObjectItem(json, "kind")->valuestring,
+                 SERVER_ERR_INVALID_ARGUMENT) == 0);
    cJSON_Delete(json);
    free(msg);
    free(conn);
@@ -2434,6 +2486,7 @@ int main(void)
 {
    test_health_kb_verdict_states();
    test_invalid_json();
+   test_invalid_json_utf8();
    test_session_brief_assemble();
    test_mcp_span_shorthand_batch_parse();
    test_conn_update_events_null_evloop();
@@ -2441,6 +2494,7 @@ int main(void)
    test_api_enroll_preserves_sequential_bearers();
    test_missing_method();
    test_oversized_payload();
+   test_excessive_json_depth_is_invalid_argument();
    test_large_delegate_payload_within_limit();
    test_large_roundtable_payload_within_limit();
    test_large_mcp_call_payload_within_limit();

--- a/src/tests/test_server_error_kind.c
+++ b/src/tests/test_server_error_kind.c
@@ -77,6 +77,7 @@ int main(void)
    expect_status(SERVER_ERR_NOT_FOUND, 404);
    expect_status(SERVER_ERR_PERMISSION_DENIED, 403);
    expect_status(SERVER_ERR_UNAVAILABLE, 503);
+   expect_status(SERVER_ERR_PAYLOAD_TOO_LARGE, 413);
    expect_status("unknown", 502);
    expect_status(NULL, 502);
 


### PR DESCRIPTION
## Summary

- classify RPC payload budget violations as `payload_too_large` and return HTTP 413
- classify JSON depth/field-limit violations as invalid arguments and return HTTP 400
- reject malformed UTF-8 before cJSON parsing so JSON behavior is consistent across transports
- extend runtime-web's validated status vocabulary and focused regression coverage

## Release-testing evidence

Exploratory testing of the exact published `testing-1a2d14f` release on the isolated `.252` environment reproduced:

- a 2 MiB `session.get` request returned 502 with `PAYLOAD_TOO_LARGE`
- JSON above the 32-level / 4096-field limits returned 502 with `PAYLOAD_MALFORMED`
- an invalid UTF-8 JSON string was accepted and reached session lookup

## Verification

- `unit-test-server-dispatch`
- `unit-test-server-error-kind`
- `unit-test-process-module-handlers`
- `git diff --check`

This is stacked on #2913 because that PR fixes the current `testing` static-analysis baseline blocker. Live candidate-image validation on `.252` is in progress and will be posted before merge.
