### PR TITLE
fix(kb): stop the audit bus consumer pinning a DB2 pool connection

### DIFF
--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -347,6 +347,11 @@ static void *kbiw_timer_thread(void *arg)
       if (interval_secs <= 0)
          interval_secs = 6 * 3600;
 
+      /* Same reason as the watch thread, over a much longer wait: the enqueue
+       * above leases lazily, and this loop then sleeps out the whole ingest
+       * interval (six hours by default) with nothing to end the unit of work. */
+      db2_lease_release_idle();
+
       int slept = 0;
       while (slept < interval_secs)
       {
@@ -431,6 +436,13 @@ static void *kbiw_watch_thread(void *arg)
    char evbuf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
    while (!ctx->ingest_stop)
    {
+      /* Let go before waiting for the next filesystem event. The enqueue below
+       * leases a pooled DB2 connection lazily and this thread has no unit of
+       * work to end, so without this it kept the connection across an idle
+       * watch -- which on a quiet tree is the whole life of the process, and
+       * the pool reaper reports it as a stuck lease. Releasing here costs one
+       * re-acquire per burst of edits, not per event. */
+      db2_lease_release_idle();
       struct pollfd pfd = {.fd = ifd, .events = POLLIN};
       if (poll(&pfd, 1, 1000) <= 0)
          continue;

--- a/src/kb/kb_obs_bus_adapter.c
+++ b/src/kb/kb_obs_bus_adapter.c
@@ -4,6 +4,7 @@
 #include <aimee/audit/obs_bus.h>
 
 #include "modules/db2/c/kb_audit_worm.h"
+#include "modules/db2/c/db2.h" /* db2_lease_release_idle */
 
 static int persist_durable(const char *actor_role, const char *actor_principal, const char *action,
                            const char *subject, const char *verdict, const char *detail, void *ctx)
@@ -12,7 +13,20 @@ static int persist_durable(const char *actor_role, const char *actor_principal, 
    return db2_kb_audit_append(actor_role, actor_principal, action, subject, verdict, detail);
 }
 
+/* db2_kb_audit_append leases a pooled DB2 connection lazily, and the bus
+ * consumer thread never ends a unit of work, so the lease outlived every burst
+ * and pinned one pool member until the process exited. Handing the release back
+ * on the bus's idle edge returns the connection between bursts while keeping it
+ * for the duration of one. */
+static void release_idle_lease(void *ctx)
+{
+   (void)ctx;
+   db2_lease_release_idle();
+}
+
 int kb_obs_bus_configure(void)
 {
-   return obs_bus_set_durable_sink(persist_durable, NULL);
+   if (obs_bus_set_durable_sink(persist_durable, NULL) != 0)
+      return -1;
+   return obs_bus_set_sink_idle_hook(release_idle_lease, NULL);
 }

--- a/src/modules/audit/include/aimee/audit/obs_bus.h
+++ b/src/modules/audit/include/aimee/audit/obs_bus.h
@@ -82,6 +82,16 @@ extern "C"
     * running is refused. */
    int obs_bus_set_durable_sink(obs_bus_durable_sink_fn sink, void *ctx);
 
+   /* Called on the consumer thread each time the bus goes idle, before it naps.
+    * A durable sink that holds a per-thread resource uses this to let go of it
+    * between bursts: aimee-kb's WORM append lazily leases a pooled DB2
+    * connection, and without this hook that lease is held for the life of the
+    * process, because the consumer thread never ends a unit of work. obs_bus
+    * stays storage-neutral -- it only says "idle now" and the adapter decides
+    * what that costs. Optional; leaving it unset is a no-op. */
+   typedef void (*obs_bus_sink_idle_fn)(void *ctx);
+   int obs_bus_set_sink_idle_hook(obs_bus_sink_idle_fn hook, void *ctx);
+
    /* Commit one action-class record synchronously to the daemon's WORM sink.
     * This is the durability edge for security-relevant bridges whose ordinary
     * ACTION event is intentionally asynchronous.  Returns 0 only after the

--- a/src/modules/audit/obs_bus.c
+++ b/src/modules/audit/obs_bus.c
@@ -215,6 +215,8 @@ static struct
    void *guardrail_ctx;
    obs_bus_durable_sink_fn durable;
    void *durable_ctx;
+   obs_bus_sink_idle_fn sink_idle;
+   void *sink_idle_ctx;
    char module_socket[108];
    char module_policy_dir[4096];
    char capture_fault[24]; /* deterministic unit-test seam; empty in production */
@@ -906,6 +908,15 @@ static void *consumer_main(void *arg)
          capture_flush();
       if (n == 0 && routed == 0)
       {
+         /* Idle: let the sink drop anything it is holding per-thread before we
+          * sleep. The KB's WORM append leases a pooled DB2 connection lazily and
+          * nothing in this loop ever ends a unit of work, so without this the
+          * consumer pinned one pool member from its first durable row until
+          * process exit -- the pool reaper reported it as a stuck lease held for
+          * the whole uptime. Only on the idle path: during a burst the lease is
+          * worth keeping, and this is exactly where the burst has ended. */
+         if (sinks.sink_idle)
+            sinks.sink_idle(sinks.sink_idle_ctx);
          struct timespec nap = {.tv_sec = 0, .tv_nsec = nap_ns};
          nanosleep(&nap, NULL);
          if (nap_ns < nap_max_ns)
@@ -1624,6 +1635,20 @@ int obs_bus_set_durable_sink(obs_bus_durable_sink_fn sink, void *ctx)
    }
    sinks.durable = sink;
    sinks.durable_ctx = sink ? ctx : NULL;
+   pthread_mutex_unlock(&start_lock);
+   return 0;
+}
+
+int obs_bus_set_sink_idle_hook(obs_bus_sink_idle_fn hook, void *ctx)
+{
+   pthread_mutex_lock(&start_lock);
+   if (g.started)
+   {
+      pthread_mutex_unlock(&start_lock);
+      return -1;
+   }
+   sinks.sink_idle = hook;
+   sinks.sink_idle_ctx = hook ? ctx : NULL;
    pthread_mutex_unlock(&start_lock);
    return 0;
 }

--- a/src/tests/test_bus_audit_durability.c
+++ b/src/tests/test_bus_audit_durability.c
@@ -19,7 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdatomic.h>
 #include <time.h>
+#include <unistd.h>
 
 #include <aimee/audit/obs_bus.h>
 #include <aimee/audit/audit_ledger.h>
@@ -30,6 +32,20 @@
 #define N 5000
 
 static int worm_commits;
+
+/* The consumer thread never ends a unit of work, so a durable sink that takes a
+ * per-thread resource on first use holds it until the process exits. That is not
+ * hypothetical: aimee-kb's WORM append leases a pooled DB2 connection lazily, and
+ * it pinned one of sixteen pool members from the first audit row onward, which
+ * the pool reaper reported as a stuck lease held for the whole uptime. The bus
+ * hands the sink an idle edge to let go on; this counts it. */
+static _Atomic int idle_calls;
+
+static void count_idle(void *ctx)
+{
+   (void)ctx;
+   atomic_fetch_add(&idle_calls, 1);
+}
 
 static int test_worm_sink(const char *actor_role, const char *actor_principal, const char *action,
                           const char *subject, const char *verdict, const char *detail, void *ctx)
@@ -90,6 +106,7 @@ int main(void)
                                 "allow", 17) == 0);
    assert(worm_commits == 1);
    assert(obs_bus_set_durable_sink(NULL, NULL) == 0);
+   assert(obs_bus_set_sink_idle_hook(count_idle, NULL) == 0);
 
    if (obs_bus_start() != 0)
    {
@@ -120,6 +137,24 @@ int main(void)
       obs_bus_emit("primary", tool, hash, "cd ; rm", "approve", "read_before_write", "block", i);
       emit_ns[i] = now_ns() - s;
    }
+
+   /* Once the backlog is drained the consumer must reach its idle edge and tell
+    * the sink so, repeatedly -- not once at startup. Poll rather than sleep a
+    * fixed span: the consumer naps 200us and backs off to 5ms, so this settles
+    * in milliseconds and the bound only exists so a broken build fails instead
+    * of hanging. */
+   int first_idle = 0;
+   for (int i = 0; i < 2000 && (first_idle = atomic_load(&idle_calls)) == 0; i++)
+      usleep(1000);
+   assert(first_idle > 0);
+   for (int i = 0; i < 2000 && atomic_load(&idle_calls) <= first_idle; i++)
+      usleep(1000);
+   assert(atomic_load(&idle_calls) > first_idle);
+   printf("  sink idle edge fired %d time(s) while idle\n", atomic_load(&idle_calls));
+
+   /* Reconfiguration while running is refused, for the idle hook as for the
+    * sinks it accompanies. */
+   assert(obs_bus_set_sink_idle_hook(NULL, NULL) == -1);
 
    /* Stop drains every in-flight row before returning. */
    obs_bus_stop();

--- a/tests/baselines/db2/declarations-v1.json
+++ b/tests/baselines/db2/declarations-v1.json
@@ -14762,6 +14762,7 @@
         "src/kb/kb_ingest_workers.c",
         "src/kb/kb_main.c",
         "src/kb/kb_memory_facts.c",
+        "src/kb/kb_obs_bus_adapter.c",
         "src/kb/kb_reflection.c",
         "src/kb/kb_service_code_embed.c",
         "src/kb/kb_service_workers.c",
@@ -27113,7 +27114,7 @@
     }
   ],
   "declarations_complete": false,
-  "fingerprint": "bc377b05cba86b6e89d7b2ad294bd3f65383cfeb84b31abdf23de64ff6995270",
+  "fingerprint": "db0cec3312cf0d9e20aae5960b5e26996166cda9610dda16cf2f99b1ae8e8dae",
   "module": "db2",
   "schema_version": 1,
   "summary": {


### PR DESCRIPTION
## The leak

The KB permanently loses one of its sixteen DB2 pool connections, from the first audit row it writes until the process exits. The pool's own reaper says so every thirty seconds, with the hold time tracking uptime:

```
db2.pool: member 0 leased 779902ms (> 300000ms ceiling)
  by unattributed — missed lease_end?
```

Reproduced on a clean container running the stock `:testing` image, so it is not workload-specific.

## Cause

`db2_conn()` leases lazily and caches the connection in a thread-local, so a thread that acquires once outside a `db2_lease_begin`/`_end` scope holds a pool member until it exits or calls `db2_lease_release_idle`. Every other long-lived KB worker calls one of those at a job boundary.

The `obs_bus` consumer thread does not, because it has no notion of a job — it pumps, drains, and naps forever. Its durable sink is aimee-kb's WORM append, which reaches `db2_kb_audit_append` and takes the lease on first use.

## Fix

`obs_bus` cannot release it itself: it is storage-neutral by design and the sink is injected per daemon (SQLite in the server, PostgreSQL in the KB). So the bus now exposes the one thing only it knows — when the flow goes idle — and the KB adapter decides what that costs.

The hook fires only on the idle edge, so a burst still runs on a single lease and pays nothing extra. The server adapter needs no hook: its WORM append is SQLite and its guardrail sink is DB1, neither of which uses the DB2 pool.

## How it was found

By instrumenting a live KB, not by reading. A temporary trace of every lazy acquire and every release, keyed by thread, showed **exactly one thread with an unmatched acquire**, and its backtrace named the path:

```
consumer_main → bus_host_pump → governance_tap
  → persist_or_queue_durable → persist_durable → db2_kb_audit_append
```

I had previously guessed a different thread and was wrong; the trace is what disproved it, and I did not ship that guess.

## Verification

On the same container, with the fix:

- **zero** stuck-lease reports after eight minutes, where the same image logged one every thirty seconds from startup;
- the trace shows that thread completing **three acquire/release cycles**, so it releases and then re-acquires correctly for later rows rather than losing the connection. Release resolves to `consumer_main` (the new hook), acquire to `db2_kb_audit_append`.

`make lint` passes all 76 checks. The DB2 declaration ledger is regenerated for the one new consumer entry this adds.

## Test

`test_bus_audit_durability` now asserts the invariant that prevents the leak: once the backlog drains, the consumer reaches its idle edge and keeps telling the sink so. It also pins that reconfiguration while running is refused, matching the sinks it accompanies.

It **fails with the hook call removed** (`Assertion 'first_idle > 0' failed`), and the file's existing durability invariants still hold alongside it (5000 rows, each exactly once, zero drops).