### PR TITLE
fix(release): unblock GCC 16 Windows thin client

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -1435,10 +1435,13 @@ static int attn_git_default_ref(const char *dir, const char *defbr, char *out, s
    /* Both resolve: take whichever already contains the other, so neither a local
     * branch left behind nor one carrying unpushed default-branch commits can
     * shrink the yardstick. Ties (identical refs) fall to the local name. */
-   char cmd[2600];
-   snprintf(cmd, sizeof(cmd),
-            "git -C '%s' merge-base --is-ancestor '%s^{commit}' '%s^{commit}' >/dev/null 2>&1", dir,
-            remote, defbr);
+   char cmd[2800];
+   int n =
+       snprintf(cmd, sizeof(cmd),
+                "git -C '%s' merge-base --is-ancestor '%s^{commit}' '%s^{commit}' >/dev/null 2>&1",
+                dir, remote, defbr);
+   if (n < 0 || (size_t)n >= sizeof(cmd))
+      return 0;
    int local_contains_remote = system(cmd) == 0;
    snprintf(out, outlen, "%s", local_contains_remote ? defbr : remote);
    return 1;


### PR DESCRIPTION
## Summary
- size the attention-guard merge-base command buffer for its bounded path and ref inputs
- reject any unexpected snprintf truncation before invoking git
- keep strict Windows compiler warnings enabled

## Failed-run evidence
- release run 33482289767, job 99775260267 failed in the Windows CMake build
- MinGW GCC 16 diagnosed up to 2676 bytes written into the 2600-byte command buffer
- warnings are errors in the shipping build, so the Windows artifact and v0.4.0 release were blocked

## Validation
- clang-format dry-run clean
- strict GCC build with -Werror -Wformat=2 clean
- attention-guard test suite passes
- git diff --check clean