### PR TITLE
fix(release): unblock v0.4.0 verification

### DIFF
--- a/src/hook_session_token.c
+++ b/src/hook_session_token.c
@@ -282,7 +282,8 @@ int hook_session_token_load(const char *home, const char *session_id, const char
    buf[strcspn(buf, "\r\n")] = '\0';
    if (!token_shape_valid(buf))
       return -1;
-   snprintf(out, HOOK_SESSION_TOKEN_CAP, "%s", buf);
+   memcpy(out, buf, HOOK_SESSION_TOKEN_HEX_LEN);
+   out[HOOK_SESSION_TOKEN_HEX_LEN] = '\0';
    memset(buf, 0, sizeof(buf));
    return 0;
 }

--- a/src/tests/test_decision_log.c
+++ b/src/tests/test_decision_log.c
@@ -12,13 +12,13 @@ static void test_record_is_active(void)
 {
    db2_decision_log_row_t row;
    int rc = db2_decision_log_record("deploy-window", "opt-a|opt-b", "opt-a", "lower risk",
-                                    "jbailes", 7, "2026-09-01", 0, &row);
+                                    "jbailes", 7, "2999-09-01", 0, &row);
    assert(rc == 0);
    assert(strcmp(row.status, "active") == 0);
    assert(strcmp(row.subject, "deploy-window") == 0);
    assert(strcmp(row.chosen, "opt-a") == 0);
    assert(strcmp(row.author, "jbailes") == 0);
-   assert(strcmp(row.revisit_when, "2026-09-01") == 0);
+   assert(strcmp(row.revisit_when, "2999-09-01") == 0);
    assert(row.linked_policy_id == 7);
    assert(row.id > 0);
    printf("  PASS: test_record_is_active\n");


### PR DESCRIPTION
The v0.4.0 release failed on the Windows thin-client build under GCC 16 because snprintf could theoretically truncate the validated session-token buffer and warnings are fatal. The fix copies the already-validated fixed-length token explicitly and terminates it. The first PR run then exposed a same-day test fixture boundary: test_record_is_active used 2026-09-01, so the revisit sweep changed two decisions instead of its intended one. That round-trip-only fixture now uses a far-future date.

Validation:
- Windows windows-build and windows-cmake passed on the first PR commit
- Focused hook-session-token test passed
- Focused decision-log test passed five consecutive runs
- Linux thin client built with v0.4.0
- Release-policy and diff checks passed