### PR TITLE
fix(compose): select bundled A25M embedder by default

### DIFF
--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -45,7 +45,10 @@ services:
       # MUST receive both: `aimee config deploy-env` emits them, and without them
       # reaching the container the entrypoint sees no selection, starts nothing, and
       # the builtin serves forever — the wizard's embedder silently never runs.
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}
+      # Keep the selection paired with the default bundled-image variant. The
+      # entrypoint intentionally refuses to guess a vector space, so an empty
+      # value makes the default image restart forever despite carrying A25M.
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-bekko-a25m}
       EMBEDDER_URL: ${EMBEDDER_URL:-}
       # Embedding dim — empty = config default 1024 (CPU tier); set 2560 for GPU.
       EMBEDDER_DIMS: ${EMBEDDER_DIMS:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,10 @@ services:
       # MUST receive both: `aimee config deploy-env` emits them, and without them
       # reaching the container the entrypoint sees no selection, starts nothing, and
       # the builtin serves forever — the wizard's embedder silently never runs.
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}
+      # Keep the selection paired with the default bundled-image variant. The
+      # entrypoint intentionally refuses to guess a vector space, so an empty
+      # value makes the default image restart forever despite carrying A25M.
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-bekko-a25m}
       EMBEDDER_URL: ${EMBEDDER_URL:-}
       # Embedding dim — empty = config default 384 (bundled bekko-a25m). Only set
       # it for an external embedder of a different width; changing it against a

--- a/scripts/check-kb-container-packaging.py
+++ b/scripts/check-kb-container-packaging.py
@@ -589,6 +589,30 @@ SHIPPED_COMPOSE_FILES = (
 )
 
 
+def bundled_embedder_default_failures(text: str) -> list[str]:
+    """Keep an image carrying A25M paired with an explicit A25M selection."""
+    if yaml is None:
+        return ["PyYAML is required to validate bundled embedder defaults"]
+    try:
+        model = yaml.load(text, Loader=UniqueKeySafeLoader)
+    except yaml.YAMLError as exc:
+        return [f"invalid Compose YAML: {exc.__class__.__name__}"]
+    services = model.get("services") if isinstance(model, dict) else None
+    service = services.get("aimee-kb") if isinstance(services, dict) else None
+    if not isinstance(service, dict):
+        return []
+    image = str(service.get("image", ""))
+    if "aimee-kb-a25m:" not in image:
+        return []
+    environment = service.get("environment")
+    selected = environment.get("EMBEDDER_MODEL") if isinstance(environment, dict) else None
+    if selected != "${EMBEDDER_MODEL:-bekko-a25m}":
+        return [
+            "defaults to aimee-kb-a25m but does not default EMBEDDER_MODEL to bekko-a25m"
+        ]
+    return []
+
+
 def empty_key_failures(text: str) -> list[str]:
     """Catch a service key that is present but null.
 
@@ -624,7 +648,10 @@ def check(root: Path) -> list[str]:
     for rel in SHIPPED_COMPOSE_FILES:
         path = root / rel
         if path.exists():
-            for failure in empty_key_failures(read(path)):
+            text = read(path)
+            for failure in empty_key_failures(text):
+                failures.append(f"{rel} {failure}")
+            for failure in bundled_embedder_default_failures(text):
                 failures.append(f"{rel} {failure}")
     dockerfile = root / "Dockerfile"
     compose = root / "compose.yaml"
@@ -803,9 +830,11 @@ def plant_test() -> int:
                     "    build:",
                     "      context: .",
                     "      dockerfile: Dockerfile",
+                    "    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-a25m:${AIMEE_IMAGE_TAG:-latest}}",
                     "    environment:",
                     "      AIMEE_HOME: /var/lib/aimee",
                     "      SYNTHESIS_ENDPOINT: ${SYNTHESIS_ENDPOINT:-}",
+                    "      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-bekko-a25m}",
                     "      AIMEE_KB_MTLS_HOST: aimee-kb",
                     '      AIMEE_KB_MTLS_PORT: "8745"',
                     "    ports:",
@@ -1082,6 +1111,17 @@ def plant_test() -> int:
             '      - "127.0.0.1:8741:8741"\n      - $KB_PORT:8741',
         ]
         safe_compose = read(root / "compose.server.yaml")
+        missing_embedder_default = safe_compose.replace(
+            "EMBEDDER_MODEL: ${EMBEDDER_MODEL:-bekko-a25m}",
+            "EMBEDDER_MODEL: ${EMBEDDER_MODEL:-}",
+            1,
+        )
+        if missing_embedder_default == safe_compose:
+            print("kb-container-packaging plant: embedder-default mutation did not apply", file=sys.stderr)
+            return 1
+        if not bundled_embedder_default_failures(missing_embedder_default):
+            print("kb-container-packaging plant: missed empty bundled embedder selection", file=sys.stderr)
+            return 1
         for bad in bad_publications:
             planted = safe_compose.replace('      - "127.0.0.1:8741:8741"', bad)
             if planted == safe_compose:


### PR DESCRIPTION
## What

Pair the default `aimee-kb-a25m` image with `EMBEDDER_MODEL=bekko-a25m` in both root Compose entrypoints, and enforce that invariant for every shipped Compose file.

## Release-blocking reproduction

On isolated release CT121, recreating the official split stack from published commit `6b8bbdc2` and `ghcr.io/rakuensoftware/aimee-kb-a25m:testing@sha256:0df2c059...` with no ambient embedder variable produced a restart loop:

```
aimee-kb: no embedder selected, and there is no fallback. Retrieval needs one.
aimee-kb: then re-run Deploy. Refusing to start.
```

The default image already carries A25M weights; the entrypoint deliberately requires an explicit vector-space selection. The shipped root Compose files selected the image but passed an empty model, unlike `deploy/compose/aimee.yaml`, which already keeps the pair together.

## Verification

- `python3 scripts/check-kb-container-packaging.py --root .`
- `python3 scripts/check-kb-container-packaging.py --root . --plant-test`
- Live official-image recreation proof will be posted from CT121.