### PR TITLE
fix(release): unblock v0.4.0 Windows artifacts

### DIFF
--- a/src/hook_session_token.c
+++ b/src/hook_session_token.c
@@ -282,7 +282,8 @@ int hook_session_token_load(const char *home, const char *session_id, const char
    buf[strcspn(buf, "\r\n")] = '\0';
    if (!token_shape_valid(buf))
       return -1;
-   snprintf(out, HOOK_SESSION_TOKEN_CAP, "%s", buf);
+   memcpy(out, buf, HOOK_SESSION_TOKEN_HEX_LEN);
+   out[HOOK_SESSION_TOKEN_HEX_LEN] = '\0';
    memset(buf, 0, sizeof(buf));
    return 0;
 }

--- a/src/tests/test_decision_log.c
+++ b/src/tests/test_decision_log.c
@@ -12,13 +12,13 @@ static void test_record_is_active(void)
 {
    db2_decision_log_row_t row;
    int rc = db2_decision_log_record("deploy-window", "opt-a|opt-b", "opt-a", "lower risk",
-                                    "jbailes", 7, "2026-09-01", 0, &row);
+                                    "jbailes", 7, "2999-09-01", 0, &row);
    assert(rc == 0);
    assert(strcmp(row.status, "active") == 0);
    assert(strcmp(row.subject, "deploy-window") == 0);
    assert(strcmp(row.chosen, "opt-a") == 0);
    assert(strcmp(row.author, "jbailes") == 0);
-   assert(strcmp(row.revisit_when, "2026-09-01") == 0);
+   assert(strcmp(row.revisit_when, "2999-09-01") == 0);
    assert(row.linked_policy_id == 7);
    assert(row.id > 0);
    printf("  PASS: test_record_is_active\n");


### PR DESCRIPTION
## Summary
- avoid GCC 16 truncation diagnostics in the validated Windows session-token copy
- replace the decision-log fixture date that expired on 2026-09-01
- restore the cross-platform v0.4.0 release path

## Failed-run evidence
- release run 33475015885 failed while compiling the Windows thin client with warnings as errors
- the repair PR also exposed a deterministic decision-log fixture failure on its encoded revisit date

## Validation
- repair PR #2942: complete CI suite green
- Windows CMake and Windows release-equivalent builds green
- all unit and real-Postgres shards green
- ASan/UBSan, static analysis, secret scanning, integration, and live authorization gates green
- local focused token and decision-log tests green
- release-policy and diff checks green