### PR TITLE
fix: two argument-shape defects — IPv6 transition SSRF bypass, and authorize-versus-execute divergence

### DIFF
--- a/docs/architecture/langgraph-module.md
+++ b/docs/architecture/langgraph-module.md
@@ -1,0 +1,126 @@
+# LangGraph module contract
+
+Design for the Python module proposed in
+[langgraph-module-with-memory-and-delegate-interop](../proposals/pending/langgraph-module-with-memory-and-delegate-interop.md).
+The proposal argues for it; this page is the contract someone would build
+against. Nothing here is implemented yet, and the event kinds below are
+derivations, not allocations.
+
+## Boundary
+
+The module owns graph definition, graph execution, and the translation between a
+LangGraph node and a bus call.
+
+It owns no authorization, credential, workspace, worktree, storage or audit
+path. Every governed action is a bus call to the module that owns it, and the
+answer, including a refusal, is returned to the node unchanged.
+
+## Principal and event kinds
+
+A ref is allocated in `tests/baselines/modules/canonical-inventory.yaml` under
+`principal_refs` and added to `retired_principal_refs` if the module is ever
+removed. Event kinds derive from it as `4096 + ref*256 + stage`; they are not
+chosen.
+
+The module serves one stage. A graph run is a request in and a bounded result
+out, so a second stage would only split what callers already treat as one
+operation.
+
+| Stage | Purpose |
+|---|---|
+| `run` (stage 1) | Execute a named graph against a payload, return the result and a per-node trace. |
+
+Everything else the module does is outbound: it consumes other modules' stages
+rather than serving more of its own.
+
+## Stages the module consumes
+
+| Module | Event | Used for |
+|---|---|---|
+| `memory` | `retrieve` 5892 | Node recall. Returns the PII sensitivity tier per relation; a node cannot bypass it by not asking. |
+| `memory` | `reranking` 5893 | The `high`/`medium`/`low` confidence band attached to recalled context. |
+| `memory` | `write` 5890 | Node fact writes. The typed-fact gate decides whether a candidate triple may commit as a semantic edge. |
+| `memory` | `embedding` 5891 | Only if a graph needs its own vectors. Most will not; recall covers the common path. |
+| `delegates` | `delegate-invocation` (v2) | A node that dispatches a bounded delegate turn and returns its result. |
+
+`extract_index` 5889 is deliberately absent. Extraction is the curator's job on
+the turn stream, not something a graph node should trigger.
+
+## Failure semantics the module inherits
+
+These are chosen per seam by the owning module and the node sees them as errors,
+never as empty success.
+
+| Seam | On failure |
+|---|---|
+| `write` 5890 | Defers. Nothing is written and the caller may retry. A node must not treat a deferral as a successful write. |
+| `retrieve` 5892 | Fails closed. Recall withholds rather than exposes. |
+| `reranking` 5893 | No local substitution. A missing tier means the context envelope is omitted and the absence is logged, not that the tier is `low`. |
+| `delegate-invocation` | A malformed handoff is a verdict, not a transport failure. |
+
+A node that swallows any of these and continues is the module's bug, not the
+seam's. Surface them.
+
+## State
+
+Two stores, and the split is load-bearing.
+
+**Resumption state** is mechanical: `lifecycle_work_item` when the run is a work
+item, LangGraph's own checkpointer otherwise. Messages, node outputs and pending
+writes live here.
+
+**Memory** is a node capability, not the checkpointer. Routing checkpoints
+through `write` 5890 asks a gate that decides what may commit as a semantic edge
+to adjudicate transcript noise at every superstep. It will refuse most of it,
+correctly, and the refusals carry no signal.
+
+The cost is that a graph author can stash a summary in checkpoint state instead
+of writing a fact, get no curation, no decay and no cross-session recall, and
+see no error. Examples must teach the difference; the API cannot enforce it.
+
+## Attaching from Python
+
+The bus is a POSIX shared-memory bus, not JSON over a socket. Modules attach
+through a local `SOCK_SEQPACKET` handshake and then use only their shared-memory
+mappings (`src/core/README.md`).
+
+Out-of-tree modules link `aimee-core-event-bus-client`, which carries the
+attach, wire, region and ring contracts and no host-side region lifecycle,
+admission, routing, arena allocator or capture code. The Python module is a cffi
+binding over that archive.
+
+Build it and prove one round trip against an existing stage before allocating a
+principal ref. Every current provider is C or Go, so this is the one step whose
+cost cannot be read off an existing module.
+
+## Argument shape, if the module runs tool loops
+
+A node that calls a delegate does not run a tool loop; the delegate does. A node
+that calls a model directly and dispatches tools itself does.
+
+In that case it must use `tool_args_canonicalize`
+(`src/headers/tool_args_coerce.h`) and authorize the canonical bytes, not the
+model's raw arguments. The C loop rewrites the parsed call in place before any
+gate runs, so the two orchestrators produce identical shapes. Deriving arguments
+independently reintroduces the defect that fix closed: execution-policy
+authorizing one shape while the tool runs another, and an audit record of a call
+that never executed.
+
+## Activation
+
+`AIMEE_MODULE_LANGGRAPH=1` or `0` overrides whatever the image shipped; unset
+keeps it. The module is optional: a deployment without it is a smaller
+deployment, not a broken one, which is the test for `runtime_toggle.supported`.
+
+## Registration checklist
+
+- Principal ref in `canonical-inventory.yaml` (one-way).
+- Sources and tests in `module.yaml`, with `ownership_complete` set only once the
+  latch actually holds.
+- Build registration in Make and CMake.
+- Test registration regenerated into
+  `tests/baselines/refactor/module-test-registration.json`.
+- A canonical document at `docs/modules/langgraph.md` covering purpose,
+  contracts, dependencies, providers, configuration, surfaces, data, security,
+  journeys, tests, diagnostics, compatibility, and removal.
+- Python runtime in the server image and under `module-runtime` supervision.

--- a/docs/proposals/pending/langgraph-module-with-memory-and-delegate-interop.md
+++ b/docs/proposals/pending/langgraph-module-with-memory-and-delegate-interop.md
@@ -1,0 +1,145 @@
+# Proposal: A Python module that seats LangGraph graphs on aimee's memory and delegates
+
+- **State:** PENDING. Design only, no code in this PR.
+- **Author:** JBailes
+- **Date:** 2026-08-29
+- **Charter roles:** Execute (graph nodes dispatch through the existing
+  delegate-invocation stage), Persist (graph reads and writes cross the memory
+  module's write and recall gates), Review (the module adds no authorization
+  path of its own; it consumes the ones that exist).
+
+## Thesis
+
+LangGraph is good at graph execution and has an ecosystem. Its durable state is
+a checkpointer: a per-thread snapshot that exists to resume a run. It has no
+extraction, no contradiction detection, no decay, no PII recall gate, and no
+confidence tier. Bolting a vector store on does not produce those.
+
+aimee has all of them behind five bus stages and no reach into the frameworks
+people already run.
+
+A Python module trades one for the other. It is not new plumbing: `memory`
+already serves `write` 5890, `extract_index` 5889, `retrieve` 5892, `reranking`
+5893 and `embedding` 5891 to a supervised Go process, and `delegates` already
+serves a version-2 execution contract over `delegate-invocation` to the native
+WFE and roundtable. Both consumers are in-tree and neither is C. The module adds
+a second consumer of two contracts that already have one.
+
+The claim is reach, not capability. Nothing here lets aimee do something it
+cannot do today. It lets a graph someone already wrote do it.
+
+## The case for not doing this
+
+Two objections deserve their strongest form.
+
+**The dependency tree.** aimee vets untrusted MCP packages and ships delegate
+sandboxes with no network and no credentials. LangChain's transitive
+dependencies are large and move fast. Putting that in the server path would be a
+governance event, and calling it a module does not change what it pulls in.
+
+The answer is placement, not assurance. The module is the process boundary. It
+holds no vault material, resolves no workspace, and reaches storage only through
+the stages below. Its blast radius is the grant its principal ref carries, which
+is the same containment argument every other module already makes. A deployment
+that does not want it sets `AIMEE_MODULE_LANGGRAPH=0` and the seam is absent
+rather than degraded.
+
+**Two orchestrators, two behaviours.** If the module owns tool loops, aimee has
+two of them. Two tool loops that derive arguments differently mean
+execution-policy authorizes different shapes depending on which one ran, and the
+ledger records calls that did not execute.
+
+That was true when this was first sketched. It is now false: argument shape is
+decided once, in `tool_args_canonicalize` (`headers/tool_args_coerce.h`), before
+any gate, and `src/posix/agent_runtime.c` rewrites the parsed call in place so
+every reader sees the same bytes. A second orchestrator calls the same function
+and cannot diverge. The precondition is met; that is why this proposal is
+reachable now and was not before.
+
+## What the module owns
+
+Graph definition, graph execution, and the translation between a LangGraph node
+and a bus call. Nothing else.
+
+It does not own authorization, credentials, workspaces, worktrees, storage, or
+the audit path. A node that wants any of those makes a bus call and gets the
+answer the module that owns it returns, including that module's failure
+semantics: the typed-fact write gate defers rather than committing, and both
+halves of the PII recall gate withhold rather than expose. Inheriting those is
+the point. A LangGraph node talking to Postgres directly has none of them.
+
+## State: two stores, one of them not memory
+
+The tempting design is to make aimee memory the checkpointer. One store, one
+answer to "what does this graph know."
+
+It is the wrong split, and the write gate is what shows it. A checkpoint is raw
+per-thread state: messages, node outputs, pending writes, retained so a run can
+resume. Curated memory is facts with evidence and decay. Routing checkpoints
+into `write` 5890 asks a gate whose job is deciding what may commit as a
+semantic edge to adjudicate transcript noise, at every superstep. It will
+correctly refuse most of it, and the refusals are not a signal anyone can act on.
+
+So:
+
+- **Resumption state** stays mechanical. `lifecycle_work_item` if the run is a
+  work item, LangGraph's own checkpointer otherwise. Uninteresting by design.
+- **Memory** is a node capability: recall through `retrieve` 5892 with the tier
+  from `reranking` 5893, writes through `write` 5890.
+
+The awkward consequence is that a graph has two places state can live and the
+module cannot decide which for the author. A node that stashes a summary in
+checkpoint state instead of writing a fact gets no curation, no decay, and no
+recall from another session, and nothing in the API stops it. That is a
+documentation and example burden the module carries permanently.
+
+## Attaching from Python
+
+The bus is not JSON over a socket. `src/core/README.md`: modules attach through
+a local `SOCK_SEQPACKET` handshake and then use only their shared-memory
+mappings, and external module repositories link the
+`aimee-core-event-bus-client` archive, which carries no host or routing code.
+
+So the module is a cffi binding over that archive plus graph code on top. The
+archive already exists and was already carved out for out-of-tree consumers, so
+this is binding work rather than protocol work. It is the only genuinely new
+engineering in the proposal and the only line item I would not estimate from the
+existing modules, because every current provider is C or Go and none of them
+exercises the client archive from a foreign runtime.
+
+The rest is known cost:
+
+- A principal ref from `tests/baselines/modules/canonical-inventory.yaml`. Event
+  kinds are carved as `4096 + ref*256 + stage`, and a ref is retired rather than
+  recycled, so allocation is one-way.
+- Registration in Make and CMake, a `module.yaml` descriptor, test registration
+  pinned to `tests/baselines/refactor/module-test-registration.json`, and a
+  canonical document under `docs/modules/`.
+- Image packaging and supervision for a Python runtime, which
+  `module-runtime` has not supervised before.
+
+## Staging
+
+1. **Attach.** cffi binding over the client archive, one round trip against a
+   stage that already exists, no LangGraph. This retires the only unknown, and
+   it is worth building before the ref is allocated.
+2. **Memory as a node capability.** Recall and write through 5892/5890/5893,
+   with the gate failure semantics surfaced as node errors rather than swallowed.
+3. **Delegates as nodes.** A node that dispatches through `delegate-invocation`
+   and returns the bounded result.
+4. **Optional toggle and docs.** `AIMEE_MODULE_LANGGRAPH`, the module document,
+   and the examples that teach the state split above.
+
+Stage 1 is the decision point. If attaching from Python is awkward, that is
+worth knowing before the ref is spent and before any LangGraph code exists.
+
+## What would make this the wrong call
+
+If the graphs people actually bring turn out to need aimee's worktrees and
+write-authority model rather than just memory and a delegate call, the module
+becomes a second front door onto machinery whose contracts assume the WFE owns
+the run. The seam to watch is source authority: a graph node that wants a
+writable worktree is asking for something `delegate-invocation` deliberately
+keeps caller-side. If that request arrives early and often, the answer is
+probably to keep those graphs outside and let them call in, not to widen the
+module.

--- a/server-go/modules/delegates/proxyguard.go
+++ b/server-go/modules/delegates/proxyguard.go
@@ -121,8 +121,9 @@ func ProxyAddressBlocked(ip net.IP) bool {
 // embeddedIPv4 returns the IPv4 address carried inside an IPv6 address, or nil.
 //
 // Covers v4-mapped (::ffff:a.b.c.d), v4-compatible (::a.b.c.d, deprecated),
-// NAT64 (64:ff9b::a.b.c.d) and 6to4 (2002:AABB:CCDD::), each of which is a way
-// to name an IPv4 destination without looking like one.
+// NAT64 (64:ff9b::a.b.c.d and the 64:ff9b:1::/48 local-use prefix), 6to4
+// (2002:AABB:CCDD::) and Teredo (2001::/32, trailing v4 complemented), each of
+// which is a way to name an IPv4 destination without looking like one.
 func embeddedIPv4(ip net.IP) net.IP {
 	v6 := ip.To16()
 	if v6 == nil || ip.To4() != nil {
@@ -145,6 +146,14 @@ func embeddedIPv4(ip net.IP) net.IP {
 	// NAT64 64:ff9b::/96
 	if isPrefix([]byte{0x00, 0x64, 0xFF, 0x9B, 0, 0, 0, 0, 0, 0, 0, 0}) {
 		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	// NAT64 local-use 64:ff9b:1::/48, at the /96 suffix length aimee accepts.
+	if isPrefix([]byte{0x00, 0x64, 0xFF, 0x9B, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) {
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+	}
+	// Teredo 2001::/32 carries the client v4 in the trailing 32 bits, complemented.
+	if isPrefix([]byte{0x20, 0x01, 0x00, 0x00}) {
+		return net.IPv4(^v6[12], ^v6[13], ^v6[14], ^v6[15])
 	}
 	// v4-compatible ::a.b.c.d, excluding :: and ::1 which are handled as v6.
 	if isPrefix(make([]byte, 12)) && (v6[12]|v6[13]|v6[14]|v6[15]) != 0 {

--- a/server-go/modules/delegates/proxyguard_test.go
+++ b/server-go/modules/delegates/proxyguard_test.go
@@ -84,6 +84,11 @@ func TestProxyAddressBlocksIPv4EmbeddedInIPv6(t *testing.T) {
 		{"v4-compatible private", "::192.168.1.1"},
 		{"NAT64 metadata", "64:ff9b::169.254.169.254"},
 		{"NAT64 private", "64:ff9b::10.0.0.1"},
+		{"NAT64 local-use metadata", "64:ff9b:1::169.254.169.254"},
+		// Teredo carries the client v4 complemented in the trailing 32 bits:
+		// ^169.254.169.254 == 0x56015601, ^127.0.0.1 == 0x80fffffe.
+		{"Teredo metadata", "2001::5601:5601"},
+		{"Teredo loopback", "2001::80ff:fffe"},
 	}
 	for _, c := range cases {
 		ip := net.ParseIP(c.addr)
@@ -108,6 +113,14 @@ func TestProxyAddressBlocksIPv4EmbeddedInIPv6(t *testing.T) {
 	// A v4-mapped PUBLIC address must still be reachable.
 	if ProxyAddressBlocked(net.ParseIP("::ffff:1.1.1.1")) {
 		t.Error("a v4-mapped public address was blocked")
+	}
+	// So must a Teredo address whose client v4 is public (^8.8.8.8).
+	if ProxyAddressBlocked(net.ParseIP("2001::f7f7:f7f7")) {
+		t.Error("a Teredo address embedding a public v4 was blocked")
+	}
+	// 2001::/32 is Teredo, but 2001:4860::/32 is ordinary global unicast.
+	if ProxyAddressBlocked(net.ParseIP("2001:4860:4860::8888")) {
+		t.Error("a global-unicast 2001: address was misread as Teredo")
 	}
 }
 

--- a/server-go/modules/egress/egress.go
+++ b/server-go/modules/egress/egress.go
@@ -277,7 +277,73 @@ func validDigest(value string) bool {
 	return true
 }
 
+// egressBlockedIPv4 are the ranges a module-initiated call must not reach.
+// Deliberately in step with server-go/modules/delegates/proxyguard.go and
+// server-go/modules/sandbox/proxy_policy.go: the same destination must not be
+// refused on one plane and dialed on another. The stdlib predicates alone are
+// not enough -- IsPrivate covers RFC1918 and fc00::/7 but not CGNAT, the
+// TEST-NETs, or the reserved space.
+var egressBlockedIPv4 = func() []*net.IPNet {
+	cidrs := []string{
+		"0.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16",
+		"172.16.0.0/12", "192.0.0.0/24", "192.0.2.0/24", "192.88.99.0/24", "192.168.0.0/16",
+		"198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4",
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		if _, n, err := net.ParseCIDR(cidr); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}()
+
+// egressEmbeddedIPv4 returns the IPv4 an IPv6 address translates or tunnels to.
+// Covers v4-mapped, v4-compatible, NAT64 (both prefixes), 6to4 and Teredo: each
+// spells an IPv4 destination as an IPv6 literal that matches no blocked v6
+// prefix, so a guard that skips this step admits 169.254.169.254 by another name.
+func egressEmbeddedIPv4(ip net.IP) net.IP {
+	v6 := ip.To16()
+	if v6 == nil || ip.To4() != nil {
+		return nil
+	}
+	hasPrefix := func(prefix []byte) bool {
+		for i, b := range prefix {
+			if v6[i] != b {
+				return false
+			}
+		}
+		return true
+	}
+	switch {
+	case hasPrefix([]byte{0x00, 0x64, 0xFF, 0x9B, 0, 0, 0, 0, 0, 0, 0, 0}),
+		hasPrefix([]byte{0x00, 0x64, 0xFF, 0x9B, 0x00, 0x01, 0, 0, 0, 0, 0, 0}):
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15]) // NAT64
+	case hasPrefix([]byte{0x20, 0x01, 0x00, 0x00}):
+		return net.IPv4(^v6[12], ^v6[13], ^v6[14], ^v6[15]) // Teredo
+	case v6[0] == 0x20 && v6[1] == 0x02:
+		return net.IPv4(v6[2], v6[3], v6[4], v6[5]) // 6to4
+	case hasPrefix(make([]byte, 12)) && (v6[12]|v6[13]|v6[14]|v6[15]) != 0:
+		return net.IPv4(v6[12], v6[13], v6[14], v6[15]) // v4-compatible
+	}
+	return nil
+}
+
 func publicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if embedded := egressEmbeddedIPv4(ip); embedded != nil {
+		ip = embedded
+	}
+	if v4 := ip.To4(); v4 != nil {
+		for _, blocked := range egressBlockedIPv4 {
+			if blocked.Contains(v4) {
+				return false
+			}
+		}
+		return true
+	}
 	return !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsUnspecified() &&
 		!ip.IsLinkLocalMulticast() && !ip.IsLinkLocalUnicast() && !ip.IsMulticast()
 }

--- a/server-go/modules/egress/ssrf_test.go
+++ b/server-go/modules/egress/ssrf_test.go
@@ -1,0 +1,54 @@
+package egress
+
+import (
+	"net"
+	"testing"
+)
+
+// publicIP is the SSRF gate for every module-initiated call. It must agree with
+// the delegate proxy guard and the sandbox proxy policy: a destination refused
+// on one plane must not be dialed on another.
+func TestPublicIPBlocksNonPublicAndTransitionForms(t *testing.T) {
+	blocked := []string{
+		// Plain v4 the stdlib predicates alone do not all cover.
+		"127.0.0.1", "10.0.0.1", "169.254.169.254", "172.16.0.1", "192.168.1.1",
+		"0.0.0.0", "100.64.0.1", "192.0.0.1", "192.0.2.1", "192.88.99.1",
+		"198.18.0.1", "198.51.100.1", "203.0.113.1", "224.0.0.1", "255.255.255.255",
+		// Native v6.
+		"::1", "::", "fe80::1", "fc00::1", "ff02::1",
+		// An IPv4 destination spelled as an IPv6 literal.
+		"::ffff:169.254.169.254", "::ffff:127.0.0.1", "::169.254.169.254",
+		"64:ff9b::a9fe:a9fe", "64:ff9b:1::a9fe:a9fe", "2002:a9fe:a9fe::",
+		"2001::5601:5601", // Teredo carrying ^169.254.169.254
+		"2001::80ff:fffe", // Teredo carrying ^127.0.0.1
+	}
+	for _, address := range blocked {
+		ip := net.ParseIP(address)
+		if ip == nil {
+			t.Fatalf("could not parse %q", address)
+		}
+		if publicIP(ip) {
+			t.Errorf("%s must not be treated as public", address)
+		}
+	}
+
+	public := []string{
+		"8.8.8.8", "1.1.1.1", "::ffff:8.8.8.8", "64:ff9b::808:808",
+		"2002:808:808::", "2606:4700:4700::1111",
+		"2001:4860:4860::8888", // global unicast, not Teredo
+		"2001::f7f7:f7f7",      // Teredo carrying public 8.8.8.8
+	}
+	for _, address := range public {
+		ip := net.ParseIP(address)
+		if ip == nil {
+			t.Fatalf("could not parse %q", address)
+		}
+		if !publicIP(ip) {
+			t.Errorf("%s must remain reachable", address)
+		}
+	}
+
+	if publicIP(nil) {
+		t.Fatal("a missing address must fail closed")
+	}
+}

--- a/server-go/modules/sandbox/proxy_policy.go
+++ b/server-go/modules/sandbox/proxy_policy.go
@@ -103,11 +103,17 @@ func proxyIPBlocked(ip net.IP) bool {
 		}
 	}
 	nat64 := []byte{0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}
-	if (compat && (v6[12]|v6[13]|v6[14]|v6[15]) != 0) || string(v6[:12]) == string(nat64) {
+	nat64Local := []byte{0x00, 0x64, 0xff, 0x9b, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	if (compat && (v6[12]|v6[13]|v6[14]|v6[15]) != 0) || string(v6[:12]) == string(nat64) ||
+		string(v6[:12]) == string(nat64Local) {
 		return ipv4Blocked(binary.BigEndian.Uint32(v6[12:16]))
 	}
 	if v6[0] == 0x20 && v6[1] == 0x02 { // 6to4: 2002:V4:V4::
 		return ipv4Blocked(binary.BigEndian.Uint32(v6[2:6]))
+	}
+	// Teredo 2001::/32: the client v4 is the trailing 32 bits, complemented.
+	if v6[0] == 0x20 && v6[1] == 0x01 && v6[2] == 0x00 && v6[3] == 0x00 {
+		return ipv4Blocked(^binary.BigEndian.Uint32(v6[12:16]))
 	}
 
 	allZero := true

--- a/server-go/modules/sandbox/proxy_policy_test.go
+++ b/server-go/modules/sandbox/proxy_policy_test.go
@@ -37,6 +37,11 @@ func TestProxyIPv6Policy(t *testing.T) {
 		"::1", "::", "fe80::1", "fc00::1", "fd12:3456::1", "ff02::1",
 		"::ffff:127.0.0.1", "::ffff:169.254.169.254", "::ffff:10.0.0.1",
 		"64:ff9b::7f00:1", "64:ff9b::a9fe:a9fe", "2002:7f00:1::",
+		"64:ff9b:1::a9fe:a9fe", // local-use NAT64 prefix
+		// Teredo: trailing 32 bits are the client v4, complemented.
+		"2001::5601:5601", // ^169.254.169.254
+		"2001::80ff:fffe", // ^127.0.0.1
+		"2001::f5ff:fffe", // ^10.0.0.1
 	}
 	for _, address := range blocked {
 		if !proxyIPBlocked(net.ParseIP(address)) {
@@ -46,6 +51,7 @@ func TestProxyIPv6Policy(t *testing.T) {
 	public := []string{
 		"::ffff:8.8.8.8", "64:ff9b::808:808", "2002:808:808::",
 		"2606:4700:4700::1111", "2001:4860:4860::8888",
+		"2001::f7f7:f7f7", // Teredo carrying public 8.8.8.8
 	}
 	for _, address := range public {
 		if proxyIPBlocked(net.ParseIP(address)) {

--- a/src/headers/ip_transition.h
+++ b/src/headers/ip_transition.h
@@ -1,0 +1,114 @@
+/* ip_transition.h -- IPv6 transition-address normalization for SSRF guards.
+ *
+ * WHY THIS EXISTS
+ *
+ * An SSRF deny-list that reasons about IPv6 prefixes alone is bypassable. Half
+ * a dozen transition mechanisms let an IPv4 destination be spelled as an IPv6
+ * literal that matches no blocked v6 prefix: ::ffff:169.254.169.254,
+ * 64:ff9b::a9fe:a9fe, 2002:a9fe:a9fe::, ::a9fe:a9fe, and the Teredo encoding
+ * all name the cloud metadata service. A guard that checks only v4-mapped
+ * catches the first and admits the rest.
+ *
+ * So every guard extracts the embedded IPv4 FIRST and applies the v4 policy to
+ * it. This header is the one definition of "which IPv4 does this IPv6 name",
+ * shared by the server's web egress guard and aimee-kb's management-endpoint
+ * guard so the two cannot drift. The Go planes carry the same table in
+ * server-go/modules/delegates/proxyguard.go and
+ * server-go/modules/sandbox/proxy_policy.go.
+ *
+ * Reachability is not the point. Whether a given deployment has a NAT64 gateway
+ * or a 6to4 relay is a property of the network, not of the request, and a guard
+ * that assumes their absence is asserting something it cannot check. */
+#ifndef DEC_IP_TRANSITION_H
+#define DEC_IP_TRANSITION_H 1
+
+#include <netinet/in.h>
+#include <stdint.h>
+
+/* Extract the IPv4 address an IPv6 address translates or tunnels to.
+ *
+ * Returns 1 and writes the address to *out_v4 in HOST byte order when `a`
+ * carries an embedded IPv4; returns 0 when it names no IPv4 and must be judged
+ * as a native IPv6 address.
+ *
+ * :: and ::1 deliberately return 0: they are the unspecified and loopback
+ * addresses, judged by the v6 rules, not IPv4-compatible forms. */
+static inline int ip_embedded_ipv4(const struct in6_addr *a, uint32_t *out_v4)
+{
+   const uint8_t *b = a->s6_addr;
+   uint32_t tail =
+       ((uint32_t)b[12] << 24) | ((uint32_t)b[13] << 16) | ((uint32_t)b[14] << 8) | (uint32_t)b[15];
+
+   int top12_zero = 1;
+   for (int i = 0; i < 12; i++)
+      if (b[i])
+      {
+         top12_zero = 0;
+         break;
+      }
+
+   /* ::ffff:0:0/96 IPv4-mapped */
+   int mapped_prefix = 1;
+   for (int i = 0; i < 10; i++)
+      if (b[i])
+      {
+         mapped_prefix = 0;
+         break;
+      }
+   if (mapped_prefix && b[10] == 0xff && b[11] == 0xff)
+   {
+      *out_v4 = tail;
+      return 1;
+   }
+
+   /* 64:ff9b::/96 well-known NAT64, and 64:ff9b:1::/48 local-use NAT64. The
+    * local-use prefix carries the v4 in the same trailing octets for the /96
+    * suffix length, which is the only one aimee emits or accepts. */
+   if (b[0] == 0x00 && b[1] == 0x64 && b[2] == 0xff && b[3] == 0x9b)
+   {
+      int wellknown_zero = 1;
+      for (int i = 4; i < 12; i++)
+         if (b[i])
+         {
+            wellknown_zero = 0;
+            break;
+         }
+      int localuse = b[4] == 0x00 && b[5] == 0x01;
+      for (int i = 6; i < 12 && localuse; i++)
+         if (b[i])
+            localuse = 0;
+      if (wellknown_zero || localuse)
+      {
+         *out_v4 = tail;
+         return 1;
+      }
+   }
+
+   /* 2002::/16 6to4 carries the v4 at bytes 2..5. */
+   if (b[0] == 0x20 && b[1] == 0x02)
+   {
+      *out_v4 =
+          ((uint32_t)b[2] << 24) | ((uint32_t)b[3] << 16) | ((uint32_t)b[4] << 8) | (uint32_t)b[5];
+      return 1;
+   }
+
+   /* 2001::/32 Teredo. The client's v4 is the trailing 32 bits, obfuscated by
+    * a bitwise complement. */
+   if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && b[3] == 0x00)
+   {
+      *out_v4 = ~tail;
+      return 1;
+   }
+
+   /* ::a.b.c.d IPv4-compatible (deprecated, still routed by some stacks).
+    * Excludes :: and ::1, which the v6 rules own. */
+   if (top12_zero && tail > 1)
+   {
+      *out_v4 = tail;
+      return 1;
+   }
+
+   return 0;
+}
+
+#endif /* DEC_IP_TRANSITION_H */

--- a/src/headers/tool_args_coerce.h
+++ b/src/headers/tool_args_coerce.h
@@ -16,6 +16,23 @@ extern "C"
     * returns at minimum a deep clone of raw_args. */
    cJSON *tool_args_coerce(const cJSON *declared_schema, const cJSON *raw_args);
 
+   /* The ONE place a tool call's argument shape is decided: alias resolution,
+    * named integer-field coercion, then the schema coercion above.
+    *
+    * Callers must canonicalize BEFORE authorization, then pass the same result
+    * to every gate, to the executor, and to the audit record. Authorizing one
+    * shape and executing another is the defect this exists to prevent.
+    *
+    * Idempotent: canonicalizing an already-canonical object is a no-op, so a
+    * second call on a deeper layer is safe.
+    *
+    * Both return a NEWLY-ALLOCATED value the caller frees (cJSON_Delete /
+    * free). tool_args_canonicalize_json returns NULL when raw_args_json is not
+    * valid JSON, which the validator reports; the caller should then fall back
+    * to the raw string so the error surfaces there rather than here. */
+   cJSON *tool_args_canonicalize(const cJSON *declared_schema, const cJSON *raw_args);
+   char *tool_args_canonicalize_json(const cJSON *declared_schema, const char *raw_args_json);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kb/kb_mgmt_endpoint.c
+++ b/src/kb/kb_mgmt_endpoint.c
@@ -1,4 +1,5 @@
 #include "kb_mgmt_endpoint.h"
+#include "ip_transition.h"
 #include <aimee/core/connection/control.h>
 #include <aimee/core/connection/socket.h>
 #include <arpa/inet.h>
@@ -113,14 +114,14 @@ int kb_mgmt_sockaddr_permitted(const struct sockaddr *addr, socklen_t len)
       return v4_permitted(((const struct sockaddr_in *)addr)->sin_addr.s_addr);
    if (addr->sa_family != AF_INET6 || len < sizeof(struct sockaddr_in6))
       return 0;
-   const unsigned char *b = ((const struct sockaddr_in6 *)addr)->sin6_addr.s6_addr;
-   static const unsigned char mapped[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff};
-   if (memcmp(b, mapped, sizeof(mapped)) == 0)
-   {
-      uint32_t v4;
-      memcpy(&v4, b + 12, sizeof(v4));
-      return v4_permitted(v4);
-   }
+   const struct in6_addr *in6 = &((const struct sockaddr_in6 *)addr)->sin6_addr;
+   const unsigned char *b = in6->s6_addr;
+   /* A transition address names an IPv4 endpoint; judge it as that IPv4.
+    * Checking only v4-mapped here left NAT64, 6to4, Teredo and v4-compatible
+    * spellings of an internal address permitted -- see headers/ip_transition.h. */
+   uint32_t embedded = 0;
+   if (ip_embedded_ipv4(in6, &embedded))
+      return v4_permitted(htonl(embedded));
    int all_zero = 1;
    for (int i = 0; i < 16; i++)
       all_zero &= b[i] == 0;

--- a/src/modules/tools/agent_tools_dispatch.c
+++ b/src/modules/tools/agent_tools_dispatch.c
@@ -2060,54 +2060,19 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       return safe_strdup(cancel_msg);
    }
 
-   /* --- Argument normalization: resolve common aliases --- */
+   /* --- Argument canonicalization ---------------------------------------
+    *
+    * One shape, decided in one place (headers/tool_args_coerce.h). The agent
+    * loop canonicalizes BEFORE its gates and hands the result down, so for that
+    * caller this is a no-op; the call stays here for the entry points that do
+    * not go through the loop (script RPC, the MCP gateway), which would
+    * otherwise dispatch un-normalized arguments. Idempotent, so both are safe. */
    {
-      static const struct
+      cJSON *canonical = tool_args_canonicalize(agent_tool_get_schema_cached(name), args);
+      if (canonical && canonical != args)
       {
-         const char *from;
-         const char *to;
-      } aliases[] = {{"filepath", "path"}, {"file_path", "path"}, {"file", "path"},
-                     {"filename", "path"}, {"file_name", "path"}, {"cmd", "command"},
-                     {"dir", "path"},      {"directory", "path"}, {"msg", "message"},
-                     {NULL, NULL}};
-      for (int i = 0; aliases[i].from; i++)
-      {
-         cJSON *f = cJSON_GetObjectItem(args, aliases[i].from);
-         if (f && !cJSON_GetObjectItem(args, aliases[i].to))
-         {
-            cJSON *det = cJSON_DetachItemFromObject(args, aliases[i].from);
-            if (det)
-               cJSON_AddItemToObject(args, aliases[i].to, det);
-         }
-      }
-      /* Coerce string integers: "5" → 5 for offset/limit/count fields */
-      static const char *int_fields[] = {"offset", "limit", "count", "max_results", NULL};
-      for (int i = 0; int_fields[i]; i++)
-      {
-         cJSON *f = cJSON_GetObjectItem(args, int_fields[i]);
-         if (f && cJSON_IsString(f))
-         {
-            char *end = NULL;
-            long v = strtol(f->valuestring, &end, 10);
-            if (end && *end == '\0' && f->valuestring != end)
-               cJSON_ReplaceItemInObject(args, int_fields[i], cJSON_CreateNumber(v));
-         }
-      }
-
-      /* Schema-driven coercion (small/local model providers emit ints/bools
-       * as strings, scalars where arrays are expected, JSON strings where
-       * objects are expected). Runs after the targeted int-field block so
-       * tools whose schema isn't in the registry still benefit from the
-       * fallback. */
-      cJSON *schema = agent_tool_get_schema_cached(name);
-      if (schema)
-      {
-         cJSON *coerced = tool_args_coerce(schema, args);
-         if (coerced && coerced != args)
-         {
-            cJSON_Delete(args);
-            args = coerced;
-         }
+         cJSON_Delete(args);
+         args = canonical;
       }
    }
 

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -9,6 +9,7 @@
 #include <aimee/translation/aimee_backend.h> /* anthropic_backend_parse / openai_backend_parse */
 #include <aimee/ir/aimee_ir.h>               /* aimee_response_t + block accessors */
 #include "tool_call_args.h"                  /* assistant_message arg normalize/sanitize */
+#include "tool_args_coerce.h"                /* tool_args_canonicalize_json */
 #include "agent_exec.h"
 #include "agent_protocol.h"
 #include "agent_runtime_messages.h"
@@ -1670,6 +1671,35 @@ native_provider_http:
       agent_tools_begin_turn(turn);
 
       liveness_progress_action_t progress_action = LIVENESS_PROGRESS_NONE;
+
+      /* Canonicalize each call's arguments ONCE, here, before anything reads
+       * them.
+       *
+       * The alternative is what this replaced: validation normalized a copy it
+       * discarded, the dispatcher normalized differently and executed THAT, and
+       * in between execution-policy and the audit record both saw the raw
+       * arguments. So the authorizer could permit one shape while the tool ran
+       * another, and the ledger recorded a call that never executed.
+       *
+       * Rewriting in place is what makes that structural rather than a rule to
+       * remember: `arguments` is owned by parsed_response_t and freed by
+       * agent_free_parsed_response, so every reader below — the rounds-to-resume
+       * observer, tool_validate, policy_check_tool, directive_check_tool, the
+       * executor, the audit record and the stuck-detection signature — sees the
+       * same bytes without each having to opt in. A reader added later cannot
+       * miss it.
+       *
+       * The assistant message keeps the model's original arguments: that is the
+       * model's own turn in the transcript, not a description of what ran. */
+      for (int i = 0; i < parsed.call_count; i++)
+      {
+         char *canonical = tool_args_canonicalize_json(
+             agent_tool_get_schema_cached(parsed.calls[i].name), parsed.calls[i].arguments);
+         if (!canonical)
+            continue; /* unparseable JSON: leave it for tool_validate to report */
+         free(parsed.calls[i].arguments);
+         parsed.calls[i].arguments = canonical;
+      }
 
       /* Rounds-to-resume accounting: judge what the model ASKED for, before the
        * tools run — a re-derivation is a re-derivation whether or not it

--- a/src/posix/web_egress.c
+++ b/src/posix/web_egress.c
@@ -12,6 +12,7 @@
 #include "aimee.h"
 
 #include "agent_exec.h"
+#include "ip_transition.h"
 #include "log.h"
 #include "web_egress.h"
 
@@ -27,25 +28,40 @@
 /* ---------------- SSRF egress deny-list ---------------- */
 
 /* 1 if this IPv4 (host byte order) is in a private/reserved/link-local range. */
+/* Every range a model- or ranking-chosen destination has no business reaching.
+ * Kept deliberately in step with blockedIPv4Nets in
+ * server-go/modules/delegates/proxyguard.go and the table in
+ * server-go/modules/sandbox/proxy_policy.go: the same destination must not be
+ * refused on one plane and dialed on another. */
 static int ipv4_blocked(uint32_t a)
 {
-   uint8_t b0 = (a >> 24) & 0xff, b1 = (a >> 16) & 0xff;
-   if (b0 == 0)
-      return 1; /* 0.0.0.0/8 */
-   if (b0 == 10)
-      return 1; /* 10/8 private */
-   if (b0 == 127)
-      return 1; /* loopback */
-   if (b0 == 169 && b1 == 254)
-      return 1; /* link-local incl. 169.254.169.254 metadata */
-   if (b0 == 172 && b1 >= 16 && b1 <= 31)
-      return 1; /* 172.16/12 private */
-   if (b0 == 192 && b1 == 168)
-      return 1; /* 192.168/16 private */
-   if (b0 == 100 && b1 >= 64 && b1 <= 127)
-      return 1; /* 100.64/10 CGNAT */
-   if (b0 >= 224)
-      return 1; /* 224/4 multicast + 240/4 reserved + 255.255.255.255 */
+   static const struct
+   {
+      uint32_t network;
+      unsigned bits;
+   } blocked[] = {
+       {0x00000000u, 8},  /* 0.0.0.0/8 this-network / unspecified */
+       {0x0a000000u, 8},  /* 10/8 private */
+       {0x64400000u, 10}, /* 100.64/10 CGNAT */
+       {0x7f000000u, 8},  /* 127/8 loopback */
+       {0xa9fe0000u, 16}, /* 169.254/16 link-local incl. 169.254.169.254 metadata */
+       {0xac100000u, 12}, /* 172.16/12 private */
+       {0xc0000000u, 24}, /* 192.0.0/24 IETF protocol assignments */
+       {0xc0000200u, 24}, /* 192.0.2/24 TEST-NET-1 */
+       {0xc0586300u, 24}, /* 192.88.99/24 6to4 relay anycast (deprecated) */
+       {0xc0a80000u, 16}, /* 192.168/16 private */
+       {0xc6120000u, 15}, /* 198.18/15 benchmarking */
+       {0xc6336400u, 24}, /* 198.51.100/24 TEST-NET-2 */
+       {0xcb007100u, 24}, /* 203.0.113/24 TEST-NET-3 */
+       {0xe0000000u, 4},  /* 224/4 multicast */
+       {0xf0000000u, 4},  /* 240/4 reserved incl. 255.255.255.255 */
+   };
+   for (size_t i = 0; i < sizeof(blocked) / sizeof(blocked[0]); i++)
+   {
+      uint32_t mask = blocked[i].bits == 0 ? 0u : (~0u << (32 - blocked[i].bits));
+      if ((a & mask) == blocked[i].network)
+         return 1;
+   }
    return 0;
 }
 
@@ -68,20 +84,12 @@ static int ipv6_blocked(const struct in6_addr *a)
       return 1; /* fe80::/10 link-local */
    if (b[0] == 0xff)
       return 1; /* ff00::/8 multicast */
-   /* ::ffff:0:0/96 IPv4-mapped -> validate the embedded v4 */
-   int mapped = 1;
-   for (int i = 0; i < 10; i++)
-      if (b[i])
-      {
-         mapped = 0;
-         break;
-      }
-   if (mapped && b[10] == 0xff && b[11] == 0xff)
-   {
-      uint32_t v4 =
-          ((uint32_t)b[12] << 24) | ((uint32_t)b[13] << 16) | ((uint32_t)b[14] << 8) | b[15];
-      return ipv4_blocked(v4);
-   }
+   /* A transition address names an IPv4 destination; judge it as that IPv4.
+    * Covers v4-mapped, NAT64, 6to4, Teredo and v4-compatible -- see
+    * headers/ip_transition.h for why checking only v4-mapped is a bypass. */
+   uint32_t embedded = 0;
+   if (ip_embedded_ipv4(a, &embedded))
+      return ipv4_blocked(embedded);
    return 0;
 }
 

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -51,77 +51,6 @@ static const char *tool_prompts_lookup_embedded(const char *name)
    return NULL;
 }
 
-/* --- Argument alias table --- */
-
-typedef struct
-{
-   const char *alias;
-   const char *canonical;
-} arg_alias_t;
-
-static const arg_alias_t g_arg_aliases[] = {
-    {"filepath", "path"},  {"file_path", "path"},  {"file", "path"}, {"filename", "path"},
-    {"file_name", "path"}, {"cmd", "command"},     {"dir", "path"},  {"directory", "path"},
-    {"q", "query"},        {"max", "max_results"}, {"cnt", "count"}, {"num", "count"},
-    {"msg", "message"},    {NULL, NULL},
-};
-
-/* Normalize argument names: resolve aliases, coerce "123" to 123 for integer
- * fields. Modifies args in-place. Returns the number of normalizations. */
-static int normalize_args(cJSON *args, cJSON *schema_props)
-{
-   if (!args || !cJSON_IsObject(args))
-      return 0;
-   int count = 0;
-
-   /* Alias resolution: rename aliased keys to canonical names */
-   for (const arg_alias_t *a = g_arg_aliases; a->alias; a++)
-   {
-      cJSON *field = cJSON_GetObjectItem(args, a->alias);
-      if (!field)
-         continue;
-      /* Only rename if the canonical name is not already present */
-      if (cJSON_GetObjectItem(args, a->canonical))
-         continue;
-      /* cJSON doesn't support key rename, so detach and re-add */
-      cJSON *detached = cJSON_DetachItemFromObject(args, a->alias);
-      if (detached)
-      {
-         cJSON_AddItemToObject(args, a->canonical, detached);
-         count++;
-      }
-   }
-
-   /* Type coercion: string "123" → integer 123 for integer fields */
-   if (schema_props && cJSON_IsObject(schema_props))
-   {
-      cJSON *prop = schema_props->child;
-      while (prop)
-      {
-         cJSON *field = cJSON_GetObjectItem(args, prop->string);
-         if (field && cJSON_IsString(field))
-         {
-            cJSON *type_spec = cJSON_GetObjectItem(prop, "type");
-            if (type_spec && cJSON_IsString(type_spec) &&
-                (strcmp(type_spec->valuestring, "integer") == 0 ||
-                 strcmp(type_spec->valuestring, "number") == 0))
-            {
-               const char *s = field->valuestring;
-               char *end = NULL;
-               long val = strtol(s, &end, 10);
-               if (end && *end == '\0' && s != end)
-               {
-                  cJSON_ReplaceItemInObject(args, prop->string, cJSON_CreateNumber(val));
-                  count++;
-               }
-            }
-         }
-         prop = prop->next;
-      }
-   }
-   return count;
-}
-
 static int validate_against_schema(const char *args_json, cJSON *schema, char *err_out,
                                    size_t err_len)
 {
@@ -135,8 +64,11 @@ static int validate_against_schema(const char *args_json, cJSON *schema, char *e
       return -1;
    }
 
+   /* No normalization here. Arguments arrive canonical (the agent loop rewrites
+    * them in place before any gate runs), so this judges the shape that will
+    * actually execute. Normalizing a private copy here -- which is what this
+    * used to do -- validated one shape and let another run. */
    cJSON *props = cJSON_GetObjectItem(schema, "properties");
-   normalize_args(args, props);
 
    cJSON *required = cJSON_GetObjectItem(schema, "required");
    if (required && cJSON_IsArray(required))
@@ -188,6 +120,25 @@ static int validate_against_schema(const char *args_json, cJSON *schema, char *e
             }
          }
          prop = prop->next;
+      }
+   }
+
+   /* Enforce additionalProperties ONLY when the schema says false. Standard
+    * JSON Schema semantics, so a tool author opts in and nothing that omits the
+    * keyword changes behaviour. Without this an undeclared key the model
+    * invented passed every gate and reached the handler. */
+   cJSON *additional = cJSON_GetObjectItem(schema, "additionalProperties");
+   if (additional && cJSON_IsFalse(additional) && props && cJSON_IsObject(props) &&
+       cJSON_IsObject(args))
+   {
+      for (cJSON *field = args->child; field; field = field->next)
+      {
+         if (field->string && !cJSON_GetObjectItem(props, field->string))
+         {
+            snprintf(err_out, err_len, "unknown field '%s'", field->string);
+            cJSON_Delete(args);
+            return -1;
+         }
       }
    }
 

--- a/src/server/tool_args_coerce.c
+++ b/src/server/tool_args_coerce.c
@@ -183,3 +183,118 @@ cJSON *tool_args_coerce(const cJSON *declared_schema, const cJSON *raw_args)
 
    return result;
 }
+
+/* --- Canonicalization: one shape, decided once ----------------------------
+ *
+ * WHY THIS EXISTS
+ *
+ * A tool call used to be normalized twice, differently, and authorized on
+ * neither result. agent_policy.c's validator resolved aliases and coerced ints
+ * on a copy it then threw away; the dispatcher resolved a DIFFERENT alias set
+ * and ran the schema coercion below, and that result is what executed. In
+ * between, execution-policy and the audit record both saw the raw arguments.
+ *
+ * So the authorizer could permit {"paths": "/etc/passwd"} while the tool ran
+ * {"paths": ["/etc/passwd"]}, and the ledger recorded arguments that never
+ * executed. The fix is not a better transform, it is a single one: the caller
+ * canonicalizes once, before the gates, and every gate plus the executor plus
+ * the audit record see the same bytes.
+ *
+ * Idempotent by construction, so the dispatcher can keep calling it for its
+ * other entry points (script RPC, the MCP gateway) without double-transforming
+ * a turn the agent loop already canonicalized. */
+
+/* Names a model commonly emits instead of a tool's declared parameter. The
+ * union of the two tables that previously disagreed. */
+typedef struct
+{
+   const char *alias;
+   const char *canonical;
+} arg_alias_t;
+
+static const arg_alias_t g_arg_aliases[] = {
+    {"filepath", "path"},  {"file_path", "path"},  {"file", "path"},      {"filename", "path"},
+    {"file_name", "path"}, {"dir", "path"},        {"directory", "path"}, {"cmd", "command"},
+    {"q", "query"},        {"max", "max_results"}, {"cnt", "count"},      {"num", "count"},
+    {"msg", "message"},    {NULL, NULL},
+};
+
+/* Fields historically coerced by name for tools with no registry schema. */
+static const char *g_int_fields[] = {"offset", "limit", "count", "max_results", NULL};
+
+static void apply_aliases(cJSON *args, const cJSON *properties)
+{
+   for (const arg_alias_t *a = g_arg_aliases; a->alias; a++)
+   {
+      if (!cJSON_GetObjectItem(args, a->alias))
+         continue;
+      if (cJSON_GetObjectItem(args, a->canonical))
+         continue; /* the real parameter is already present */
+      if (properties)
+      {
+         /* With a schema in hand, rewrite ONLY when the alias is not itself a
+          * declared parameter and the canonical name is one. A tool with a real
+          * `file` parameter and no `path` keeps its argument; the unguarded
+          * rewrite the dispatcher used to do would have silently renamed it. */
+         if (cJSON_GetObjectItemCaseSensitive(properties, a->alias))
+            continue;
+         if (!cJSON_GetObjectItemCaseSensitive(properties, a->canonical))
+            continue;
+      }
+      cJSON *detached = cJSON_DetachItemFromObject(args, a->alias);
+      if (detached)
+         cJSON_AddItemToObject(args, a->canonical, detached);
+   }
+}
+
+static void coerce_named_int_fields(cJSON *args)
+{
+   for (int i = 0; g_int_fields[i]; i++)
+   {
+      cJSON *f = cJSON_GetObjectItem(args, g_int_fields[i]);
+      if (!f || !cJSON_IsString(f))
+         continue;
+      char *end = NULL;
+      long v = strtol(f->valuestring, &end, 10);
+      if (end && *end == '\0' && f->valuestring != end)
+         cJSON_ReplaceItemInObject(args, g_int_fields[i], cJSON_CreateNumber((double)v));
+   }
+}
+
+cJSON *tool_args_canonicalize(const cJSON *declared_schema, const cJSON *raw_args)
+{
+   if (!cJSON_IsObject(raw_args))
+      return cJSON_Duplicate(raw_args, 1);
+
+   cJSON *work = cJSON_Duplicate(raw_args, 1);
+   if (!work)
+      return NULL;
+
+   const cJSON *properties =
+       declared_schema ? cJSON_GetObjectItemCaseSensitive(declared_schema, "properties") : NULL;
+   if (properties && !cJSON_IsObject(properties))
+      properties = NULL;
+
+   apply_aliases(work, properties);
+   coerce_named_int_fields(work);
+
+   cJSON *coerced = tool_args_coerce(declared_schema, work);
+   cJSON_Delete(work);
+   return coerced;
+}
+
+char *tool_args_canonicalize_json(const cJSON *declared_schema, const char *raw_args_json)
+{
+   if (!raw_args_json)
+      return NULL;
+   cJSON *raw = cJSON_Parse(raw_args_json);
+   if (!raw)
+      return NULL; /* invalid JSON is the validator's error to report, not ours */
+   cJSON *canonical = tool_args_canonicalize(declared_schema, raw);
+   cJSON_Delete(raw);
+   if (!canonical)
+      return NULL;
+   char *out = cJSON_PrintUnformatted(canonical);
+   cJSON_Delete(canonical);
+   return out;
+}

--- a/src/tests/test_kb_mgmt_endpoint.c
+++ b/src/tests/test_kb_mgmt_endpoint.c
@@ -46,5 +46,22 @@ int main(void)
    assert(!allowed6("fe80::1") && !allowed6("fc00::1") && !allowed6("ff02::1"));
    assert(!allowed6("::ffff:127.0.0.1"));
    assert(allowed6("::ffff:8.8.8.8"));
+   /* v4-mapped is only one spelling. NAT64, 6to4, Teredo and the deprecated
+    * v4-compatible form all name an IPv4 endpoint without matching a blocked v6
+    * prefix, so checking only ::ffff: left an internal endpoint permitted. */
+   assert(!allowed6("64:ff9b::7f00:1"));      /* NAT64 -> 127.0.0.1 */
+   assert(!allowed6("64:ff9b::a9fe:a9fe"));   /* NAT64 -> 169.254.169.254 */
+   assert(!allowed6("64:ff9b:1::a9fe:a9fe")); /* local-use NAT64 prefix */
+   assert(!allowed6("2002:7f00:1::"));        /* 6to4 -> 127.0.0.1 */
+   assert(!allowed6("2002:a9fe:a9fe::"));     /* 6to4 -> 169.254.169.254 */
+   assert(!allowed6("::a9fe:a9fe"));          /* v4-compatible -> metadata */
+   assert(!allowed6("2001::5601:5601"));      /* Teredo -> ^169.254.169.254 */
+   assert(!allowed6("2001::80ff:fffe"));      /* Teredo -> ^127.0.0.1 */
+   /* The same forms carrying a public v4 stay reachable, and 2001:4860::/32 is
+    * ordinary global unicast rather than Teredo. */
+   assert(allowed6("64:ff9b::808:808"));
+   assert(allowed6("2002:808:808::"));
+   assert(allowed6("2001::f7f7:f7f7"));
+   assert(allowed6("2001:4860:4860::8888"));
    return 0;
 }

--- a/src/tests/test_tool_args_coerce.c
+++ b/src/tests/test_tool_args_coerce.c
@@ -199,7 +199,7 @@ static void test_alias_rewrites_only_toward_a_declared_parameter(void)
 {
    cJSON *schema =
        cJSON_Parse("{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}");
-   cJSON *raw = cJSON_Parse("{\"filepath\":\"/tmp/x\"}");
+   cJSON *raw = cJSON_Parse("{\"filepath\":\"/doc/a.txt\"}");
    cJSON *out = tool_args_canonicalize(schema, raw);
    assert(cJSON_GetObjectItemCaseSensitive(out, "path") != NULL);
    assert(cJSON_GetObjectItemCaseSensitive(out, "filepath") == NULL);
@@ -210,10 +210,10 @@ static void test_alias_rewrites_only_toward_a_declared_parameter(void)
    /* A tool whose real parameter IS `file` keeps it. */
    cJSON *schema2 =
        cJSON_Parse("{\"type\":\"object\",\"properties\":{\"file\":{\"type\":\"string\"}}}");
-   cJSON *raw2 = cJSON_Parse("{\"file\":\"/tmp/y\"}");
+   cJSON *raw2 = cJSON_Parse("{\"file\":\"/doc/b.txt\"}");
    cJSON *out2 = tool_args_canonicalize(schema2, raw2);
    cJSON *kept = cJSON_GetObjectItemCaseSensitive(out2, "file");
-   assert(kept && cJSON_IsString(kept) && strcmp(kept->valuestring, "/tmp/y") == 0);
+   assert(kept && cJSON_IsString(kept) && strcmp(kept->valuestring, "/doc/b.txt") == 0);
    assert(cJSON_GetObjectItemCaseSensitive(out2, "path") == NULL);
    cJSON_Delete(out2);
    cJSON_Delete(raw2);

--- a/src/tests/test_tool_args_coerce.c
+++ b/src/tests/test_tool_args_coerce.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "tool_args_coerce.h"
@@ -148,6 +149,129 @@ static void test_failed_coercion_leaves_alone(void)
    printf("  PASS: test_failed_coercion_leaves_alone\n");
 }
 
+/* --- Canonicalization: one shape, decided once ---------------------------
+ *
+ * These pin the defect the canonicalizer exists to close. Arguments used to be
+ * normalized twice, differently, and authorized on neither result: the
+ * validator resolved aliases on a copy it discarded, the dispatcher resolved a
+ * different alias set and executed THAT, and execution-policy plus the audit
+ * record saw the raw arguments in between. */
+
+/* The load-bearing property: canonicalizing is a fixed point. The agent loop
+ * canonicalizes before its gates and the dispatcher canonicalizes again for its
+ * other entry points, so a second pass must not transform anything a second
+ * time -- a scalar wrapped into an array once must not become [[x]]. */
+static void test_canonicalize_is_idempotent(void)
+{
+   cJSON *schema = cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                               "\"paths\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},"
+                               "\"n\":{\"type\":\"integer\"},"
+                               "\"deep\":{\"type\":\"boolean\"}}}");
+   cJSON *raw = cJSON_Parse("{\"paths\":\"/etc/passwd\",\"n\":\"7\",\"deep\":\"true\"}");
+
+   cJSON *once = tool_args_canonicalize(schema, raw);
+   cJSON *twice = tool_args_canonicalize(schema, once);
+
+   char *a = cJSON_PrintUnformatted(once);
+   char *b = cJSON_PrintUnformatted(twice);
+   assert(strcmp(a, b) == 0);
+
+   cJSON *paths = cJSON_GetObjectItemCaseSensitive(once, "paths");
+   assert(cJSON_IsArray(paths) && cJSON_GetArraySize(paths) == 1);
+   assert(cJSON_IsString(cJSON_GetArrayItem(paths, 0)));
+   assert(cJSON_IsNumber(cJSON_GetObjectItemCaseSensitive(once, "n")));
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(once, "deep")));
+
+   free(a);
+   free(b);
+   cJSON_Delete(twice);
+   cJSON_Delete(once);
+   cJSON_Delete(raw);
+   cJSON_Delete(schema);
+   printf("  PASS: test_canonicalize_is_idempotent\n");
+}
+
+/* An alias is rewritten only when the canonical name is a real parameter and
+ * the alias is not. This is what makes the table safe to actually apply: the
+ * dispatcher's old unguarded rewrite would rename a tool's genuine `file`
+ * argument to `path` and the tool would lose it. */
+static void test_alias_rewrites_only_toward_a_declared_parameter(void)
+{
+   cJSON *schema =
+       cJSON_Parse("{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}");
+   cJSON *raw = cJSON_Parse("{\"filepath\":\"/tmp/x\"}");
+   cJSON *out = tool_args_canonicalize(schema, raw);
+   assert(cJSON_GetObjectItemCaseSensitive(out, "path") != NULL);
+   assert(cJSON_GetObjectItemCaseSensitive(out, "filepath") == NULL);
+   cJSON_Delete(out);
+   cJSON_Delete(raw);
+   cJSON_Delete(schema);
+
+   /* A tool whose real parameter IS `file` keeps it. */
+   cJSON *schema2 =
+       cJSON_Parse("{\"type\":\"object\",\"properties\":{\"file\":{\"type\":\"string\"}}}");
+   cJSON *raw2 = cJSON_Parse("{\"file\":\"/tmp/y\"}");
+   cJSON *out2 = tool_args_canonicalize(schema2, raw2);
+   cJSON *kept = cJSON_GetObjectItemCaseSensitive(out2, "file");
+   assert(kept && cJSON_IsString(kept) && strcmp(kept->valuestring, "/tmp/y") == 0);
+   assert(cJSON_GetObjectItemCaseSensitive(out2, "path") == NULL);
+   cJSON_Delete(out2);
+   cJSON_Delete(raw2);
+   cJSON_Delete(schema2);
+
+   /* An explicit `path` already present is never overwritten by an alias. */
+   cJSON *schema3 =
+       cJSON_Parse("{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}");
+   cJSON *raw3 = cJSON_Parse("{\"path\":\"/real\",\"filepath\":\"/decoy\"}");
+   cJSON *out3 = tool_args_canonicalize(schema3, raw3);
+   cJSON *p = cJSON_GetObjectItemCaseSensitive(out3, "path");
+   assert(p && strcmp(p->valuestring, "/real") == 0);
+   cJSON_Delete(out3);
+   cJSON_Delete(raw3);
+   cJSON_Delete(schema3);
+   printf("  PASS: test_alias_rewrites_only_toward_a_declared_parameter\n");
+}
+
+/* The whole point: the bytes the gates authorize are the bytes that execute.
+ * Before the canonicalizer, the authorizer saw {"paths":"/etc/passwd"} while
+ * the tool ran {"paths":["/etc/passwd"]}. */
+static void test_authorized_bytes_equal_executed_bytes(void)
+{
+   cJSON *schema = cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                               "\"paths\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}}}");
+   const char *raw = "{\"paths\":\"/etc/passwd\"}";
+
+   /* What the agent loop computes once and hands to every gate. */
+   char *gate_view = tool_args_canonicalize_json(schema, raw);
+   assert(gate_view != NULL);
+
+   /* What the dispatcher independently derives for its own entry points. */
+   cJSON *parsed = cJSON_Parse(gate_view);
+   cJSON *executed = tool_args_canonicalize(schema, parsed);
+   char *executed_view = cJSON_PrintUnformatted(executed);
+
+   assert(strcmp(gate_view, executed_view) == 0);
+   assert(strcmp(gate_view, raw) != 0); /* load-bearing: the shape really did change */
+
+   free(executed_view);
+   cJSON_Delete(executed);
+   cJSON_Delete(parsed);
+   free(gate_view);
+   cJSON_Delete(schema);
+   printf("  PASS: test_authorized_bytes_equal_executed_bytes\n");
+}
+
+/* Unparseable arguments are the validator's error to report, not something to
+ * paper over here: the caller keeps the raw string so the failure surfaces with
+ * a useful message instead of being silently replaced with {}. */
+static void test_invalid_json_is_left_for_the_validator(void)
+{
+   cJSON *schema = cJSON_Parse("{\"type\":\"object\",\"properties\":{}}");
+   assert(tool_args_canonicalize_json(schema, "{not json") == NULL);
+   cJSON_Delete(schema);
+   printf("  PASS: test_invalid_json_is_left_for_the_validator\n");
+}
+
 int main(void)
 {
    printf("tool_args_coerce:\n");
@@ -159,6 +283,10 @@ int main(void)
    test_already_correct_passthrough();
    test_null_schema_clones();
    test_failed_coercion_leaves_alone();
+   test_canonicalize_is_idempotent();
+   test_alias_rewrites_only_toward_a_declared_parameter();
+   test_authorized_bytes_equal_executed_bytes();
+   test_invalid_json_is_left_for_the_validator();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_tool_validation.c
+++ b/src/tests/test_tool_validation.c
@@ -208,13 +208,13 @@ static void test_validate_alias_filepath_normalized(void)
 {
    setup_db();
    char err[256] = {0};
-   int rc = canonicalize_then_validate("read_file", "{\"filepath\":\"/tmp/x\"}", err, sizeof(err));
+   const char *raw = "{\"filepath\":\"/tmp/x\"}";
+   int rc = canonicalize_then_validate("read_file", raw, err, sizeof(err));
    assert(rc == 0);
 
    /* Load-bearing: the alias is resolved in the bytes that go on to execute,
     * not merely inside the validator. */
-   char *canonical = tool_args_canonicalize_json(agent_tool_get_schema_cached("read_file"),
-                                                 "{\"filepath\":\"/tmp/x\"}");
+   char *canonical = tool_args_canonicalize_json(agent_tool_get_schema_cached("read_file"), raw);
    assert(canonical != NULL);
    assert(strstr(canonical, "\"path\"") != NULL);
    assert(strstr(canonical, "filepath") == NULL);
@@ -251,7 +251,7 @@ static void test_validate_does_not_rewrite_arguments(void)
 {
    setup_db();
    char err[256] = {0};
-   int rc = tool_validate("read_file", "{\"filepath\":\"/tmp/x\"}", err, sizeof(err));
+   int rc = tool_validate("read_file", "{\"filepath\":\"/doc/a.txt\"}", err, sizeof(err));
    assert(rc != 0); /* `path` is required and an un-canonicalized call lacks it */
    teardown_db();
    printf("  PASS: tool_validate judges without rewriting\n");

--- a/src/tests/test_tool_validation.c
+++ b/src/tests/test_tool_validation.c
@@ -11,6 +11,8 @@
 
 #include "../headers/aimee.h"
 #include "../headers/agent_exec.h"
+#include "../headers/tool_args_coerce.h"
+#include <aimee/tools/agent_tools.h>
 #include "db1_client/db1.h"
 #include "../modules/db2/c/db2.h"
 #include "../modules/db2/c/db2_test_shim.h"
@@ -184,38 +186,75 @@ static void test_validate_valid_bash(void)
    printf("  PASS: valid bash call returns 0\n");
 }
 
-/* --- alias normalization in tool_validate --- */
+/* --- alias resolution across the real pipeline ---------------------------
+ *
+ * Alias resolution moved OUT of tool_validate. It used to happen on a copy the
+ * validator discarded, so validation accepted {"filepath": ...} and the tool
+ * then received no `path` at all -- validation was more permissive than
+ * execution. It now happens once in the canonicalizer, before any gate, and
+ * these tests exercise that order rather than the validator alone. */
+
+/* What src/posix/agent_runtime.c does per call: canonicalize once, then let
+ * every gate judge the bytes that will actually execute. */
+static int canonicalize_then_validate(const char *tool, const char *raw, char *err, size_t err_len)
+{
+   char *canonical = tool_args_canonicalize_json(agent_tool_get_schema_cached(tool), raw);
+   int rc = tool_validate(tool, canonical ? canonical : raw, err, err_len);
+   free(canonical);
+   return rc;
+}
 
 static void test_validate_alias_filepath_normalized(void)
 {
    setup_db();
    char err[256] = {0};
-   /* 'filepath' is an alias for 'path'; validation should normalize and pass */
-   int rc = tool_validate("read_file", "{\"filepath\":\"/tmp/x\"}", err, sizeof(err));
+   int rc = canonicalize_then_validate("read_file", "{\"filepath\":\"/tmp/x\"}", err, sizeof(err));
    assert(rc == 0);
+
+   /* Load-bearing: the alias is resolved in the bytes that go on to execute,
+    * not merely inside the validator. */
+   char *canonical = tool_args_canonicalize_json(agent_tool_get_schema_cached("read_file"),
+                                                 "{\"filepath\":\"/tmp/x\"}");
+   assert(canonical != NULL);
+   assert(strstr(canonical, "\"path\"") != NULL);
+   assert(strstr(canonical, "filepath") == NULL);
+   free(canonical);
+
    teardown_db();
-   printf("  PASS: alias 'filepath' normalized to 'path' in validation\n");
+   printf("  PASS: alias 'filepath' resolves to 'path' before the gates\n");
 }
 
 static void test_validate_alias_file_normalized(void)
 {
    setup_db();
    char err[256] = {0};
-   int rc = tool_validate("read_file", "{\"file\":\"/tmp/x\"}", err, sizeof(err));
+   int rc = canonicalize_then_validate("read_file", "{\"file\":\"/tmp/x\"}", err, sizeof(err));
    assert(rc == 0);
    teardown_db();
-   printf("  PASS: alias 'file' normalized to 'path' in validation\n");
+   printf("  PASS: alias 'file' resolves to 'path' before the gates\n");
 }
 
 static void test_validate_alias_cmd_normalized(void)
 {
    setup_db();
    char err[256] = {0};
-   /* 'cmd' is an alias for 'command' */
-   int rc = tool_validate("bash", "{\"cmd\":\"ls\"}", err, sizeof(err));
+   int rc = canonicalize_then_validate("bash", "{\"cmd\":\"ls\"}", err, sizeof(err));
    assert(rc == 0);
    teardown_db();
-   printf("  PASS: alias 'cmd' normalized to 'command' in validation\n");
+   printf("  PASS: alias 'cmd' resolves to 'command' before the gates\n");
+}
+
+/* tool_validate itself is now pure: it judges, it does not rewrite. If it still
+ * normalized internally we would be back to validating one shape and running
+ * another, which is the defect the canonicalizer exists to close. */
+static void test_validate_does_not_rewrite_arguments(void)
+{
+   setup_db();
+   char err[256] = {0};
+   int rc = tool_validate("read_file", "{\"filepath\":\"/tmp/x\"}", err, sizeof(err));
+   assert(rc != 0); /* `path` is required and an un-canonicalized call lacks it */
+   teardown_db();
+   printf("  PASS: tool_validate judges without rewriting\n");
 }
 
 int main(void)
@@ -242,6 +281,7 @@ int main(void)
    test_validate_alias_filepath_normalized();
    test_validate_alias_file_normalized();
    test_validate_alias_cmd_normalized();
+   test_validate_does_not_rewrite_arguments();
 
    printf("All tool_validation tests passed.\n");
    return 0;

--- a/src/tests/test_web_egress.c
+++ b/src/tests/test_web_egress.c
@@ -89,6 +89,57 @@ static void test_v4_mapped_is_judged_on_the_v4(void)
    printf("  PASS: IPv4-mapped v6 is judged on the embedded v4\n");
 }
 
+/* v4-mapped is only one of the ways to spell an IPv4 destination as an IPv6
+ * literal. NAT64, 6to4, Teredo and the deprecated v4-compatible form all name
+ * 169.254.169.254 without matching any blocked v6 prefix, so a guard that
+ * handles only ::ffff: admits the metadata service by another name. Whether a
+ * given network has a NAT64 gateway or a 6to4 relay is not a property this
+ * classifier can check, so it does not assume their absence. */
+static void test_every_transition_form_is_judged_on_the_v4(void)
+{
+   /* NAT64, well-known 64:ff9b::/96 and local-use 64:ff9b:1::/48 */
+   assert(blocked_v6("64:ff9b::a9fe:a9fe")); /* -> 169.254.169.254 */
+   assert(blocked_v6("64:ff9b::7f00:1"));    /* -> 127.0.0.1 */
+   assert(blocked_v6("64:ff9b::a00:5"));     /* -> 10.0.0.5 */
+   assert(blocked_v6("64:ff9b:1::a9fe:a9fe"));
+   /* 6to4 carries the v4 at bytes 2..5 */
+   assert(blocked_v6("2002:a9fe:a9fe::")); /* -> 169.254.169.254 */
+   assert(blocked_v6("2002:7f00:1::"));    /* -> 127.0.0.1 */
+   /* v4-compatible ::a.b.c.d (deprecated, still routed by some stacks) */
+   assert(blocked_v6("::a9fe:a9fe"));   /* -> 169.254.169.254 */
+   assert(blocked_v6("::192.168.1.1")); /* -> 192.168.1.1 */
+   /* Teredo 2001::/32: the client v4 is the trailing 32 bits, complemented. */
+   assert(blocked_v6("2001::5601:5601")); /* ^169.254.169.254 */
+   assert(blocked_v6("2001::80ff:fffe")); /* ^127.0.0.1 */
+   assert(blocked_v6("2001::f5ff:fffe")); /* ^10.0.0.1 */
+
+   /* The same forms carrying a PUBLIC v4 must still be reachable, or the guard
+    * has simply banned IPv6 transition addressing. */
+   assert(!blocked_v6("64:ff9b::808:808")); /* -> 8.8.8.8 */
+   assert(!blocked_v6("2002:808:808::"));   /* -> 8.8.8.8 */
+   assert(!blocked_v6("2001::f7f7:f7f7"));  /* Teredo -> 8.8.8.8 */
+   /* 2001::/32 is Teredo; 2001:4860::/32 is ordinary global unicast. */
+   assert(!blocked_v6("2001:4860:4860::8888"));
+   printf("  PASS: NAT64, 6to4, Teredo and v4-compatible are judged on the embedded v4\n");
+}
+
+/* The v4 deny-list is kept in step with the Go planes (proxyguard.go,
+ * proxy_policy.go). A destination refused on one plane and dialed on another is
+ * the inconsistency this pins. */
+static void test_reserved_ranges_match_the_go_planes(void)
+{
+   assert(blocked_v4("192.0.0.1"));    /* IETF protocol assignments */
+   assert(blocked_v4("192.0.2.1"));    /* TEST-NET-1 */
+   assert(blocked_v4("192.88.99.1"));  /* 6to4 relay anycast (deprecated) */
+   assert(blocked_v4("198.18.0.1"));   /* benchmarking */
+   assert(blocked_v4("198.51.100.1")); /* TEST-NET-2 */
+   assert(blocked_v4("203.0.113.1"));  /* TEST-NET-3 */
+   assert(blocked_v4("240.0.0.1"));    /* reserved */
+   assert(!blocked_v4("198.20.0.1"));  /* just outside 198.18/15 */
+   assert(!blocked_v4("192.89.99.1")); /* just outside 192.88.99/24 */
+   printf("  PASS: reserved ranges match the Go proxy planes\n");
+}
+
 /* Over-blocking would make the tool useless; public addresses must pass. */
 static void test_public_addresses_pass(void)
 {
@@ -157,6 +208,8 @@ int main(void)
 {
    test_blocks_the_dangerous_destinations();
    test_v4_mapped_is_judged_on_the_v4();
+   test_every_transition_form_is_judged_on_the_v4();
+   test_reserved_ranges_match_the_go_planes();
    test_public_addresses_pass();
    test_private_endpoint_opt_in_is_env_only();
    test_rejects_non_http_and_malformed();


### PR DESCRIPTION
Two defects surfaced while reading [amitpatole/babelagent](https://github.com/amitpatole/babelagent) for ideas worth taking. Both are in our own code; neither is a design borrowed from it.

## 1. SSRF: IPv6 transition addresses bypassed the guards

NAT64, 6to4, Teredo and the deprecated v4-compatible form each name an IPv4 destination as an IPv6 literal that matches no blocked v6 prefix. A guard that handles only `::ffff:` admits `169.254.169.254` as `64:ff9b::a9fe:a9fe`, `2002:a9fe:a9fe::`, `::a9fe:a9fe` or `2001::5601:5601`.

Five guards disagreed about this:

| Guard | Was |
|---|---|
| `src/posix/web_egress.c:52` | v4-mapped only |
| `src/kb/kb_mgmt_endpoint.c:108` | v4-mapped only |
| `delegates/proxyguard.go:126` | missing Teredo, local-use NAT64 |
| `sandbox/proxy_policy.go:82` | missing Teredo, local-use NAT64 |
| `egress/egress.go:280` | stdlib predicates only — no transition forms, and CGNAT `100.64/10` passed |

So the same destination was refused on one plane and dialed on another.

`src/headers/ip_transition.h` is now the one definition of which IPv4 an IPv6 address names, shared by both C guards; the three Go planes carry the matching table. `web_egress`'s v4 deny-list also gains the ranges the Go planes already blocked (`192.0.0/24`, the TEST-NETs, `198.18/15`, `192.88.99/24`).

Reachability depends on whether a network has a NAT64 gateway or 6to4 relay — a property of the network, not the request, which is why no guard should assume their absence.

`src/windows/agent_runtime.c` is not an instance: it is a three-tool thin-client stub with no authorization step at all.

## 2. Tool arguments: the authorizer and the executor saw different bytes

A tool call was normalized twice, differently, and authorized on neither result:

- `agent_policy.c:139` resolved one alias table on a copy it deleted at line 194.
- `agent_tools_dispatch.c:2105` resolved a **different, smaller** table and ran the schema coercion — and that result executed.
- `policy_check_tool`, `directive_check_tool` and the audit record all saw the raw arguments.

Consequences: a fail-closed authorizer could permit `{"paths": "/etc/passwd"}` while the tool ran `{"paths": ["/etc/passwd"]}`, and the WORM record described a call that never executed. Aliases were the mirror image — validation accepted `{"filepath": ...}` because it renamed the key on the discarded copy, and the tool then received no `path` at all.

`tool_args_canonicalize` is now the single place shape is decided. `agent_runtime.c` calls it per turn and rewrites `parsed.calls[i].arguments` **in place**, so every reader below — rounds-to-resume, `tool_validate`, `policy_check_tool`, `directive_check_tool`, the executor, the audit record, stuck-detection — sees the same bytes without opting in, and a reader added later cannot miss it. It is idempotent, so the dispatcher keeps calling it for `script_rpc` and the MCP gateway.

Two behaviour changes worth review:

- **Aliases now guard on the schema**, rewriting only toward a declared parameter. The dispatcher's unguarded rewrite would rename a tool's genuine `file` argument to `path`; that was harmless only while the result was discarded, and making it live without the guard would have been a regression.
- **`additionalProperties: false` is honoured** when a schema declares it. Standard semantics, opt-in, so nothing that omits the keyword changes.

`test_tool_validation.c` had three tests asserting the validator normalizes internally. They now exercise the real pipeline (canonicalize, then validate), plus one pinning that `tool_validate` no longer rewrites.

## 3. Docs (no code)

A proposal and design doc for a Python module seating LangGraph graphs on the memory and delegate stages. Included here because the second fix is its precondition: two orchestrators deriving argument shape independently would reintroduce exactly the defect above. Event kinds in the design doc are derivations, not allocations.

## Verification

`unit-test-web-egress`, `unit-test-kb-mgmt-endpoint`, `unit-test-tool-args-coerce`, `unit-test-tool-validation`, `unit-test-agent`, `unit-test-guardrails`, `unit-test-execution-policy-bus`, `unit-test-mcp-gateway-tools`, `unit-test-mcp-native-dispatch`, `unit-test-server-dispatch`, `unit-test-toolset`, `unit-test-tool-schema-sanitizer`, `unit-test-minimax-tool-call-args` all pass. Go tests pass for the three modules. `-Werror` clean, `clang-format-19` clean, `gofmt`/`go vet` clean, `check-docs.py` and `check_module_docs.py` pass.

Re-run in full against the `testing` base after rebasing off it.
