### PR TITLE
fix(db2): satisfy strict placeholder formatting gate

### DIFF
--- a/src/modules/db2/c/epistemic_directives.c
+++ b/src/modules/db2/c/epistemic_directives.c
@@ -226,7 +226,10 @@ int db2_directive_list(const char *state, const char *cause, memory_directive_t 
       return 0;
 
    int idx = 1;
-   char placeholder[8];
+   /* "?" + a signed decimal int + NUL. Keep this sized for the type rather
+    * than the small parameter numbers used by the current queries so strict
+    * format-truncation builds can prove the snprintf is safe. */
+   char placeholder[16];
    if (have_state)
    {
       snprintf(placeholder, sizeof(placeholder), "?%d", idx++);
@@ -510,7 +513,9 @@ int db2_directive_match_by_lexical(const char *match_clause, memory_directive_t 
 
    /* Bind each LIKE pattern as '%token%'. */
    char like_bufs[ED_LEXICAL_MAX_TOKENS][ED_LEXICAL_MAX_TOKEN_LEN + 4];
-   char placeholder[8];
+   /* snprintf's argument is an int; size for its full decimal range even
+    * though the lexical query currently binds at most 17 parameters. */
+   char placeholder[16];
    for (int i = 0; i < n_tokens; i++)
    {
       size_t token_len = strlen(tokens[i]);

--- a/src/modules/db2/eventcontract/link-closure-v1.json
+++ b/src/modules/db2/eventcontract/link-closure-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 2,
   "module": "db2",
-  "source_revision": "c956c5341e53cb040b12ad5bcbba2ea392307d68",
-  "source_fingerprint": "354defdf7cfa33c0a10a209ee30106e8222309a528f127d279ac955ccc58c74d",
+  "source_revision": "69425e353eb063ea20b884529dced49b4bf617f9",
+  "source_fingerprint": "9dad4ae973e25851cfe2d1cdcde38a2dcd1b04d99fe532bbc99e6d18a292fcb0",
   "probe": {
     "compile_driver": "src/Makefile",
     "extra_c_flags": "-fno-lto -fno-common -fno-stack-protector -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM",
@@ -3245,5 +3245,5 @@
       "system-link": 140
     }
   },
-  "fingerprint": "ef965615cb46d041457dd952b5d62c7c6b6d1985659b726616b232c0fcb57cce"
+  "fingerprint": "bc88c720134efbd3b18a737d5c6bba252a59fcbb1568bbae1ca6bebfae8bfb75"
 }


### PR DESCRIPTION
Fix the final 0.4.0 promotion gate exposed by the testing-to-main PR. Strict GCC format-truncation analysis could not prove the DB2 lexical placeholder buffer safe for a formatted int. Size both DB2 placeholder buffers for the full int representation and regenerate the reviewed link-closure contract.\n\nValidated locally:\n- python3 -I -S scripts/check_db2_link_closure.py\n- python3 -I -S scripts/check_db2_link_closure.py --no-probe --previous-ref origin/main\n- python3 -I scripts/tests/test_check_db2_link_closure.py -v (62/62)\n- make -C src lint (76/76)