### PR TITLE
fix(server): classify read route errors

### DIFF
--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -560,10 +560,11 @@ int handle_agent_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
        * (unreadable, malformed, truncated) is a real fault and names the file. */
       const char *path = agent_config_path();
       if (path && access(path, F_OK) != 0)
-         return server_send_error(conn,
-                                  "no agents are configured yet: choose a provider in the setup "
-                                  "wizard, or run `aimee provider list --available`",
-                                  NULL);
+         return server_send_error_kind(
+             conn, SERVER_ERR_NOT_FOUND,
+             "no agents are configured yet: choose a provider in the setup "
+             "wizard, or run `aimee provider list --available`",
+             NULL);
       /* The file is there and the load still failed: unreadable, malformed, or
        * truncated. Deliberately no strerror() — reaching here means access() SUCCEEDED,
        * so errno carries nothing about this failure and printing it invents a cause. */
@@ -572,7 +573,7 @@ int handle_agent_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                "agent configuration at %s exists but could not be loaded; "
                "check that it is readable and valid JSON",
                path ? path : "?");
-      return server_send_error(conn, msg, NULL);
+      return server_send_error_kind(conn, SERVER_ERR_UNAVAILABLE, msg, NULL);
    }
    cJSON *resp = jo_ok();
    cJSON *arr = cJSON_CreateArray();
@@ -978,7 +979,8 @@ int handle_agent_local(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (!name || !name[0])
       name = "local";
    if (!endpoint_arg || !endpoint_arg[0])
-      return server_send_error(conn, "model.local requires endpoint", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "model.local requires endpoint", NULL);
 
    char endpoint[MAX_ENDPOINT_LEN];
    server_agent_normalize_endpoint(endpoint_arg, endpoint, sizeof(endpoint));
@@ -1008,7 +1010,8 @@ int handle_agent_local(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                                      sizeof(slot_probe_msg));
    }
    if (!model[0])
-      return server_send_error(conn, "model.local could not determine model; pass --model", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "model.local could not determine model; pass --model", NULL);
    if (slots <= 0 && detected_slots > 0)
       slots = detected_slots;
    if (slots <= 0)

--- a/src/server_provider.c
+++ b/src/server_provider.c
@@ -227,10 +227,11 @@ int handle_provider_show(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)ctx;
    cJSON *jname = cJSON_GetObjectItemCaseSensitive(req, "name");
    if (!cJSON_IsString(jname) || !jname->valuestring[0])
-      return server_send_error(conn, "provider name required", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT, "provider name required",
+                                    NULL);
    model_provider_t *p = model_provider_get(jname->valuestring);
    if (!p)
-      return server_send_error(conn, "provider not found", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_NOT_FOUND, "provider not found", NULL);
    cJSON *resp = cJSON_CreateObject();
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddItemToObject(resp, "provider", server_provider_json(p));
@@ -244,16 +245,18 @@ int handle_provider_models(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)ctx;
    cJSON *jname = cJSON_GetObjectItemCaseSensitive(req, "name");
    if (!cJSON_IsString(jname) || !jname->valuestring[0])
-      return server_send_error(conn, "provider name required", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT, "provider name required",
+                                    NULL);
    model_provider_t *p = model_provider_get(jname->valuestring);
    if (!p)
-      return server_send_error(conn, "provider not found", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_NOT_FOUND, "provider not found", NULL);
    if (!p->fetch_models)
-      return server_send_error(conn, "provider does not support model listing", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT,
+                                    "provider does not support model listing", NULL);
    provider_model_t *models = NULL;
    int n = 0;
    if (server_provider_models_cached(p, &models, &n) != 0)
-      return server_send_error(conn, "failed to fetch models", NULL);
+      return server_send_error_kind(conn, SERVER_ERR_UNAVAILABLE, "failed to fetch models", NULL);
 
    cJSON *resp = cJSON_CreateObject();
    cJSON_AddStringToObject(resp, "status", "ok");
@@ -466,14 +469,16 @@ int handle_model_show(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    {
       if (!model_capability_resolve_ref(name, resolved_provider, sizeof(resolved_provider),
                                         resolved_model, sizeof(resolved_model), &cap))
-         return server_send_error(conn, "model capability lookup failed", NULL);
+         return server_send_error_kind(conn, SERVER_ERR_NOT_FOUND, "model capability lookup failed",
+                                       NULL);
    }
    else
    {
       if (!model || !model[0])
-         return server_send_error(conn, "model required", NULL);
+         return server_send_error_kind(conn, SERVER_ERR_INVALID_ARGUMENT, "model required", NULL);
       if (!model_capability_get(provider, model, &cap))
-         return server_send_error(conn, "model capability metadata not found", NULL);
+         return server_send_error_kind(conn, SERVER_ERR_NOT_FOUND,
+                                       "model capability metadata not found", NULL);
    }
 
    cJSON *resp = cJSON_CreateObject();

--- a/src/tests/test_agent_list_handler.c
+++ b/src/tests/test_agent_list_handler.c
@@ -179,6 +179,7 @@ static void reset_capture(void)
       cJSON_Delete(g_last_response);
    g_last_response = NULL;
    g_last_error[0] = '\0';
+   g_last_error_kind[0] = '\0';
    g_cli_calls = g_http_calls = g_execute_failure = 0;
    memset(&g_executed_agent, 0, sizeof(g_executed_agent));
 }
@@ -211,7 +212,36 @@ static void test_load_failure_is_an_error_not_empty(void)
    /* Must NOT be a silent success with an empty roster. */
    assert(g_last_response == NULL);
    assert(g_last_error[0] != '\0');
+   assert(strcmp(g_last_error_kind, SERVER_ERR_NOT_FOUND) == 0);
    printf("  PASS: a config load failure returns an error, not an empty roster\n");
+}
+
+static void test_malformed_config_is_unavailable(void)
+{
+   set_home_empty();
+   write_agents("{not-json");
+   reset_capture();
+
+   assert(handle_agent_list(NULL, NULL, NULL) == 0);
+
+   assert(g_last_response == NULL);
+   assert(strstr(g_last_error, "could not be loaded") != NULL);
+   assert(strcmp(g_last_error_kind, SERVER_ERR_UNAVAILABLE) == 0);
+   printf("  PASS: a malformed existing config is unavailable, not an upstream 502\n");
+}
+
+static void test_local_requires_endpoint_as_invalid_argument(void)
+{
+   set_home_empty();
+   reset_capture();
+   cJSON *req = cJSON_CreateObject();
+
+   assert(handle_agent_local(NULL, NULL, req) == 0);
+
+   cJSON_Delete(req);
+   assert(strcmp(g_last_error, "model.local requires endpoint") == 0);
+   assert(strcmp(g_last_error_kind, SERVER_ERR_INVALID_ARGUMENT) == 0);
+   printf("  PASS: model.local missing endpoint is an invalid argument\n");
 }
 
 static void test_empty_config_is_ok_with_empty_array(void)
@@ -736,6 +766,8 @@ int main(void)
 {
    printf("agent_list_handler:\n");
    test_load_failure_is_an_error_not_empty();
+   test_malformed_config_is_unavailable();
+   test_local_requires_endpoint_as_invalid_argument();
    test_empty_config_is_ok_with_empty_array();
    test_populated_config_lists_agents();
    test_delegate_default_is_independent_and_persists();

--- a/src/tests/test_integration.sh
+++ b/src/tests/test_integration.sh
@@ -1209,6 +1209,25 @@ for r in (doc.get('marshal') or []):
 check_output "a served spec arrives with its fields" "capability,json,open_weights_only" \
     echo "$CATALOG_SPEC"
 
+# Read routes backed by the command dispatcher used to turn every handler error
+# into 502 Bad Gateway. Missing arguments and absent configuration are not
+# upstream transport failures: keep the typed kind in the envelope so the HTTP
+# bridge can return an actionable 4xx status and clients will not retry it.
+RESP=$(http_call GET /v1/model/local '{}') || true
+check_output "model.local missing endpoint stays typed" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call GET /v1/provider/models '{}') || true
+check_output "provider.models missing name stays typed" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call GET /v1/provider/models '{"name":"integ-no-such-provider"}') || true
+check_output "provider.models unknown provider stays typed" '"kind":"not_found"' echo "$RESP"
+
+RESP=$(http_call GET /v1/catalog/show '{}') || true
+check_output "catalog.show missing model stays typed" '"kind":"invalid_argument"' echo "$RESP"
+
+RESP=$(http_call GET /v1/agent/list '{}') || true
+check_output "agent.list absent config stays typed" '"kind":"not_found"' echo "$RESP"
+
 # ============================================================
 # 4. Session management
 # ============================================================


### PR DESCRIPTION
## Summary

- classify missing agent configuration as `not_found` and malformed configuration as `unavailable`
- classify agent/provider/catalog input failures as `invalid_argument`, absent resources as `not_found`, and provider fetch failures as `unavailable`
- preserve those typed errors through the command-dispatch HTTP bridge instead of emitting retryable 502 Bad Gateway responses
- add focused handler and full integration regression coverage

## Release-test discovery

A read-only sweep of all 100 exact GET routes on the published `:testing` container found eight 502 responses. Five were misclassified caller/configuration outcomes (`agent.list`, `model.list`, `model.local`, `provider.models`, and `catalog.show`); the dependency-backed sandbox and agents routes remain unchanged.

## Validation

- `make -C src all -j2`
- `src/build/obj/tests/unit-test-agent-list-handler`
- integration harness: 88/88 passed (69 topology-dependent skips)
- thin-client remote-exclusive post-check: passed in an isolated clone
- `make -C src aimee-home-check`
- `clang-format-19 --dry-run --Werror` on changed C files
- `bash -n src/tests/test_integration.sh`
- `git diff --check`