### PR TITLE
feat(memory,benchmarks): measure lane outcomes and run coverage

### DIFF
--- a/benchmarks/common/adapter_llm.py
+++ b/benchmarks/common/adapter_llm.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 
 _BENCH_META = {
@@ -140,7 +141,9 @@ def main() -> int:
     results: list[dict[str, Any]] = []
     try:
         adapter.call({"op": "describe"})
+        samples_run = 0
         for sample in _load_cases(args.bench, args.dataset, args.max_samples):
+            samples_run += 1
             events = _flatten_events(sample, args.bench)
             ingest = adapter.call({"op": "ingest", "session_id": sample.get("id", "bench"), "events": events})
             state_ref = ingest.get("state_ref", "")
@@ -192,6 +195,15 @@ def main() -> int:
         "track": "llm",
         "git_commit": git_commit(root),
         "result_count": len(results),
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            max_questions=args.max_questions,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "agent_model": harness.current_model,
         "judge_runs": 3,
         "judge_profile": "frontier",

--- a/benchmarks/common/result_schema.py
+++ b/benchmarks/common/result_schema.py
@@ -212,3 +212,122 @@ def retrieval_outcome_bucket(row: dict[str, Any]) -> str:
         f"{'complete' if sufficient else 'partial_or_insufficient'}_context__"
         f"{'correct' if correct else 'wrong'}_answer"
     )
+
+
+# ---------------------------------------------------------------------------
+# Run coverage: whether a result file describes a complete run
+# ---------------------------------------------------------------------------
+#
+# A subsampled run and a full run produce byte-identical result schemas, so a
+# number measured over 600 questions can be compared against a baseline measured
+# over 10,000 and reported as a reproduction. That is not hypothetical here: the
+# reranker investigation measured +0.020 on a 600-question subsample and -0.0048
+# on the full 10,000, a sign flip, and the recommendation was nearly shipped on
+# the subsample (docs/blog/we-measured-our-reranker-and-deleted-it.md).
+#
+# The fix is to make the distinction a recorded property rather than something a
+# reader is expected to remember. `coverage` states the caps that were in force
+# and how much actually ran; `require_complete_run` refuses a partial file where
+# a full one is required.
+#
+# Validation stays lenient and eligibility is strict, deliberately: existing
+# result files predate this block and must keep validating, but a file that
+# cannot prove it was complete is not eligible to back a baseline. Absent
+# coverage is refused for the same reason a partial run is - unknown provenance
+# is not evidence of a full run.
+
+COVERAGE_REQUIRED = {
+    "complete": bool,
+    "limits": dict,
+    "counts": dict,
+}
+
+
+def make_coverage(
+    *,
+    max_samples: int = 0,
+    max_questions: int = 0,
+    samples_run: int = 0,
+    questions_run: int = 0,
+) -> dict[str, Any]:
+    """Build the coverage block for a result payload.
+
+    A run is complete when no cap was in force. `max_samples`/`max_questions`
+    follow the harness convention where 0 means unbounded.
+
+    `max_samples` records the per-run sample cap whatever the producer calls its
+    flag: the LongMemEval benches spell it `--max-cases`, the LoCoMo and memory
+    benches `--max-samples`, and both mean the same thing here.
+    """
+    return {
+        "complete": int(max_samples) == 0 and int(max_questions) == 0,
+        "limits": {
+            "max_samples": int(max_samples),
+            "max_questions": int(max_questions),
+        },
+        "counts": {
+            "samples_run": int(samples_run),
+            "questions_run": int(questions_run),
+        },
+    }
+
+
+def validate_coverage(block: dict[str, Any]) -> None:
+    _ensure(isinstance(block, dict), "coverage must be a dict")
+    _validate_required(block, COVERAGE_REQUIRED)
+    for field in ("max_samples", "max_questions"):
+        _ensure(field in block["limits"], f"missing coverage.limits.{field}")
+        _ensure(isinstance(block["limits"][field], int), f"coverage.limits.{field} must be an int")
+        _ensure(block["limits"][field] >= 0, f"coverage.limits.{field} must be non-negative")
+    for field in ("samples_run", "questions_run"):
+        _ensure(field in block["counts"], f"missing coverage.counts.{field}")
+        _ensure(isinstance(block["counts"][field], int), f"coverage.counts.{field} must be an int")
+        _ensure(block["counts"][field] >= 0, f"coverage.counts.{field} must be non-negative")
+    capped = block["limits"]["max_samples"] != 0 or block["limits"]["max_questions"] != 0
+    _ensure(
+        block["complete"] is not capped,
+        "coverage.complete contradicts coverage.limits",
+    )
+
+
+def run_coverage(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the payload's coverage block, or None when it records none."""
+    block = payload.get("coverage")
+    if block is None:
+        return None
+    validate_coverage(block)
+    return block
+
+
+def run_is_complete(payload: dict[str, Any]) -> bool | None:
+    """True/False when coverage was recorded, None when it was not.
+
+    None is not False: a legacy file may well be a full run. It is unproven,
+    which is why require_complete_run refuses it and this helper does not
+    silently assert either way.
+    """
+    block = run_coverage(payload)
+    return None if block is None else bool(block["complete"])
+
+
+def require_complete_run(payload: dict[str, Any], purpose: str, *, source: str = "") -> None:
+    """Raise unless the payload proves it came from an uncapped run.
+
+    Call this at every point a score is promoted rather than merely printed:
+    baseline eligibility, cross-run comparison, published claims.
+    """
+    where = f"{source}: " if source else ""
+    state = run_is_complete(payload)
+    if state is None:
+        raise ValueError(
+            f"{where}{purpose} requires a complete run, and this result file records no "
+            "coverage block, so the question count it was measured over is unknown"
+        )
+    if not state:
+        limits = payload["coverage"]["limits"]
+        counts = payload["coverage"]["counts"]
+        raise ValueError(
+            f"{where}{purpose} requires a complete run, but this result file was capped "
+            f"(max_samples={limits['max_samples']}, max_questions={limits['max_questions']}; "
+            f"ran {counts['samples_run']} samples / {counts['questions_run']} questions)"
+        )

--- a/benchmarks/common/runner.py
+++ b/benchmarks/common/runner.py
@@ -14,6 +14,7 @@ from benchmarks.common.harness import (
     summarize_costs,
     summarize_latencies,
 )
+from benchmarks.common.result_schema import validate_coverage
 
 # ---------------------------------------------------------------------------
 # Abstention detection
@@ -125,6 +126,11 @@ def build_summary(
 
 
 def write_result_file(path: Path, payload: dict[str, Any]) -> None:
+    # A malformed coverage block is worse than none: it would be read back as
+    # proof of a complete run. Reject it at the point of writing, where the
+    # producer that got it wrong is still on the stack.
+    if "coverage" in payload:
+        validate_coverage(payload["coverage"])
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n")
 

--- a/benchmarks/locomo/bench_aimee_llm.py
+++ b/benchmarks/locomo/bench_aimee_llm.py
@@ -15,6 +15,7 @@ from benchmarks.common.llm_eval import (
     judge_majority,
     llm_cost_breakdown,
 )
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.locomo.common.dataset import load_cases
 
@@ -31,7 +32,9 @@ def main() -> int:
     harness = AimeeHarness()
     results = []
 
+    samples_run = 0
     for sample in load_cases(args.dataset, args.max_samples):
+        samples_run += 1
         tmp, home = harness.prepare_home()
         try:
             store_conversation(harness, home, sample)
@@ -91,6 +94,14 @@ def main() -> int:
         "agent_model": harness.current_model,
         "judge_runs": 3,
         "vector_runtime": collect_vector_runtime_metadata(),
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/locomo/bench_bm25_llm.py
+++ b/benchmarks/locomo/bench_bm25_llm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from benchmarks.common.bm25 import BM25Index
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import ANSWER_SYSTEM, build_answer_prompt, judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.locomo.common.dataset import load_cases
 
@@ -46,7 +47,9 @@ def main() -> int:
     results = []
     tmp, home = harness.prepare_home()
     try:
+        samples_run = 0
         for sample in load_cases(args.dataset, args.max_samples):
+            samples_run += 1
             index = BM25Index(build_documents(sample))
             for row in sample["questions"]:
                 started = time.perf_counter()
@@ -104,6 +107,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/locomo/bench_rag_chromadb_llm.py
+++ b/benchmarks/locomo/bench_rag_chromadb_llm.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import ANSWER_SYSTEM, build_answer_prompt, judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.locomo.common.dataset import load_cases
 
@@ -74,7 +75,9 @@ def main() -> int:
     results = []
     tmp, home = harness.prepare_home()
     try:
+        samples_run = 0
         for sample in load_cases(args.dataset, args.max_samples):
+            samples_run += 1
             docs = build_documents(sample)
 
             # Build an ephemeral ChromaDB collection for this sample
@@ -148,6 +151,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/longmemeval/bench_aimee_llm.py
+++ b/benchmarks/longmemeval/bench_aimee_llm.py
@@ -15,6 +15,7 @@ from benchmarks.common.llm_eval import (
     judge_majority,
     llm_cost_breakdown,
 )
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.longmemeval.common.dataset import load_cases
 
@@ -33,7 +34,9 @@ def main() -> int:
     harness = AimeeHarness()
     results = []
 
+    samples_run = 0
     for case in load_cases(args.dataset, args.max_cases):
+        samples_run += 1
         tmp, home = harness.prepare_home()
         try:
             store_case(harness, home, case)
@@ -92,6 +95,14 @@ def main() -> int:
         "agent_model": harness.current_model,
         "judge_runs": 3,
         "vector_runtime": collect_vector_runtime_metadata(),
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_cases,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/longmemeval/bench_bm25_llm.py
+++ b/benchmarks/longmemeval/bench_bm25_llm.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from benchmarks.common.bm25 import BM25Index
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import ANSWER_SYSTEM, build_answer_prompt, judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.longmemeval.common.dataset import load_cases
 
@@ -46,7 +47,9 @@ def main() -> int:
     results = []
     tmp, home = harness.prepare_home()
     try:
+        samples_run = 0
         for case in load_cases(args.dataset, args.max_cases):
+            samples_run += 1
             index = BM25Index(build_documents(case))
             started = time.perf_counter()
             facts = index.search(case["question"], args.top_k)
@@ -103,6 +106,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_cases,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/longmemeval/bench_mem0_llm.py
+++ b/benchmarks/longmemeval/bench_mem0_llm.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import ANSWER_SYSTEM, build_answer_prompt, judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.longmemeval.common.dataset import load_cases
 
@@ -63,7 +64,9 @@ def main() -> int:
     results = []
     tmp, home = harness.prepare_home()
     try:
+        samples_run = 0
         for case in load_cases(args.dataset, args.max_cases):
+            samples_run += 1
             # Ingest conversation turns into Mem0
             user_id = f"bench_{case['question_id']}"
             messages = []
@@ -142,6 +145,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_cases,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/longmemeval/bench_rag_chromadb_llm.py
+++ b/benchmarks/longmemeval/bench_rag_chromadb_llm.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from benchmarks.common.harness import AimeeHarness, git_commit
 from benchmarks.common.llm_eval import ANSWER_SYSTEM, build_answer_prompt, judge_majority, llm_cost_breakdown
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 from benchmarks.longmemeval.common.dataset import load_cases
 
@@ -74,7 +75,9 @@ def main() -> int:
     results = []
     tmp, home = harness.prepare_home()
     try:
+        samples_run = 0
         for case in load_cases(args.dataset, args.max_cases):
+            samples_run += 1
             docs = build_documents(case)
 
             # Build an ephemeral ChromaDB collection for this case
@@ -147,6 +150,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_cases,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/memory/bench_beam.py
+++ b/benchmarks/memory/bench_beam.py
@@ -113,6 +113,7 @@ from benchmarks.common.llm_eval import (
     judge_majority,
     llm_cost_breakdown,
 )
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 
 
@@ -149,7 +150,9 @@ def main() -> int:
     harness = AimeeHarness()
     results: list[dict[str, Any]] = []
 
+    samples_run = 0
     for sample in _load_cases(args.dataset, args.max_samples):
+        samples_run += 1
         tmp, home = harness.prepare_home()
         try:
             _store_turns(harness, home, sample["conversation_id"], sample["turns"])
@@ -212,6 +215,14 @@ def main() -> int:
         "agent_model": harness.current_model,
         "judge_runs": 3,
         "vector_runtime": collect_vector_runtime_metadata(),
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/memory/bench_dmr.py
+++ b/benchmarks/memory/bench_dmr.py
@@ -17,6 +17,7 @@ from benchmarks.common.llm_eval import (
     judge_majority,
     llm_cost_breakdown,
 )
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, write_result_file
 from benchmarks.memory.dataset import _load_cases, _normalize_turns
 
@@ -53,7 +54,9 @@ def main() -> int:
     harness = AimeeHarness()
     results: list[dict] = []
 
+    samples_run = 0
     for case in _load_cases(args.dataset, args.max_samples):
+        samples_run += 1
         # Normalise both 'conversation' and 'sessions' shapes to a flat turn list.
         turns = _normalize_turns(case)
         tmp, home = harness.prepare_home()
@@ -116,6 +119,14 @@ def main() -> int:
         "agent_model": harness.current_model,
         "judge_runs": 3,
         "vector_runtime": collect_vector_runtime_metadata(),
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/memory/bench_msc.py
+++ b/benchmarks/memory/bench_msc.py
@@ -25,6 +25,7 @@ from benchmarks.common.llm_eval import (
     judge_majority,
     llm_cost_breakdown,
 )
+from benchmarks.common.result_schema import make_coverage
 from benchmarks.common.runner import build_summary, print_summary, write_result_file
 
 
@@ -99,7 +100,9 @@ def main() -> int:
     harness = AimeeHarness()
     results = []
 
+    samples_run = 0
     for case in _load_cases(args.dataset, args.max_samples):
+        samples_run += 1
         tmp, home = harness.prepare_home()
         try:
             _store_conversation(harness, home, case)
@@ -157,6 +160,14 @@ def main() -> int:
         "result_count": len(results),
         "agent_model": harness.current_model,
         "judge_runs": 3,
+        # Records whether this run was capped, so a subsample cannot later be
+        # compared against a full-run baseline without the difference showing.
+        # See require_complete_run in benchmarks/common/result_schema.py.
+        "coverage": make_coverage(
+            max_samples=args.max_samples,
+            samples_run=samples_run,
+            questions_run=len(results),
+        ),
         "results": results,
         "summary": summary,
     }

--- a/benchmarks/tests/test_result_schema.py
+++ b/benchmarks/tests/test_result_schema.py
@@ -16,7 +16,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from benchmarks.common.result_schema import (
     PROVENANCE_FIELDS,
+    make_coverage,
+    require_complete_run,
     retrieval_outcome_bucket,
+    run_is_complete,
+    validate_coverage,
     validate_direct_result,
     validate_llm_result,
     validate_provenance,
@@ -226,6 +230,63 @@ class ProvenanceSchemaTest(unittest.TestCase):
             any("seed" in e and "wrong type" in e for e in errors),
             f"Expected type error for seed, got {errors}",
         )
+
+
+class TestRunCoverage(unittest.TestCase):
+    """A subsampled run must not be usable where a full run is required.
+
+    The failure this guards is on record: the reranker investigation measured
+    +0.020 on a 600-question subsample and -0.0048 on the full 10,000 - a sign
+    flip - and the two result files were indistinguishable.
+    """
+
+    def test_uncapped_run_is_complete(self) -> None:
+        block = make_coverage(samples_run=500, questions_run=10000)
+        validate_coverage(block)
+        self.assertTrue(block["complete"])
+        self.assertTrue(run_is_complete({"coverage": block}))
+        require_complete_run({"coverage": block}, "baseline eligibility")
+
+    def test_capped_samples_is_partial(self) -> None:
+        block = make_coverage(max_samples=10, samples_run=10, questions_run=600)
+        validate_coverage(block)
+        self.assertFalse(block["complete"])
+        with self.assertRaises(ValueError) as ctx:
+            require_complete_run({"coverage": block}, "baseline eligibility")
+        self.assertIn("max_samples=10", str(ctx.exception))
+
+    def test_capped_questions_is_partial(self) -> None:
+        block = make_coverage(max_questions=5, samples_run=10, questions_run=50)
+        self.assertFalse(block["complete"])
+        with self.assertRaises(ValueError):
+            require_complete_run({"coverage": block}, "baseline eligibility")
+
+    def test_missing_coverage_is_unknown_not_complete(self) -> None:
+        # None, not False: a legacy file may be a full run, but it cannot show it.
+        self.assertIsNone(run_is_complete({"result_count": 3}))
+        with self.assertRaises(ValueError) as ctx:
+            require_complete_run({"result_count": 3}, "baseline eligibility")
+        self.assertIn("no coverage block", str(ctx.exception))
+
+    def test_complete_flag_cannot_contradict_limits(self) -> None:
+        # The flag a reader trusts must not be settable independently of the
+        # caps that determine it.
+        forged = make_coverage(max_questions=5, samples_run=1, questions_run=5)
+        forged["complete"] = True
+        with self.assertRaises(ValueError):
+            validate_coverage(forged)
+
+    def test_negative_counts_rejected(self) -> None:
+        block = make_coverage(samples_run=1, questions_run=1)
+        block["counts"]["questions_run"] = -1
+        with self.assertRaises(ValueError):
+            validate_coverage(block)
+
+    def test_source_is_named_in_the_error(self) -> None:
+        block = make_coverage(max_samples=2, samples_run=2, questions_run=8)
+        with self.assertRaises(ValueError) as ctx:
+            require_complete_run({"coverage": block}, "comparison", source="lme_lite.json")
+        self.assertIn("lme_lite.json", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/benchmarks/verify_scores.py
+++ b/benchmarks/verify_scores.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from benchmarks.common.harness import category_accuracy
 from benchmarks.common.result_schema import (
     label_field_for_dataset,
+    require_complete_run,
+    run_coverage,
     validate_direct_report,
     validate_direct_result,
     validate_llm_result,
@@ -22,6 +24,15 @@ from benchmarks.common.result_schema import (
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("result_file", nargs="+")
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help=(
+            "fail unless every result file proves it came from an uncapped run. "
+            "Use whenever a score is promoted rather than merely read: baseline "
+            "eligibility, cross-run comparison, published claims."
+        ),
+    )
     return parser
 
 
@@ -32,6 +43,26 @@ def verify_file(path: Path) -> dict[str, object]:
     track = payload["track"]
     system_name = str(payload.get("system") or (payload.get("results") or [{}])[0].get("system", "unknown"))
     print(f"{path}: dataset={dataset_name} track={track}")
+
+    # Coverage is printed for every file, complete or not, so the reader never
+    # has to infer the question count a score was measured over.
+    coverage = run_coverage(payload)
+    if coverage is None:
+        print("  coverage: unrecorded (cannot be shown to be a complete run)")
+    elif coverage["complete"]:
+        print(
+            f"  coverage: complete "
+            f"(samples={coverage['counts']['samples_run']} "
+            f"questions={coverage['counts']['questions_run']})"
+        )
+    else:
+        print(
+            f"  coverage: PARTIAL "
+            f"(max_samples={coverage['limits']['max_samples']} "
+            f"max_questions={coverage['limits']['max_questions']}; "
+            f"ran samples={coverage['counts']['samples_run']} "
+            f"questions={coverage['counts']['questions_run']})"
+        )
 
     if track == "direct" and "segments" in payload and "results" not in payload:
         validate_direct_report(payload, label_field)
@@ -181,6 +212,19 @@ def main() -> int:
     reports = []
     for item in args.result_file:
         reports.append(verify_file(Path(item)))
+    if args.require_complete:
+        failures = []
+        for report in reports:
+            try:
+                require_complete_run(
+                    report["payload"], "score verification", source=str(report["path"])
+                )
+            except ValueError as exc:
+                failures.append(str(exc))
+        if failures:
+            for message in failures:
+                print(f"ERROR {message}", file=sys.stderr)
+            return 1
     grouped: dict[tuple[str, str], list[dict[str, object]]] = {}
     for report in reports:
         key = (str(report["dataset"]), str(report["track"]))

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -60,6 +60,25 @@ Record:
 
 Keep raw machine output beside the summary when practical.
 
+### Coverage is recorded, not remembered
+
+Every result file the memory and retrieval producers write carries a `coverage`
+block stating the caps that were in force (`--max-samples` / `--max-cases` /
+`--max-questions`) and how much actually ran. A run with no cap is `complete`.
+
+A subsampled run and a full run are otherwise the same shape, so a score from a
+short run can be read back as a reproduction of a long one. That has already
+cost us once: reranking measured **+0.020** on a 600-question subsample and
+**-0.0048** on the full 10,000 — a sign flip — and the recommendation was nearly
+shipped on the subsample. See
+[the retrieval writeup](blog/we-measured-our-reranker-and-deleted-it.md).
+
+`benchmarks/verify_scores.py` prints coverage for every file, and
+`--require-complete` fails the run unless every file proves it was uncapped. Use
+it wherever a score is promoted rather than merely read: baseline eligibility,
+cross-run comparison, and published claims. A file with no coverage block is
+refused there too — an unknown question count is not evidence of a full run.
+
 ## Compare
 
 Change one variable at a time. Compare against the same corpus and acceptance metric. A cheaper or

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -69,7 +69,7 @@ block stating the caps that were in force (`--max-samples` / `--max-cases` /
 A subsampled run and a full run are otherwise the same shape, so a score from a
 short run can be read back as a reproduction of a long one. That has already
 cost us once: reranking measured **+0.020** on a 600-question subsample and
-**-0.0048** on the full 10,000 — a sign flip — and the recommendation was nearly
+**-0.0048** on the full 10,000, a sign flip, and the recommendation was nearly
 shipped on the subsample. See
 [the retrieval writeup](blog/we-measured-our-reranker-and-deleted-it.md).
 
@@ -77,7 +77,7 @@ shipped on the subsample. See
 `--require-complete` fails the run unless every file proves it was uncapped. Use
 it wherever a score is promoted rather than merely read: baseline eligibility,
 cross-run comparison, and published claims. A file with no coverage block is
-refused there too — an unknown question count is not evidence of a full run.
+refused there too: an unknown question count is not evidence of a full run.
 
 ## Compare
 

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -156,6 +156,33 @@ and `memory_health` diagnostics to separate empty knowledge from provider or ind
 retain the concrete database, sidecar, and HTTP error rather than collapsing every failure into a generic
 `index unavailable` message.
 
+### Per-lane recall outcomes
+
+Recall runs several candidate lanes (graph, variant, decomposition, unit-semantic, semantic,
+negation, FTS) and each candidate is already tagged with the lane that produced it. That tagging fed
+ranking, through the multi-source fusion bonus, and nothing else: whether a lane's contribution
+*survived* ranking was never recorded, so a lane that produces candidates on every query and never
+places one looked identical to a lane carrying the answer.
+
+After ranking fixes the order, `memory_record_lane_outcome_metrics()` attributes the served window
+back to its lanes:
+
+| Counter | Meaning |
+| --- | --- |
+| `memory.query.lane.<lane>.candidates` | rows this lane contributed to the pool |
+| `memory.query.lane.<lane>.served` | of those, how many are in the window handed back |
+| `memory.query.lane.<lane>.shutout` | queries where the lane contributed and placed nothing |
+| `memory.query.route.<route>.lane.<lane>.served` | the same, split by query route |
+
+A lane that contributed nothing emits no counters, so a silent lane and a losing lane are not summed
+together.
+
+This is measurement, not control. No lane is skipped, reordered, or truncated on the strength of
+these counters, and no recall decision reads them back. Stopping collection early would need the
+lanes ordered by expected yield relative to each other, and they are not: candidate volume is not
+evidence that the lane holding the answer has already run. The counters exist so a decision to drop
+a lane can be made from evidence about this corpus, the way the reranker's removal was.
+
 ## Compatibility
 
 Public `memory_*`, KB-client JSON, CLI, route, schema, and embedding-version contracts remain stable

--- a/src/modules/memory/memory_core_internal.h
+++ b/src/modules/memory/memory_core_internal.h
@@ -272,6 +272,9 @@ int memory_query_wants_future(const char *norm_query);
 int memory_query_wants_past(const char *norm_query);
 int memory_query_wants_recent(const char *norm_query);
 memory_ranker_input_t memory_ranker_input_from(const memory_t *m);
+void memory_record_lane_outcome_metrics(const memory_query_plan_t *plan, const memory_t *matches,
+                                        int served, const memory_candidate_source_t *source_stats,
+                                        int source_stats_count);
 void memory_record_query_plan_metrics(const memory_query_plan_t *plan, double elapsed_ms);
 void memory_record_query_stage_metric(const memory_query_plan_t *plan, const char *stage_name);
 int memory_rerank_matches(const char *raw_query, memory_t *matches, int count, int limit,

--- a/src/modules/memory/memory_core_search_b.c
+++ b/src/modules/memory/memory_core_search_b.c
@@ -691,6 +691,123 @@ static double memory_source_fusion_bonus(const memory_candidate_source_t *stats,
    return bonus;
 }
 
+/* Lane names for the MEM_SOURCE_* bits, indexed by bit position. A NULL entry
+ * is an unnamed bit and is skipped rather than reported under a wrong name. */
+static const char *const memory_lane_names[] = {
+    "lexical",  /* MEM_SOURCE_LEXICAL  */
+    "alias",    /* MEM_SOURCE_ALIAS    */
+    "entity",   /* MEM_SOURCE_ENTITY   */
+    "summary",  /* MEM_SOURCE_SUMMARY  */
+    "event",    /* MEM_SOURCE_EVENT    */
+    "chunk",    /* MEM_SOURCE_CHUNK    */
+    "unit",     /* MEM_SOURCE_UNIT     */
+    "temporal", /* MEM_SOURCE_TEMPORAL */
+    "semantic", /* MEM_SOURCE_SEMANTIC */
+    "like",     /* MEM_SOURCE_LIKE     */
+    "code",     /* MEM_SOURCE_CODE     */
+    "graph"     /* MEM_SOURCE_GRAPH    */
+};
+
+#define MEMORY_LANE_COUNT ((int)(sizeof(memory_lane_names) / sizeof(memory_lane_names[0])))
+
+static unsigned int memory_lane_mask_for(const memory_candidate_source_t *stats, int stats_count,
+                                         int64_t memory_id)
+{
+   for (int i = 0; i < stats_count; i++)
+   {
+      if (stats[i].memory_id == memory_id)
+         return stats[i].source_mask;
+   }
+   return 0u;
+}
+
+/* Per-lane outcome accounting, recorded after ranking has fixed the order.
+ *
+ * The candidate collector already tags every row with the lane(s) that produced
+ * it (memory_note_candidate_sources), but that tagging was only ever consumed as
+ * a ranking input (memory_source_fusion_bonus). Nothing recorded whether a lane's
+ * contribution SURVIVED ranking, so a lane that produces candidates on every
+ * query and never places one in the served set is indistinguishable from a lane
+ * that carries the answer.
+ *
+ * This is measurement, not control: no lane is skipped, reordered, or truncated
+ * on the strength of these counters. It exists so that a decision to drop a lane
+ * can be made from evidence about this corpus, the way the reranker's removal
+ * was. Deciding sufficiency mid-collection would need the lanes to be ordered by
+ * expected yield relative to each other, and they are not.
+ *
+ * `served` is the count the caller is about to hand back; rows beyond it were
+ * ranked and dropped, and are counted only as candidates.
+ */
+void memory_record_lane_outcome_metrics(const memory_query_plan_t *plan, const memory_t *matches,
+                                        int served, const memory_candidate_source_t *source_stats,
+                                        int source_stats_count)
+{
+   char key[160];
+   int candidates[MEMORY_LANE_COUNT];
+   int wins[MEMORY_LANE_COUNT];
+   const char *route_name = plan ? memory_query_route_name(plan->route) : NULL;
+
+   if (!source_stats || source_stats_count <= 0)
+      return;
+   if (served < 0)
+      served = 0;
+
+   for (int lane = 0; lane < MEMORY_LANE_COUNT; lane++)
+   {
+      candidates[lane] = 0;
+      wins[lane] = 0;
+   }
+
+   for (int i = 0; i < source_stats_count; i++)
+   {
+      unsigned int mask = source_stats[i].source_mask;
+      for (int lane = 0; lane < MEMORY_LANE_COUNT; lane++)
+      {
+         if (mask & (1u << lane))
+            candidates[lane]++;
+      }
+   }
+
+   if (matches)
+   {
+      for (int i = 0; i < served; i++)
+      {
+         unsigned int mask =
+             memory_lane_mask_for(source_stats, source_stats_count, matches[i].id);
+         for (int lane = 0; lane < MEMORY_LANE_COUNT; lane++)
+         {
+            if (mask & (1u << lane))
+               wins[lane]++;
+         }
+      }
+   }
+
+   for (int lane = 0; lane < MEMORY_LANE_COUNT; lane++)
+   {
+      if (!memory_lane_names[lane] || candidates[lane] == 0)
+         continue;
+      snprintf(key, sizeof(key), "memory.query.lane.%s.candidates", memory_lane_names[lane]);
+      memory_runtime_state_increment(key, candidates[lane]);
+      snprintf(key, sizeof(key), "memory.query.lane.%s.served", memory_lane_names[lane]);
+      memory_runtime_state_increment(key, wins[lane]);
+      /* A lane that contributed candidates and placed none is the shape worth
+       * counting on its own: summing served==0 across queries is what tells a
+       * lane apart from one that merely ranks low. */
+      if (wins[lane] == 0)
+      {
+         snprintf(key, sizeof(key), "memory.query.lane.%s.shutout", memory_lane_names[lane]);
+         memory_runtime_state_increment(key, 1);
+      }
+      if (route_name)
+      {
+         snprintf(key, sizeof(key), "memory.query.route.%s.lane.%s.served", route_name,
+                  memory_lane_names[lane]);
+         memory_runtime_state_increment(key, wins[lane]);
+      }
+   }
+}
+
 void memory_record_query_stage_metric(const memory_query_plan_t *plan, const char *stage_name)
 {
    char key[128];

--- a/src/modules/memory/memory_core_search_b.c
+++ b/src/modules/memory/memory_core_search_b.c
@@ -773,8 +773,7 @@ void memory_record_lane_outcome_metrics(const memory_query_plan_t *plan, const m
    {
       for (int i = 0; i < served; i++)
       {
-         unsigned int mask =
-             memory_lane_mask_for(source_stats, source_stats_count, matches[i].id);
+         unsigned int mask = memory_lane_mask_for(source_stats, source_stats_count, matches[i].id);
          for (int lane = 0; lane < MEMORY_LANE_COUNT; lane++)
          {
             if (mask & (1u << lane))

--- a/src/modules/memory/memory_core_search_c.c
+++ b/src/modules/memory/memory_core_search_c.c
@@ -960,6 +960,8 @@ static int memory_find_facts_scoped_impl(const char *query, const char *scope_ty
                                  config_memory_recall_lanes_floor_fact(), eff);
       }
    }
+   memory_record_lane_outcome_metrics(&plan, candidates, reranked, source_stats,
+                                      source_stats_count);
    for (int i = 0; i < reranked; i++)
       out[i] = candidates[i];
 
@@ -1165,6 +1167,8 @@ int memory_find_facts_visible_ex(const char *query, const char *workspace, const
     * Re-apply the hard scope order last so relevance features can only move
     * candidates within their scope bucket. */
    memory_sort_scope_buckets(candidates, ranked_count, scope_rank);
+   memory_record_lane_outcome_metrics(&plan, candidates, reranked, source_stats,
+                                      source_stats_count);
    for (int i = 0; i < reranked; i++)
       out[i] = candidates[i];
    clock_gettime(CLOCK_MONOTONIC, &ts1);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -307,6 +307,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-memory-redi
                $(TESTPREFIX)/unit-test-entity-nodes \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
                $(TESTPREFIX)/unit-test-memory-lanes \
+               $(TESTPREFIX)/unit-test-memory-lane-outcome \
                $(TESTPREFIX)/unit-test-workspace \
                $(TESTPREFIX)/unit-test-cross-repo-deps \
                $(TESTPREFIX)/unit-test-cross-repo-stats \
@@ -1926,6 +1927,9 @@ $(TESTPREFIX)/unit-test-memory-ranker-boundary: $(OBJDIR)/tests/test_memory_rank
 
 $(TESTPREFIX)/unit-test-memory-lanes: $(OBJDIR)/tests/test_memory_lanes.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-memory-lane-outcome: $(OBJDIR)/tests/test_memory_lane_outcome.o $(TEST_DATA_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 $(TESTPREFIX)/unit-test-workspace: $(OBJDIR)/tests/test_workspace.o \
                           $(OBJDIR)/worktree_gc.o \

--- a/src/tests/test_memory_lane_outcome.c
+++ b/src/tests/test_memory_lane_outcome.c
@@ -1,0 +1,183 @@
+/* test_memory_lane_outcome.c — unit tests for per-lane recall outcome metrics.
+ *
+ * What is tested:
+ *   memory_record_lane_outcome_metrics() attributes the SERVED window back to
+ *   the lanes that produced it, so a lane that contributes candidates on every
+ *   query and never places one can be told apart from a lane that carries the
+ *   answer. The counters are measurement only: nothing in the recall path reads
+ *   them back, and this test asserts the arithmetic, not a control decision.
+ *
+ *   - a lane's candidates are counted once per tagged row;
+ *   - `served` counts only rows inside the served window, not the ranked tail;
+ *   - a row tagged with two lanes counts for both;
+ *   - a lane that contributed and placed nothing raises exactly one shutout;
+ *   - a lane with no candidates emits no keys at all;
+ *   - the route-qualified key appears only when a plan is supplied.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "aimee.h"
+#include "modules/memory/memory_core_internal.h"
+
+/* Capture sink for the runtime counters. db1_runtime_state_add_int is declared
+ * `#pragma weak`, so defining it here binds memory_runtime_state_increment to
+ * this test rather than to a live DB1. */
+#define CAPTURE_MAX 64
+
+static struct
+{
+   char key[160];
+   int total;
+} s_captured[CAPTURE_MAX];
+static int s_captured_count;
+
+int db1_runtime_state_add_int(const char *key, int delta, int *new_value_out);
+
+int db1_runtime_state_add_int(const char *key, int delta, int *new_value_out)
+{
+   (void)new_value_out;
+   for (int i = 0; i < s_captured_count; i++)
+   {
+      if (strcmp(s_captured[i].key, key) == 0)
+      {
+         s_captured[i].total += delta;
+         return 0;
+      }
+   }
+   assert(s_captured_count < CAPTURE_MAX);
+   snprintf(s_captured[s_captured_count].key, sizeof(s_captured[0].key), "%s", key);
+   s_captured[s_captured_count].total = delta;
+   s_captured_count++;
+   return 0;
+}
+
+static void reset_capture(void)
+{
+   s_captured_count = 0;
+   memset(s_captured, 0, sizeof(s_captured));
+}
+
+/* -1 when the key was never emitted, which is distinct from an emitted zero. */
+static int captured(const char *key)
+{
+   for (int i = 0; i < s_captured_count; i++)
+      if (strcmp(s_captured[i].key, key) == 0)
+         return s_captured[i].total;
+   return -1;
+}
+
+static void test_served_window_attributed_to_lanes(void)
+{
+   reset_capture();
+
+   /* Four candidates. 1 and 2 are served; 3 and 4 were ranked and dropped.
+    * Row 2 carries two lanes, so it counts for both. The graph lane produced
+    * only row 4, which did not survive. */
+   memory_t matches[4];
+   memset(matches, 0, sizeof(matches));
+   matches[0].id = 1;
+   matches[1].id = 2;
+   matches[2].id = 3;
+   matches[3].id = 4;
+
+   memory_candidate_source_t stats[4] = {
+       {1, MEM_SOURCE_SEMANTIC},
+       {2, MEM_SOURCE_SEMANTIC | MEM_SOURCE_LEXICAL},
+       {3, MEM_SOURCE_LEXICAL},
+       {4, MEM_SOURCE_GRAPH},
+   };
+
+   memory_query_plan_t plan;
+   memset(&plan, 0, sizeof(plan));
+   plan.route = MEM_ROUTE_HYBRID;
+
+   memory_record_lane_outcome_metrics(&plan, matches, 2, stats, 4);
+
+   assert(captured("memory.query.lane.semantic.candidates") == 2);
+   assert(captured("memory.query.lane.semantic.served") == 2);
+   assert(captured("memory.query.lane.lexical.candidates") == 2);
+   /* Row 2 is served and row 3 is not, so lexical places exactly one. */
+   assert(captured("memory.query.lane.lexical.served") == 1);
+   assert(captured("memory.query.lane.graph.candidates") == 1);
+   assert(captured("memory.query.lane.graph.served") == 0);
+
+   /* Only the lane that placed nothing raises a shutout. */
+   assert(captured("memory.query.lane.graph.shutout") == 1);
+   assert(captured("memory.query.lane.semantic.shutout") == -1);
+   assert(captured("memory.query.lane.lexical.shutout") == -1);
+
+   /* A lane with no candidates is silent rather than reported as zero. */
+   assert(captured("memory.query.lane.alias.candidates") == -1);
+   assert(captured("memory.query.lane.alias.served") == -1);
+
+   assert(captured("memory.query.route.hybrid.lane.semantic.served") == 2);
+   assert(captured("memory.query.route.hybrid.lane.graph.served") == 0);
+
+   printf("  served window attributed to lanes: ok\n");
+}
+
+static void test_no_plan_omits_route_key(void)
+{
+   reset_capture();
+
+   memory_t matches[1];
+   memset(matches, 0, sizeof(matches));
+   matches[0].id = 7;
+   memory_candidate_source_t stats[1] = {{7, MEM_SOURCE_UNIT}};
+
+   memory_record_lane_outcome_metrics(NULL, matches, 1, stats, 1);
+
+   assert(captured("memory.query.lane.unit.served") == 1);
+   assert(captured("memory.query.route.hybrid.lane.unit.served") == -1);
+
+   printf("  route key omitted without a plan: ok\n");
+}
+
+static void test_empty_and_degenerate_inputs(void)
+{
+   reset_capture();
+   memory_t matches[1];
+   memset(matches, 0, sizeof(matches));
+   matches[0].id = 1;
+   memory_candidate_source_t stats[1] = {{1, MEM_SOURCE_LEXICAL}};
+
+   /* No stats: nothing to attribute, so nothing is emitted. */
+   memory_record_lane_outcome_metrics(NULL, matches, 1, NULL, 0);
+   assert(s_captured_count == 0);
+   memory_record_lane_outcome_metrics(NULL, matches, 1, stats, 0);
+   assert(s_captured_count == 0);
+
+   /* A served count of zero still records the candidates, and the shutout. */
+   memory_record_lane_outcome_metrics(NULL, matches, 0, stats, 1);
+   assert(captured("memory.query.lane.lexical.candidates") == 1);
+   assert(captured("memory.query.lane.lexical.served") == 0);
+   assert(captured("memory.query.lane.lexical.shutout") == 1);
+
+   /* A negative served count is clamped rather than read off the end. */
+   reset_capture();
+   memory_record_lane_outcome_metrics(NULL, matches, -3, stats, 1);
+   assert(captured("memory.query.lane.lexical.served") == 0);
+
+   /* A NULL match array still accounts for the candidates it was told about. */
+   reset_capture();
+   memory_record_lane_outcome_metrics(NULL, NULL, 5, stats, 1);
+   assert(captured("memory.query.lane.lexical.candidates") == 1);
+   assert(captured("memory.query.lane.lexical.served") == 0);
+
+   printf("  empty and degenerate inputs: ok\n");
+}
+
+int main(void)
+{
+   printf("test_memory_lane_outcome\n");
+   test_served_window_attributed_to_lanes();
+   test_no_plan_omits_route_key();
+   test_empty_and_degenerate_inputs();
+   printf("test_memory_lane_outcome: ok\n");
+   return 0;
+}


### PR DESCRIPTION
Two instruments, no behaviour change. Neither commit alters a ranking, a lane, or a score.

The shared idea is making something implicit into something recorded, so a later decision can be made from evidence rather than memory.

## `feat(memory)`: per-lane recall outcomes

Every recall candidate is already tagged with the lane that produced it, and that tagging fed exactly one consumer — the multi-source fusion bonus. Nothing recorded whether a lane's contribution *survived* ranking, so a lane that contributes on every query and never places a row looks identical to one carrying the answer.

`memory_record_lane_outcome_metrics()` runs once ranking has fixed the order and lane floors have applied:

| Counter | Meaning |
| --- | --- |
| `memory.query.lane.<lane>.candidates` | rows the lane contributed |
| `memory.query.lane.<lane>.served` | of those, how many are in the returned window |
| `memory.query.lane.<lane>.shutout` | queries where it contributed and placed nothing |
| `memory.query.route.<route>.lane.<lane>.served` | the same, split by route |

A lane that contributed nothing emits no counters, so a silent lane and a losing lane are not summed together.

**Measurement, not control.** No lane is skipped, reordered, or truncated on these counters, and no recall decision reads them back. An early stop would need the lanes ordered by expected yield relative to each other, and they are not — candidate volume is not evidence that the lane holding the answer has already run. The counters exist so a decision to drop a lane can be made the way the reranker's removal was.

## `feat(benchmarks)`: run coverage

A subsampled run and a full run produce byte-identical result files, so a score from a short run can be read back as a reproduction of a long one. On record: reranking measured **+0.020** on a 600-question subsample and **−0.0048** on the full 10,000 — a sign flip — and the recommendation was nearly shipped on the subsample.

Result payloads now carry a `coverage` block naming the caps in force and what actually ran.

Validation stays lenient, eligibility is strict. Existing result files keep validating; `require_complete_run` refuses both a capped run and one with no coverage at all, because an unknown question count is not evidence of a full run. `validate_coverage` also rejects a `complete` flag contradicting its own limits.

`verify_scores.py` prints coverage for every file and gains `--require-complete`, opt-in rather than default: enabling it refuses every result file currently in `benchmarks/results/`, and when to take that step is a baseline-eligibility call rather than a code one.

Wired through all eleven producers, not just the one that prompted it.

## Verification

- `make all` clean under `-Werror`; `make docs-gen-check` ok, no generated churn
- `unit-test-memory-lane-outcome` (new, links the real function via the weak `db1_runtime_state_add_int`), `unit-test-memory-lanes`, `unit-test-memory-filter` pass
- 49 benchmark tests pass, including 7 new coverage tests
- `verify_scores.py` exercised against a real result file in all three states: unrecorded → refused under the flag, complete → passes, partial → refused