### PR TITLE
fix(release): repair published-image startup and E2E rigs

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -587,7 +587,12 @@ fi
 # the extracted config process.
 DEPLOY_ENV_DIR="${AIMEE_DEPLOY_COMPOSE_DIR:-/opt/aimee/deploy}"
 if [ -d "$DEPLOY_ENV_DIR" ]; then
-    if runuser -u aimee -- env AIMEE_HOME="$AIMEE_HOME" aimee config deploy-env \
+    # The image ships the remote-only thin client.  It deliberately has no
+    # implicit co-located topology, so name the Unix socket the entrypoint just
+    # waited for instead of relying on the retired local default.
+    if runuser -u aimee -- env AIMEE_HOME="$AIMEE_HOME" \
+        AIMEE_API_ENDPOINT="unix:$AIMEE_HOME/aimee-http.sock" \
+        aimee config deploy-env \
         >"$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null; then
         chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null || true
         mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"

--- a/scripts/check-cited-paths-exist.py
+++ b/scripts/check-cited-paths-exist.py
@@ -47,7 +47,24 @@ SCAN_SUFFIXES = {".go", ".c", ".h", ".py", ".sh", ".md", ".mk", ".sql"}
 # reader to follow.
 COMMENT = re.compile(r"^\s*(//|#|\*|/\*|--|>)")
 SCAN_NAMES = {"Makefile", "CONTRIBUTING.md", "README.md"}
-SKIP_DIRS = {".git", "build", "obj", "node_modules", ".ci-logs", "vendor", ".venv"}
+# Agent-managed worktree directories contain generated full-repository
+# checkouts. Walking them makes this gate scan every active and retained
+# worktree as though it were part of the checkout under test (hundreds of
+# copies on a busy host). Keep these paths exact so a tracked directory named
+# `worktrees` elsewhere remains in scope.
+SKIP_DIRS = {
+    ".git",
+    "build",
+    "obj",
+    "node_modules",
+    ".ci-logs",
+    "vendor",
+    ".venv",
+}
+SKIP_TREES = {
+    REPO_ROOT / ".aimee",
+    REPO_ROOT / ".claude" / "worktrees",
+}
 
 # A path with an extension, or a directory reference ending in a slash.
 CITATION = re.compile(
@@ -69,7 +86,11 @@ HISTORY = re.compile(
 def scan_files() -> list[Path]:
     out = []
     for root, dirs, files in os.walk(REPO_ROOT):
-        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in SKIP_DIRS and Path(root, d) not in SKIP_TREES
+        ]
         for name in files:
             path = Path(root) / name
             if path.suffix in SCAN_SUFFIXES or name in SCAN_NAMES:

--- a/src/tests/test_deploy_compose_env.sh
+++ b/src/tests/test_deploy_compose_env.sh
@@ -53,6 +53,12 @@ grep -q -- 'aimee config deploy-env' "$entrypoint" \
     && r=yes || r=no
 check "entrypoint derives the env from config" "yes" "$r"
 
+# The container carries the remote-only thin client, whose lack of an implicit
+# local endpoint is deliberate.  The entrypoint has just waited for this Unix
+# socket, so it must name it when invoking the client.
+grep -q 'AIMEE_API_ENDPOINT="unix:$AIMEE_HOME/aimee-http.sock"' "$entrypoint" && r=yes || r=no
+check "entrypoint points the thin client at the live Unix socket" "yes" "$r"
+
 grep -q 'DEPLOY_ENV_DIR' "$entrypoint" && r=yes || r=no
 check "entrypoint targets the compose project directory" "yes" "$r"
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -30,8 +30,8 @@ a real maintenance cycle, so do not point it at anything you care about.
 # 1. inside the throwaway box, as root
 tests/e2e/provision-pg-env.sh
 
-# 2. build
-cd src && make -j$(nproc) server all
+# 2. build the daemons and their required config module
+cd src && make -j$(nproc) server all build/obj/aimee-module-config
 
 # 3. let aimee-kb apply the schema itself (see the warning below)
 ./aimee-kb --http-port=8911

--- a/tests/e2e/learning-loops-pg-e2e.sh
+++ b/tests/e2e/learning-loops-pg-e2e.sh
@@ -26,7 +26,9 @@
 #   WORKDIR        scratch for HOMEs and logs                    (default /tmp/learning-loops)
 #   PGDB           the throwaway database                        (default aimee_shared)
 #   AIMEE_DB2_URL  libpq URL reaching that database
-#   AIMEE_STORE_URL PostgreSQL URL for the daemon store (defaults to AIMEE_DB2_URL)
+#   AIMEE_STORE_URL non-owner PostgreSQL URL for the daemon store (required)
+#   AIMEE_STORE_MIGRATION_URL owner URL used only for schema migration
+#                             (required and must name a different role)
 #   KB_PORT        TCP port for aimee-kb                         (default 18745)
 #
 # Every assertion prints PASS or FAIL; the script exits non-zero if any failed.
@@ -39,7 +41,14 @@ WORKDIR="${WORKDIR:-/tmp/learning-loops}"
 KB_PORT="${KB_PORT:-18745}"
 PGDB="${PGDB:-aimee_shared}"
 export AIMEE_DB2_URL="${AIMEE_DB2_URL:-postgres:///$PGDB?host=/var/run/postgresql}"
-export AIMEE_STORE_URL="${AIMEE_STORE_URL:-$AIMEE_DB2_URL}"
+export AIMEE_STORE_URL="${AIMEE_STORE_URL:-}"
+export AIMEE_STORE_MIGRATION_URL="${AIMEE_STORE_MIGRATION_URL:-}"
+[ -n "$AIMEE_STORE_URL" ] || {
+  echo "AIMEE_STORE_URL is required and must name the non-owner store role" >&2; exit 1;
+}
+[ -n "$AIMEE_STORE_MIGRATION_URL" ] || {
+  echo "AIMEE_STORE_MIGRATION_URL is required and must name the schema owner" >&2; exit 1;
+}
 OBJ="$AIMEE_SRC/build/obj"
 KBHOME="$WORKDIR/kbhome"
 SRVHOME="$WORKDIR/srvhome"
@@ -93,6 +102,7 @@ attach() { # attach <name> <home> <bus> <tag>
     [ -x "$2/.config/aimee/aimee-module-$1" ] || return 1
     env HOME="$2" AIMEE_HOME="$2/.config/aimee" AIMEE_DB1_PATH="$2/.config/aimee/aimee.db" \
         AIMEE_DB2_URL="$AIMEE_DB2_URL" AIMEE_STORE_URL="$AIMEE_STORE_URL" \
+        AIMEE_STORE_MIGRATION_URL="$AIMEE_STORE_MIGRATION_URL" \
         "$2/.config/aimee/aimee-module-$1" "$3" > "$WORKDIR/mod-$4-$1.log" 2>&1 &
     MOD_PIDS="$MOD_PIDS $!"
 }

--- a/tests/e2e/module-liveness-pg-e2e.sh
+++ b/tests/e2e/module-liveness-pg-e2e.sh
@@ -25,6 +25,9 @@
 #   AIMEE_SRC      the source tree, for build/obj                (default $AIMEE_ROOT/src)
 #   WORKDIR        scratch for HOMEs and logs                    (default /tmp/module-liveness)
 #   AIMEE_DB2_URL  libpq URL for a throwaway database
+#   AIMEE_STORE_URL non-owner runtime URL for the daemon store (required)
+#   AIMEE_STORE_MIGRATION_URL owner URL used only for schema migration
+#                             (required and must name a different role)
 #   PGDB            optional psql read-back DSN (default $AIMEE_DB2_URL)
 #   KB_PORT        TCP port for aimee-kb                         (default 18744)
 #
@@ -37,6 +40,14 @@ AIMEE_SRC="${AIMEE_SRC:-$AIMEE_ROOT/src}"
 WORKDIR="${WORKDIR:-/tmp/module-liveness}"
 KB_PORT="${KB_PORT:-18744}"
 export AIMEE_DB2_URL="${AIMEE_DB2_URL:-postgres:///aimee_shared?host=/var/run/postgresql}"
+export AIMEE_STORE_URL="${AIMEE_STORE_URL:-}"
+export AIMEE_STORE_MIGRATION_URL="${AIMEE_STORE_MIGRATION_URL:-}"
+[ -n "$AIMEE_STORE_URL" ] || {
+    echo "AIMEE_STORE_URL is required and must name the non-owner store role" >&2; exit 1;
+}
+[ -n "$AIMEE_STORE_MIGRATION_URL" ] || {
+    echo "AIMEE_STORE_MIGRATION_URL is required and must name the schema owner" >&2; exit 1;
+}
 PGDB="${PGDB:-$AIMEE_DB2_URL}"
 OBJ="$AIMEE_SRC/build/obj"
 KBHOME="$WORKDIR/kbhome"
@@ -85,6 +96,8 @@ attach() { # attach <name> <home> <bus> <tag>
     [ -x "$home/.config/aimee/aimee-module-$name" ] || return 1
     env HOME="$home" AIMEE_HOME="$home/.config/aimee" \
         AIMEE_DB1_PATH="$home/.config/aimee/aimee.db" AIMEE_DB2_URL="$AIMEE_DB2_URL" \
+        AIMEE_STORE_URL="$AIMEE_STORE_URL" \
+        AIMEE_STORE_MIGRATION_URL="$AIMEE_STORE_MIGRATION_URL" \
         "$home/.config/aimee/aimee-module-$name" "$bus" > "$WORKDIR/mod-$tag-$name.log" 2>&1 &
     MOD_PIDS="$MOD_PIDS $!"
     return 0
@@ -135,7 +148,7 @@ check "health names the production capture failure" "open_failed" "${CAPTURE_REA
 GAP_ROWS=0
 for _ in $(seq 1 30); do
     GAP_ROWS=$(psql -d "$PGDB" -tA -c \
-        "SELECT count(*) FROM kb_audit_event WHERE action='bus.capture.gap' AND verdict='open_failed'" \
+        "SELECT count(*) FROM kb_audit_outbox WHERE action='bus.capture.gap' AND verdict='open_failed'" \
         2>/dev/null)
     [ "${GAP_ROWS:-0}" -gt 0 ] && break
     sleep 1
@@ -156,11 +169,31 @@ check "every KB module is still attached" "0" "$dead"
 printf '        %d attached\n' "$alive"
 
 section "1  aimee-server, with every module it is granted"
-SRV_MODULES="config db1 learning memory routing delegates tools workspace git skills
+SRV_MODULES="config postgres learning memory routing delegates tools workspace git skills
              response-composition execution-policy governance roundtable runtime-web sandbox economizer benchmarks aimee"
+SRV_MODULES="$SRV_MODULES egress"
 SRV_DEPLOYED=""
 for m in $SRV_MODULES; do
     deploy server "$m" "$SRVHOME" && SRV_DEPLOYED="$SRV_DEPLOYED $m"
+done
+# Several Go modules serve under one identity and make outbound calls under
+# narrower companion identities.  Every companion grant must point at the same
+# launched executable; launching companions would duplicate serving processes.
+deploy_companion() { # deploy_companion <grant> <serving-module>
+    local companion="$1" module="$2"
+    grant="$OBJ/module-bundle/grants/server/$companion.grant"
+    if [ -r "$grant" ] && [ -x "$SRVHOME/.config/aimee/aimee-module-$module" ]; then
+        sed "s|^executable=.*|executable=$SRVHOME/.config/aimee/aimee-module-$module|" "$grant" \
+            > "$SRVHOME/.config/aimee/modules.d/server/$companion.grant"
+    else
+        bad "companion grant '$companion' is not deployable"
+    fi
+}
+for spec in \
+    aimee-db1:aimee aimee-postgres:aimee economizer-db1:economizer \
+    git-egress:git memory-egress:memory roundtable-delegates:roundtable \
+    roundtable-egress:roundtable; do
+    deploy_companion "${spec%%:*}" "${spec#*:}"
 done
 printf '        deployed:%s\n' "$SRV_DEPLOYED"
 
@@ -176,9 +209,19 @@ for _ in $(seq 1 300); do [ -S "$SRVSOCK" ] && break; sleep 0.2; done
 if [ -S "$SRVSOCK" ]; then ok "aimee-server is serving on its socket"
 else bad "aimee-server never came up"; tail -15 "$WORKDIR/server.log"; fi
 
+# The socket can precede the store's schema migration.  Wait for the exact
+# surface below to become live and fail here with its module log if it does not.
 export HOME="$SRVHOME" AIMEE_HOME="$SRVHOME/.config/aimee"
 export AIMEE_API_ENDPOINT="unix:$SRVSOCK"
 A="$AIMEE_ROOT/aimee"
+store_up=0
+for _ in $(seq 1 120); do
+    STORE_PROBE=$("$A" eval candidates --limit 1 2>&1 | head -1)
+    printf '%s' "$STORE_PROBE" | grep -q 'could not read candidates' || { store_up=1; break; }
+    sleep 0.5
+done
+if [ "$store_up" = 1 ]; then ok "the daemon store is serving"
+else bad "the daemon store never attached"; tail -12 "$WORKDIR/mod-srv-aimee.log"; fi
 
 section "2  the surfaces answer"
 # Breadth is the point: the classifier gap was invisible because nothing drove

--- a/tests/e2e/provision-pg-env.sh
+++ b/tests/e2e/provision-pg-env.sh
@@ -17,6 +17,8 @@ set -euo pipefail
 PGDB="${PGDB:-aimee_test}"
 PGUSER="${PGUSER:-aimee}"
 PGPASS="${PGPASS:-aimee}"
+PGSTOREUSER="${PGSTOREUSER:-aimee_store_runtime}"
+PGSTOREPASS="${PGSTOREPASS:-aimee-store-runtime}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -35,13 +37,31 @@ sleep 3
 
 su - postgres -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='$PGUSER'\"" | grep -q 1 || \
   su - postgres -c "psql -c \"CREATE ROLE $PGUSER LOGIN PASSWORD '$PGPASS' SUPERUSER\""
+su - postgres -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='$PGSTOREUSER'\"" | grep -q 1 || \
+  su - postgres -c "psql -c \"CREATE ROLE $PGSTOREUSER LOGIN PASSWORD '$PGSTOREPASS' \
+    NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS\""
 
 su - postgres -c "dropdb --if-exists $PGDB"
 su - postgres -c "createdb -O $PGUSER $PGDB"
 su - postgres -c "psql -d $PGDB -c 'CREATE EXTENSION IF NOT EXISTS vector'"
 
+# The Go daemon store enforces separate migration and runtime identities.  Its
+# migrations are owned by PGUSER; default privileges make every newly-created
+# object usable by the non-owner runtime without giving that role DDL rights.
+PGPASSWORD="$PGPASS" psql -v ON_ERROR_STOP=1 -h 127.0.0.1 -U "$PGUSER" -d "$PGDB" <<SQL
+GRANT CONNECT ON DATABASE $PGDB TO $PGSTOREUSER;
+GRANT USAGE ON SCHEMA public TO $PGSTOREUSER;
+ALTER DEFAULT PRIVILEGES FOR ROLE $PGUSER IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $PGSTOREUSER;
+ALTER DEFAULT PRIVILEGES FOR ROLE $PGUSER IN SCHEMA public
+  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO $PGSTOREUSER;
+ALTER DEFAULT PRIVILEGES FOR ROLE $PGUSER IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO $PGSTOREUSER;
+SQL
+
 echo
 echo "provisioned: postgresql://$PGUSER:***@127.0.0.1:5432/$PGDB"
+echo "store runtime: postgresql://$PGSTOREUSER:***@127.0.0.1:5432/$PGDB"
 PGPASSWORD="$PGPASS" psql -h 127.0.0.1 -U "$PGUSER" -d "$PGDB" -tAc 'SELECT version()'
 echo
 echo "next:"
@@ -50,3 +70,7 @@ echo "  2. start kb ONCE so it applies the schema (it needs an explicit port,"
 echo "     and exits immediately without one):"
 echo "         ./aimee-kb --http-port=8911"
 echo "  3. run the suite:    tests/e2e/typed-facts-pg-e2e.sh"
+echo
+echo "for module-liveness-pg-e2e.sh or learning-loops-pg-e2e.sh, export:"
+echo "  AIMEE_STORE_URL=postgresql://$PGSTOREUSER:$PGSTOREPASS@127.0.0.1:5432/$PGDB"
+echo "  AIMEE_STORE_MIGRATION_URL=postgresql://$PGUSER:$PGPASS@127.0.0.1:5432/$PGDB"

--- a/tests/e2e/typed-facts-pg-e2e.sh
+++ b/tests/e2e/typed-facts-pg-e2e.sh
@@ -15,6 +15,7 @@
 #
 # Usage:  ./typed-facts-pg-e2e.sh            (expects the env described below)
 #   AIMEE_ROOT   dir holding aimee-server / aimee-kb / aimee   (default /root/aimee)
+#   AIMEE_SRC    source tree holding the built config module    (default $AIMEE_ROOT/src)
 #   PGURL        libpq URL for a database the schema can be applied to
 #   KB_PORT      TCP port for aimee-kb                         (default 8911)
 #
@@ -22,13 +23,19 @@
 set -uo pipefail
 
 AIMEE_ROOT="${AIMEE_ROOT:-/root/aimee}"
+AIMEE_SRC="${AIMEE_SRC:-$AIMEE_ROOT/src}"
 KB_PORT="${KB_PORT:-8911}"
 PGHOST_="${PGHOST_:-127.0.0.1}"
 PGUSER_="${PGUSER_:-aimee}"
 PGDB_="${PGDB_:-aimee_test}"
 export PGPASSWORD="${PGPASSWORD:-aimee}"
+PGURL="${PGURL:-postgresql://$PGUSER_:$PGPASSWORD@$PGHOST_:5432/$PGDB_}"
+export AIMEE_DB2_URL="${AIMEE_DB2_URL:-$PGURL}"
 export AIMEE_HOME="${AIMEE_HOME:-/root/.aimee}"
 SOCK="$AIMEE_HOME/aimee-http.sock"
+CONFIG_MODULE="$AIMEE_SRC/build/obj/aimee-module-config"
+MODULE_BUNDLE="${TMPDIR:-/tmp}/typed-facts-modules.$$"
+MOD_PIDS=""
 
 PASS=0; FAIL=0
 check() { # check <name> <expected> <actual>
@@ -37,7 +44,7 @@ check() { # check <name> <expected> <actual>
 }
 section() { printf '\n=== %s\n' "$1"; }
 
-q()    { psql -h "$PGHOST_" -U "$PGUSER_" -d "$PGDB_" -tA -c "$1" 2>/dev/null; }
+q()    { psql -v ON_ERROR_STOP=1 -h "$PGHOST_" -U "$PGUSER_" -d "$PGDB_" -tA -c "$1"; }
 kb()   { curl -s --max-time 25 -X POST "http://127.0.0.1:$KB_PORT/v1/actions/$1" \
               -H 'Content-Type: application/json' -d "$2"; }
 srv()  { curl -s --max-time 25 --unix-socket "$SOCK" -X POST "http://localhost$1" \
@@ -63,26 +70,114 @@ maintain() {
 d=json.load(sys.stdin).get("summary", {})
 print("%s,%s"%(d.get("promoted"),d.get("expired")))'
 }
-seed_fact() { # seed_fact src rel tgt class conf weight asserted [superseded] [suppressed]
-  q "INSERT INTO entity_edges (source,relation,target,weight,edge_class,confidence_class,
-       confidence,asserted_at,superseded_at,suppressed)
-     VALUES ('$1','$2','$3',$6,'semantic','$4',$5,'$7','${8:-}',${9:-0});" >/dev/null
+# These tests deliberately seed pre-mutation-era rows so they can exercise the
+# public recall, maintenance and correction paths.  Current databases reject raw
+# semantic writes.  Suspend every user trigger in one transaction (matching the
+# upgrade-fixture strategy in scripts/validation/fact-authority/seed-facts.sh),
+# then restore the guards before commit.  A failed statement aborts the
+# transaction, so a fixture failure cannot leave the guards disabled.
+fixture_edges_sql() { # fixture_edges_sql <SQL touching semantic entity_edges>
+  q "BEGIN;
+     ALTER TABLE entity_edges DISABLE TRIGGER USER;
+     $1
+     ALTER TABLE entity_edges ENABLE TRIGGER USER;
+     COMMIT;"
+}
+seed_fact() { # seed_fact src rel tgt class conf evidence-count asserted
+  local rank=10 lifecycle=candidate
+  if [ "$4" = A ]; then rank=30; lifecycle=persistent; fi
+  fixture_edges_sql "WITH assertion AS (
+       INSERT INTO entity_edges
+         (source,relation,target,weight,relation_id,edge_class,confidence_class,
+          confidence,asserted_at,superseded_at,invalidated_at,suppressed,
+          authority_rank,lifecycle_state)
+       VALUES ('$1','$2','$3',$6,
+               (SELECT id FROM rel_types WHERE rel_type='$2' LIMIT 1),
+               'semantic','$4',$5,'$7','','',0,$rank,'$lifecycle')
+       RETURNING id
+     )
+     INSERT INTO fact_evidence
+       (assertion_id,source_kind,source_id,observed_at,stance)
+     SELECT id,'e2e-fixture','$1:$2:$3:' || n,'$7','supports'
+       FROM assertion CROSS JOIN generate_series(1,$6) AS n;" >/dev/null || {
+    echo "failed to seed fact: $1 $2 $3" >&2
+    exit 1
+  }
 }
 scrub() {
   q "DELETE FROM memory_entities WHERE entity LIKE 'e2e-%';
-     DELETE FROM memories WHERE key LIKE 'e2e-%';
-     DELETE FROM entity_edges WHERE source LIKE 'e2e-%' OR target LIKE 'e2e-%';" >/dev/null
+     DELETE FROM memories WHERE key LIKE 'e2e-%';" >/dev/null
+  fixture_edges_sql "DELETE FROM entity_edges
+       WHERE source LIKE 'e2e-%' OR target LIKE 'e2e-%';" >/dev/null
+  q "DELETE FROM memory_rejection_tombstones
+       WHERE object_kind='fact' AND (source LIKE 'e2e-%' OR target LIKE 'e2e-%');" >/dev/null
+}
+
+stop_stack() {
+  pkill -f aimee-server 2>/dev/null
+  pkill -f aimee-kb 2>/dev/null
+  for p in $MOD_PIDS; do
+    kill "$p" 2>/dev/null
+    wait "$p" 2>/dev/null
+  done
+  MOD_PIDS=""
+}
+
+cleanup() {
+  stop_stack
+  rm -rf "$MODULE_BUNDLE"
+}
+trap cleanup EXIT INT TERM
+
+prepare_config_modules() {
+  if [ ! -x "$CONFIG_MODULE" ]; then
+    echo "missing config module: $CONFIG_MODULE" >&2
+    echo "build it with: make -C $AIMEE_SRC build/obj/aimee-module-config" >&2
+    return 1
+  fi
+
+  rm -rf "$MODULE_BUNDLE"
+  python3 "$AIMEE_ROOT/scripts/export_c_repositories.py" \
+    --runtime-bundle "$MODULE_BUNDLE" >/dev/null || return 1
+  mkdir -p "$AIMEE_HOME/modules.d/kb" "$AIMEE_HOME/modules.d/server"
+  sed "s|^executable=.*|executable=$CONFIG_MODULE|" \
+    "$MODULE_BUNDLE/grants/kb/config.grant" > "$AIMEE_HOME/modules.d/kb/config.grant"
+  sed "s|^executable=.*|executable=$CONFIG_MODULE|" \
+    "$MODULE_BUNDLE/grants/server/config.grant" > "$AIMEE_HOME/modules.d/server/config.grant"
+  chmod 0600 "$AIMEE_HOME/modules.d/kb/config.grant" \
+    "$AIMEE_HOME/modules.d/server/config.grant"
+}
+
+arm_config_module() { # socket placement log
+  local bus="$1" placement="$2" log="$3"
+  (
+    local deadline=$((SECONDS + 30))
+    while (( SECONDS < deadline )); do
+      if [ -S "$bus" ]; then
+        exec env AIMEE_HOME="$AIMEE_HOME" \
+          AIMEE_MODULE_POLICY_DIR="$AIMEE_HOME/modules.d/$placement" \
+          "$CONFIG_MODULE" "$bus"
+      fi
+      sleep 0.1
+    done
+    echo "config module: bus socket never appeared: $bus" >&2
+  ) >"$log" 2>&1 &
+  MOD_PIDS="$MOD_PIDS $!"
 }
 
 start_stack() { # start_stack [extra-yaml]
-  pkill -f aimee-server 2>/dev/null; pkill -f aimee-kb 2>/dev/null; sleep 2
-  rm -f "$SOCK"
+  stop_stack
+  sleep 2
+  rm -f "$SOCK" "$AIMEE_HOME/kb-module-bus.sock" "$AIMEE_HOME/server-module-bus.sock"
   mkdir -p "$AIMEE_HOME"
-  { echo "db2_url: \"postgresql://$PGUSER_:$PGPASSWORD@$PGHOST_:5432/$PGDB_\""
+  { echo "db2_url: \"$AIMEE_DB2_URL\""
     echo 'kb_mode: "local"'
     echo "kb_client_url: \"http://127.0.0.1:$KB_PORT\""
     echo 'embedder_dims: 768'
     echo "${1:-typed_facts_enabled: true}"; } > "$AIMEE_HOME/aimee.yaml"
+  prepare_config_modules || return 1
+  arm_config_module "$AIMEE_HOME/kb-module-bus.sock" kb /tmp/typed-facts-kb-config.log
+  arm_config_module "$AIMEE_HOME/server-module-bus.sock" server /tmp/typed-facts-server-config.log
   cd "$AIMEE_ROOT"
   nohup ./aimee-kb --http-port="$KB_PORT" > /tmp/kb.log 2>&1 &
   sleep 22
@@ -120,16 +215,18 @@ q "INSERT INTO memory_entities (memory_id,entity,role,weight)
 check "no edge: only the lexical hit"            "$A"        "$(recall_ids zorblex)"
 seed_fact e2e-alice works_for e2e-acme A 1.0 1 '2026-01-01T00:00:00Z'
 check "semantic edge bridges to the 2nd memory"  "$A,$B"     "$(recall_ids zorblex)"
-q "UPDATE entity_edges SET superseded_at='2026-08-01T00:00:00Z' WHERE source='e2e-alice';" >/dev/null
+fixture_edges_sql "UPDATE entity_edges SET lifecycle_state='superseded',
+  superseded_at='2026-08-01T00:00:00Z' WHERE source='e2e-alice';" >/dev/null
 check "superseded fact leaves the walk"          "$A"        "$(recall_ids zorblex)"
-q "UPDATE entity_edges SET superseded_at='', suppressed=1 WHERE source='e2e-alice';" >/dev/null
+fixture_edges_sql "UPDATE entity_edges SET lifecycle_state='persistent',
+  superseded_at='', suppressed=1 WHERE source='e2e-alice';" >/dev/null
 check "tombstoned fact leaves the walk"          "$A"        "$(recall_ids zorblex)"
-q "UPDATE entity_edges SET suppressed=0 WHERE source='e2e-alice';" >/dev/null
+fixture_edges_sql "UPDATE entity_edges SET suppressed=0 WHERE source='e2e-alice';" >/dev/null
 check "restored fact returns to the walk"        "$A,$B"     "$(recall_ids zorblex)"
 
 # Regression: co-occurrence edges must still traverse. The change adds a
 # population, it must not remove one.
-q "DELETE FROM entity_edges WHERE source='e2e-alice';" >/dev/null
+fixture_edges_sql "DELETE FROM entity_edges WHERE source='e2e-alice';" >/dev/null
 q "INSERT INTO entity_edges (source,relation,target,weight,edge_class)
    VALUES ('e2e-alice','co_discussed','e2e-acme',3,'cooccurrence');" >/dev/null
 check "co-occurrence edge still bridges"         "$A,$B"     "$(recall_ids zorblex)"
@@ -156,8 +253,8 @@ seed_fact e2e-durable   works_for   e2e-ecorp B 0.6 5 '2000-01-01T00:00:00Z'
 seed_fact e2e-classa    works_for   e2e-corp  A 1.0 1 '2026-01-01T00:00:00Z'
 COUNTS=$(maintain)
 check "cycle reports promoted,expired"           "1,1" "$COUNTS"
-check "aged unconfirmed C is superseded"         "t"   "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-spec'")"
-check "confirmed C survives"                     "f"   "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-spec-conf'")"
+check "aged unconfirmed C is invalidated"        "t"   "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-spec'")"
+check "confirmed C survives"                     "f"   "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-spec-conf'")"
 check "class B promoted to durable"              "0.8" "$(q "SELECT confidence FROM entity_edges WHERE source='e2e-durable'")"
 check "class A untouched"                        "1"   "$(q "SELECT confidence FROM entity_edges WHERE source='e2e-classa'")"
 check "all typed facts survive the orphan prune" "4"   "$(q "SELECT count(*) FROM entity_edges WHERE source LIKE 'e2e-%'")"
@@ -171,7 +268,7 @@ seed_fact e2e-w-b works_for e2e-w-ecorp B 0.6 5 '2000-01-01T00:00:00Z'
 # orphan prune cannot delete it before normalisation runs.
 W=$(q "INSERT INTO memories (tier,kind,key,content,confidence,created_at,updated_at)
        VALUES ('L2','fact','e2e-wmem','anchor for e2e-w-noise and e2e-w-heavy',0.9,
-               '2026-01-01T00:00:00Z','2026-01-01T00:00:00Z') RETURNING id" | head -1)
+               pg_now_text(),pg_now_text()) RETURNING id" | head -1)
 q "INSERT INTO memory_entities (memory_id,entity,role,weight) VALUES ($W,'e2e-w-heavy','mention',1.0);
    INSERT INTO entity_edges (source,relation,target,weight,edge_class)
    VALUES ('e2e-w-heavy','works_for','e2e-w-noise',50,'cooccurrence');" >/dev/null
@@ -201,9 +298,14 @@ check "retract is idempotent"       '{"status":"ok","retracted":0}' \
 
 seed_fact e2e-r-a works_for e2e-r-acme A 1.0 1 '2026-01-01T00:00:00Z'
 srv /v1/facts/retract '{"source":"e2e-r-a","relation":"works_for","target":"e2e-r-acme","authority":"model"}' >/dev/null
-check "model may not retract class A" "f"  "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-r-a'")"
-srv /v1/facts/retract '{"source":"e2e-r-a","relation":"works_for","target":"e2e-r-acme","authority":"user"}' >/dev/null
-check "user may retract class A"      "t"  "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-r-a'")"
+check "model may not retract class A" "f"  "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-r-a'")"
+# This harness intentionally uses a plaintext server -> KB hop.  The body may
+# request user authority, but without an authenticated human principal the KB
+# must downgrade it to model authority rather than trust a self-declaration.
+check "anonymous request cannot escalate to user authority" '{"status":"ok","retracted":0}' \
+  "$(srv /v1/facts/retract '{"source":"e2e-r-a","relation":"works_for","target":"e2e-r-acme","authority":"user"}')"
+check "class A remains after refused escalation" "f"  \
+  "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-r-a'")"
 
 # target omitted -> retract every current value of (source, relation)
 scrub
@@ -218,16 +320,19 @@ seed_fact e2e-imm born_in e2e-berlin B 0.6 1 '2026-01-01T00:00:00Z'
 IMM=$(srv /v1/facts/retract '{"source":"e2e-imm","relation":"born_in","target":"e2e-berlin","authority":"model"}' |
       python3 -c 'import sys,json; print(json.load(sys.stdin).get("kind",""))')
 check "immutable relation refuses a model retraction" "invalid_argument" "$IMM"
-check "immutable fact untouched"                      "f" "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-imm'")"
-srv /v1/facts/retract '{"source":"e2e-imm","relation":"born_in","target":"e2e-berlin","authority":"user"}' >/dev/null
-check "user overrides immutable"                      "t" "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-imm'")"
+check "immutable fact untouched"                      "f" "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-imm'")"
+IMM=$(srv /v1/facts/retract '{"source":"e2e-imm","relation":"born_in","target":"e2e-berlin","authority":"user"}' |
+      python3 -c 'import sys,json; print(json.load(sys.stdin).get("kind",""))')
+check "anonymous user claim cannot override immutable" "invalid_argument" "$IMM"
+check "immutable fact remains after refused escalation" "f" \
+  "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-imm'")"
 
-# hard_delete correction behaviour tombstones rather than deleting
+# Corrections are retained and auditable rather than physically deleted.
 scrub
 seed_fact e2e-aka also_known_as e2e-alias B 0.6 1 '2026-01-01T00:00:00Z'
 srv /v1/facts/retract '{"source":"e2e-aka","relation":"also_known_as","target":"e2e-alias","authority":"user"}' >/dev/null
-check "hard_delete sets the tombstone flag" "1" "$(q "SELECT suppressed FROM entity_edges WHERE source='e2e-aka'")"
-check "hard_delete still RETAINS the row"   "1" "$(q "SELECT count(*) FROM entity_edges WHERE source='e2e-aka'")"
+check "correction invalidates the assertion" "t" "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-aka'")"
+check "correction still RETAINS the row"     "1" "$(q "SELECT count(*) FROM entity_edges WHERE source='e2e-aka'")"
 
 # entity merge / unmerge
 q "DELETE FROM entity_merges WHERE from_id IN (SELECT canonical_id FROM entity_registry WHERE kind=5);
@@ -270,18 +375,17 @@ check "a pii-tier fact still bridges the walk" "$P,$P2" "$(recall_ids quibblewic
 
 ########################################################################
 section "G. lifecycle runs even with typed_facts_enabled=false"
-# Deliberate: the master gate stops new typed WRITES; speculation already on
-# disk must still be allowed to age out, or turning the gate off freezes it
-# forever.
+# The master gate is retired and the typed-fact layer is unconditional.  A stale
+# deployment config must not resurrect the old behaviour or freeze candidates.
 scrub
 seed_fact e2e-gate frobnicates e2e-gt C 0.4 1 '2000-01-01T00:00:00Z'
 start_stack "typed_facts_enabled: false"
 maintain >/dev/null
 check "class C still expires with the gate off" "t" \
-  "$(q "SELECT (superseded_at<>'') FROM entity_edges WHERE source='e2e-gate'")"
+  "$(q "SELECT (invalidated_at<>'') FROM entity_edges WHERE source='e2e-gate'")"
 
 ########################################################################
 scrub
-pkill -f aimee-server 2>/dev/null; pkill -f aimee-kb 2>/dev/null
+stop_stack
 printf '\n===============================\n  PASS: %d   FAIL: %d\n===============================\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- point the container entrypoint thin client at the live Unix socket so deploy-env is written
- update PostgreSQL E2E rigs for current module grants, store-role separation, fact authority, and schema contracts
- skip agent-managed worktree forests in the cited-path validator

## Validation
- make -C src lint (76/76)
- src/tests/test_deploy_compose_env.sh
- bash -n on every changed shell script
- python3 scripts/check-cited-paths-exist.py (110 citations, 2.38s)
- git diff --check

Release context: this supersedes the stale testing-77d7ed7 artifact; after merge the newly published testing image must pass artifact-level startup, login, KB-variant, and deploy-env checks before 0.4.0 promotion.