### PR TITLE
Release 0.4.0: repair release startup validation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -142,6 +142,7 @@ jobs:
     uses: ./.github/workflows/release-thin-client.yml
     permissions:
       contents: write
+      id-token: write
     with:
       version: ${{ needs.version.outputs.version }}
 
@@ -162,6 +163,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       version: ${{ needs.version.outputs.version }}
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -68,9 +68,6 @@ jobs:
   # Build each image for each arch on a native runner; push by digest only.
   build:
     needs: [prep]
-    # `models` is skipped on a pull request, and a skipped dependency would
-    # otherwise skip this job too. Proceed as long as it did not FAIL.
-    if: ${{ !cancelled() && needs.prep.result == 'success' && needs.models.result != 'failure' }}
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -32,6 +32,30 @@ require_reusable_only() {
     fi
 }
 
+job_block() {
+    local file=$1
+    local job=$2
+    awk -v header="  ${job}:" '
+        $0 == header { in_job = 1; print; next }
+        in_job && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+        in_job { print }
+    ' "$file"
+}
+
+require_job_permission() {
+    local file=$1
+    local job=$2
+    local permission=$3
+    local value=$4
+    local block
+    block=$(job_block "$file" "$job")
+
+    [ -n "$block" ] || fail "$file has no $job job"
+    printf '%s\n' "$block" |
+        grep -Eq "^      ${permission}:[[:space:]]+${value}[[:space:]]*$" ||
+        fail "$file $job job must grant ${permission}: ${value} to its reusable workflow"
+}
+
 auto_release="$repo_root/.github/workflows/auto-release.yml"
 main_approval="$repo_root/.github/workflows/main-merge-approval.yml"
 publish_images="$repo_root/.github/workflows/publish-images.yml"
@@ -53,6 +77,12 @@ grep -Fq 'uses: ./.github/workflows/publish-images.yml' "$auto_release" ||
     fail "$auto_release must call the guarded image publisher"
 grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
     fail "$auto_release must call the guarded thin-client publisher"
+
+# Both publishers create keyless signatures and request an OIDC token. GitHub
+# validates reusable-workflow permissions only when auto-release is triggered;
+# without these caller grants the release fails at startup before any job exists.
+require_job_permission "$auto_release" thin-clients id-token write
+require_job_permission "$auto_release" images id-token write
 
 approval_job=$(awk '
     /^  approval:[[:space:]]*$/ { in_approval = 1; print; next }


### PR DESCRIPTION
## Release intent

Promote the corrected `testing` head for the 0.4.0 release. PR #2933 merged successfully, but its post-merge release workflow failed during graph validation before any job ran:

- failed run: https://github.com/RakuenSoftware/aimee/actions/runs/33427939076
- error: `release-thin-client.yml` requested `id-token: write` while the caller allowed `id-token: none`
- no `v0.4.0` tag or GitHub Release was created

## Correction

- grant `id-token: write` to the thin-client and image reusable-workflow callers
- remove the stale `needs.models` expression from `publish-images.yml`
- enforce the caller permission contract in `check-release-policy.sh`

## Validation

- fix PR #2936: 34/34 checks green
- local `actionlint` clean across all workflows
- release-policy, workflow-pin, publisher-contract, and mutation tests green
- new testing publish: 9/9 jobs green
- immutable testing head: `dc85e1c109b3ca33ed17f85e7da65e12f71312df`
- immutable image tag: `testing-dc85e1c`
- publish run: https://github.com/RakuenSoftware/aimee/actions/runs/33430965723

Merging proposes v0.4.0 again. The post-merge `release` environment remains a separate protected human approval before tagging or publishing.