### PR TITLE
fix(release): recover v0.4.0 cross-platform artifacts

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -148,8 +148,10 @@ jobs:
 
   # Synthesis sidecars are built by publish-llm.yml, outside publish-images.yml.
   # Promote the already-tested pinned manifests; a release must not rebuild them.
+  # Wait for every thin client to build first so a platform packaging failure
+  # cannot publish only the container half of a release.
   llm-images:
-    needs: [version, tag]
+    needs: [version, tag, thin-clients]
     uses: ./.github/workflows/publish-llm.yml
     permissions:
       contents: read
@@ -158,7 +160,10 @@ jobs:
       version: ${{ needs.version.outputs.version }}
 
   images:
-    needs: [version, tag]
+    # The thin-client reusable job includes signed artifact publication. Keeping
+    # image publication behind it prevents the partial-release state where GHCR
+    # tags move even though one desktop artifact failed to link.
+    needs: [version, tag, thin-clients]
     uses: ./.github/workflows/publish-images.yml
     permissions:
       contents: read

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -39,9 +39,9 @@ jobs:
             kind: linux
             asset: aimee-linux-arm64
           # macOS: one universal (arm64 + x86_64) binary, built on macos-latest.
-          # Avoids the scarce/deprecating Intel runner; TLS uses Secure Transport
-          # (system frameworks, already universal), so a fat build still needs no
-          # arch-specific brew libraries.
+          # Avoids the scarce/deprecating Intel runner. Secure Transport is
+          # universal, and artifact verification uses the pinned universal
+          # libcrypto built below.
           - os: macos-latest
             kind: macos
             asset: aimee-macos-universal
@@ -94,10 +94,48 @@ jobs:
         run: cp aimee "${{ matrix.asset }}"
 
       # --- macOS: CMake thin-client target, lean profile ---
+      # artifact_trust uses libcrypto. Homebrew on the arm64 runner provides
+      # only an arm64 bottle, so build the same pinned universal archive that
+      # the green macos-build CI job uses.
+      - name: Build universal OpenSSL crypto (macOS)
+        if: matrix.kind == 'macos'
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/openssl-3.6.3.tar.gz"
+          curl --fail --location --retry 3 \
+            --output "$archive" \
+            https://github.com/openssl/openssl/releases/download/openssl-3.6.3/openssl-3.6.3.tar.gz
+          echo "243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1  $archive" \
+            | shasum -a 256 --check
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+          source_dir="$RUNNER_TEMP/openssl-3.6.3"
+          for arch in arm64 x86_64; do
+            build_dir="$RUNNER_TEMP/openssl-$arch"
+            prefix="$RUNNER_TEMP/openssl-$arch-install"
+            cp -R "$source_dir" "$build_dir"
+            cd "$build_dir"
+            if [ "$arch" = arm64 ]; then
+              target=darwin64-arm64-cc
+            else
+              target=darwin64-x86_64-cc
+            fi
+            ./Configure "$target" no-shared no-tests --prefix="$prefix"
+            make --jobs 3 build_libs
+            make install_dev
+          done
+          universal="$RUNNER_TEMP/openssl-universal"
+          mkdir -p "$universal/lib"
+          cp -R "$RUNNER_TEMP/openssl-arm64-install/include" "$universal/include"
+          lipo -create \
+            "$RUNNER_TEMP/openssl-arm64-install/lib/libcrypto.a" \
+            "$RUNNER_TEMP/openssl-x86_64-install/lib/libcrypto.a" \
+            -output "$universal/lib/libcrypto.a"
+          echo "OPENSSL_ROOT_DIR=$universal" >> "$GITHUB_ENV"
+
       - name: Build (macOS, CMake -- universal arm64+x86_64)
         if: matrix.kind == 'macos'
         run: |
-          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
+          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 3 --target aimee
           # Fail the build unless the artifact is a true fat binary.
           echo "archs: $(lipo -archs build/aimee)"
@@ -112,30 +150,59 @@ jobs:
         if: matrix.kind == 'windows'
         shell: pwsh
         run: |
-          # Reliable MinGW setup — avoids the Chocolatey CDN flake AND the choco
-          # package's changing gcc path (v15.2.0 moved it). Prefer the MSYS2
-          # mingw64 toolchain pre-installed on the runner; else choco-install with
-          # retries and discover gcc.exe rather than hardcoding its directory.
+          # Match the green Windows CI setup: require a complete compiler/make
+          # pair, prefer the runner's MSYS2 toolchain, and install the matching
+          # OpenSSL package before falling back to Chocolatey.
           function Find-MingwBin {
-            if (Test-Path "C:\msys64\mingw64\bin\gcc.exe") { return "C:\msys64\mingw64\bin" }
+            foreach ($candidate in @("C:\msys64\ucrt64\bin", "C:\msys64\mingw64\bin")) {
+              if ((Test-Path "$candidate\gcc.exe") -and
+                  (Test-Path "$candidate\mingw32-make.exe")) { return $candidate }
+            }
             $g = Get-ChildItem -Path "C:\ProgramData\chocolatey\lib\mingw","C:\ProgramData\mingw64" `
                    -Recurse -Filter gcc.exe -ErrorAction SilentlyContinue |
                  Where-Object { $_.FullName -match 'mingw64' } | Select-Object -First 1
-            if ($g) { return (Split-Path $g.FullName) }
+            if ($g) {
+              $candidate = Split-Path $g.FullName
+              if (Test-Path "$candidate\mingw32-make.exe") { return $candidate }
+            }
             return $null
           }
           $bin = Find-MingwBin
-          if (-not $bin) {
+          $pacman = "C:\msys64\usr\bin\pacman.exe"
+          if (-not $bin -and (Test-Path $pacman)) {
             for ($i = 0; $i -lt 3 -and -not $bin; $i++) {
-              choco install mingw -y --no-progress
-              if ($LASTEXITCODE -ne 0) { Start-Sleep 15 }
+              & $pacman -Sy --noconfirm --needed `
+                mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make `
+                mingw-w64-ucrt-x86_64-openssl
+              if ($LASTEXITCODE -ne 0) { Start-Sleep (15 * ($i + 1)) }
               $bin = Find-MingwBin
             }
           }
-          if (-not $bin) { Write-Error "MinGW gcc.exe not found after install"; exit 1 }
+          if (-not $bin) {
+            for ($i = 0; $i -lt 3 -and -not $bin; $i++) {
+              choco install mingw -y --no-progress
+              if ($LASTEXITCODE -ne 0) { Start-Sleep (15 * ($i + 1)) }
+              $bin = Find-MingwBin
+            }
+          }
+          if (-not $bin) { Write-Error "MinGW gcc.exe and mingw32-make.exe not found"; exit 1 }
+          $prefix = Split-Path $bin
+          if (-not (Test-Path "$prefix\include\openssl\evp.h") -and (Test-Path $pacman)) {
+            $opensslPackage = if ($bin -like "*\ucrt64\*") {
+              "mingw-w64-ucrt-x86_64-openssl"
+            } else {
+              "mingw-w64-x86_64-openssl"
+            }
+            & $pacman -Sy --noconfirm --needed $opensslPackage
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
+          if (-not (Test-Path "$prefix\include\openssl\evp.h")) {
+            Write-Error "MinGW OpenSSL headers not found after install"; exit 1
+          }
           Write-Host "Using MinGW at $bin"
           & "$bin\gcc.exe" --version
           echo "$bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "OPENSSL_ROOT_DIR=$($prefix -replace '\\','/')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Download SQLite amalgamation (Windows)
         if: matrix.kind == 'windows'
         shell: powershell

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -84,6 +84,13 @@ grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
 require_job_permission "$auto_release" thin-clients id-token write
 require_job_permission "$auto_release" images id-token write
 
+for image_job in llm-images images; do
+    image_job_block=$(job_block "$auto_release" "$image_job")
+    printf '%s\n' "$image_job_block" |
+        grep -Fq 'needs: [version, tag, thin-clients]' ||
+        fail "$auto_release $image_job must wait for thin-client publication"
+done
+
 # The release artifact build must retain the platform crypto setup exercised by
 # CI. macOS needs a universal libcrypto archive for its arm64+x86_64 binary;
 # Windows needs the OpenSSL package matching the selected MSYS2 toolchain and

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -84,6 +84,24 @@ grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
 require_job_permission "$auto_release" thin-clients id-token write
 require_job_permission "$auto_release" images id-token write
 
+# The release artifact build must retain the platform crypto setup exercised by
+# CI. macOS needs a universal libcrypto archive for its arm64+x86_64 binary;
+# Windows needs the OpenSSL package matching the selected MSYS2 toolchain and
+# must expose that prefix to CMake. Losing any of these makes the gated release
+# fail only after it has created the version tag.
+grep -Fq 'Build universal OpenSSL crypto (macOS)' "$release_client" ||
+    fail "$release_client must build universal OpenSSL crypto for macOS"
+grep -Fq 'lipo -create \' "$release_client" ||
+    fail "$release_client must combine both macOS libcrypto architectures"
+grep -Fq -- '-DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"' "$release_client" ||
+    fail "$release_client must pass its universal OpenSSL prefix to macOS CMake"
+grep -Fq 'mingw-w64-ucrt-x86_64-openssl' "$release_client" ||
+    fail "$release_client must install OpenSSL for the Windows UCRT toolchain"
+grep -Fq 'mingw-w64-x86_64-openssl' "$release_client" ||
+    fail "$release_client must install OpenSSL for the Windows MinGW toolchain"
+grep -Fq 'echo "OPENSSL_ROOT_DIR=$($prefix -replace' "$release_client" ||
+    fail "$release_client must pass its MinGW OpenSSL prefix to Windows CMake"
+
 approval_job=$(awk '
     /^  approval:[[:space:]]*$/ { in_approval = 1; print; next }
     in_approval && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }


### PR DESCRIPTION
## Summary
- restore universal OpenSSL linkage for the macOS release binary
- install and expose matching OpenSSL for Windows MinGW releases
- gate all image publication on successful signed thin-client publication
- enforce these release invariants in the release-policy check

## Failed-run evidence
- macOS: undefined EVP/SHA symbols in the x86_64 slice
- Windows: CMake could not find OpenSSL
- the failed run advanced all seven GHCR manifests before tag rollback; the new dependency ordering prevents that recurrence

## Validation
- repair PR #2939: 34/34 checks green
- testing publish run 33442174630: successful; six immutable manifests and two thin clients verified
- testing CI run 33442174424: successful, including macOS universal and both Windows MinGW jobs
- local actionlint, release policy, workflow pins, and diff checks green