### PR TITLE
fix(release): unblock v0.4.0 GCC 16 Windows build

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -1435,10 +1435,13 @@ static int attn_git_default_ref(const char *dir, const char *defbr, char *out, s
    /* Both resolve: take whichever already contains the other, so neither a local
     * branch left behind nor one carrying unpushed default-branch commits can
     * shrink the yardstick. Ties (identical refs) fall to the local name. */
-   char cmd[2600];
-   snprintf(cmd, sizeof(cmd),
-            "git -C '%s' merge-base --is-ancestor '%s^{commit}' '%s^{commit}' >/dev/null 2>&1", dir,
-            remote, defbr);
+   char cmd[2800];
+   int n =
+       snprintf(cmd, sizeof(cmd),
+                "git -C '%s' merge-base --is-ancestor '%s^{commit}' '%s^{commit}' >/dev/null 2>&1",
+                dir, remote, defbr);
+   if (n < 0 || (size_t)n >= sizeof(cmd))
+      return 0;
    int local_contains_remote = system(cmd) == 0;
    snprintf(out, outlen, "%s", local_contains_remote ? defbr : remote);
    return 1;


### PR DESCRIPTION
## Summary
- promote the validated attention-guard command-bound repair from testing
- unblock the MinGW GCC 16 thin-client build that stopped release run 33482289767
- preserve strict compiler warnings and fail closed on unexpected command truncation

## Release failure
- Windows release job 99775260267 failed in the CMake build
- GCC 16 proved the merge-base command could emit up to 2676 bytes into a 2600-byte buffer
- the missing Windows artifact blocked the v0.4.0 release

## Promotion acceptance gate
Do not merge this promotion until its own complete testing-to-main suite passes, including:
- release policy and clang-format-19 lint
- windows-cmake and windows-build under MinGW GCC 16
- Linux and macOS shipping builds
- full unit, Postgres, integration, and Docker topology tests
- ASan/UBSan and mandatory static analysis / secret scanning

## Focused validation already completed
- both Windows jobs green on repair commit 4699e43bbe
- pinned clang-format-19 gate green
- strict local GCC build with warnings as errors green
- attention-guard test suite green