### PR TITLE
fix(release): promote exact v0.4.0 release validation

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -61,34 +61,7 @@ jobs:
 
       - name: Infer the next version in the declared series
         id: bump
-        run: |
-          # The tree declares MAJOR.MINOR and nothing else. The patch is whatever
-          # comes next in that series, so a patch release needs no commit and
-          # cannot disagree with what was tagged. Moving series is an explicit
-          # edit of AIMEE_VERSION_SERIES, never inferred.
-          series=$(awk '$1 == "#define" && $2 == "AIMEE_VERSION_SERIES" {gsub(/"/, "", $3); print $3; exit}' \
-            src/headers/aimee_version.h)
-          if ! [[ "$series" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::AIMEE_VERSION_SERIES must be MAJOR.MINOR; got '${series:-<empty>}'"
-            exit 1
-          fi
-          # Highest patch already tagged in THIS series. Tags from other series
-          # are irrelevant: a 0.4.0 tag must not make the 0.3 line jump.
-          latest=$(git tag --list "v${series}.*" --sort=-v:refname | head -n1)
-          if [ -z "$latest" ]; then
-            next="${series}.0"
-          else
-            patch="${latest##*.}"
-            [[ "$patch" =~ ^[0-9]+$ ]] || { echo "::error::cannot read a patch number from tag ${latest}"; exit 1; }
-            next="${series}.$((patch + 1))"
-          fi
-          if git rev-parse -q --verify "refs/tags/v${next}" >/dev/null; then
-            echo "::error::tag v${next} already exists; aborting to avoid clobbering a release"
-            exit 1
-          fi
-          echo "version=$next" >> "$GITHUB_OUTPUT"
-          echo "series=$series" >> "$GITHUB_OUTPUT"
-          echo "Next version: v${next} (series ${series}, highest in series ${latest:-<none>})"
+        run: scripts/next-release-version.sh "$GITHUB_OUTPUT"
 
       - name: Publish the proposed version for the approver
         run: |
@@ -145,6 +118,7 @@ jobs:
       id-token: write
     with:
       version: ${{ needs.version.outputs.version }}
+      publish: true
 
   # Synthesis sidecars are built by publish-llm.yml, outside publish-images.yml.
   # Promote the already-tested pinned manifests; a release must not rebuild them.
@@ -158,6 +132,7 @@ jobs:
       packages: write
     with:
       version: ${{ needs.version.outputs.version }}
+      publish: true
 
   images:
     # The thin-client reusable job includes signed artifact publication. Keeping
@@ -171,6 +146,7 @@ jobs:
       id-token: write
     with:
       version: ${{ needs.version.outputs.version }}
+      publish: true
 
   # Undo the tag when the release did not actually ship.
   #

--- a/.github/workflows/main-merge-approval.yml
+++ b/.github/workflows/main-merge-approval.yml
@@ -8,12 +8,58 @@ permissions:
   contents: read
 
 # The default branch ruleset requires a successful deployment to this
-# environment. The environment and branch rules must require an approval from a
-# reviewer other than the PR author, with admin bypass disabled. The source tree
-# cannot prove live GitHub settings, so the quarterly access/ruleset export is
-# retained with the assurance evidence bundle.
+# environment. The approval job is deliberately downstream of the SAME reusable
+# workflows used by auto-release.yml. A testing -> main PR therefore cannot even
+# ask for approval until the exact versioned thin clients, release payload,
+# container images, and pinned LLM promotion sources have passed. Only the
+# irreversible tag/sign/push operations are disabled during validation.
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Infer the exact version release would build
+        id: bump
+        run: scripts/next-release-version.sh "$GITHUB_OUTPUT"
+
+  thin-clients:
+    needs: version
+    uses: ./.github/workflows/release-thin-client.yml
+    permissions:
+      contents: write
+      id-token: write
+    with:
+      version: ${{ needs.version.outputs.version }}
+      publish: false
+
+  llm-images:
+    needs: [version, thin-clients]
+    uses: ./.github/workflows/publish-llm.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: ${{ needs.version.outputs.version }}
+      publish: false
+
+  images:
+    needs: [version, thin-clients]
+    uses: ./.github/workflows/publish-images.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      version: ${{ needs.version.outputs.version }}
+      publish: false
+
   approval:
+    needs: [thin-clients, llm-images, images]
     environment: main-merge-approval
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -23,10 +23,11 @@
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
 # merge-manifest pattern, on native runners (no QEMU emulation of the C build).
 #
-# This workflow is deliberately reusable-only. The sole caller is
-# auto-release.yml, whose tag job is blocked by the protected `release`
-# environment. Do not add tag-push or workflow-dispatch triggers here: either
-# would create a second path to GHCR that bypasses the human release approval.
+# This workflow is deliberately reusable-only. auto-release.yml calls it with
+# publish=true after release approval; main-merge-approval.yml calls the same
+# per-image, per-architecture builds with publish=false before main approval. Do
+# not add tag-push or workflow-dispatch triggers here: either would create a
+# second path to GHCR that bypasses the human release approval.
 name: Publish images
 
 on:
@@ -36,6 +37,11 @@ on:
         description: 'Version without leading v (e.g. 0.2.1)'
         required: true
         type: string
+      publish:
+        description: 'Push digests/manifests and sign them; false performs the exact per-arch builds only'
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: publish-images-${{ github.ref }}-${{ inputs.version }}
@@ -106,7 +112,7 @@ jobs:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
-      # Logging in on a pull request too, so the PR build can READ the prebuilt
+      # Logging in during validation too, so the PR build can READ the prebuilt
       # aimee-model-* layers instead of re-downloading gigabytes from Hugging
       # Face. Logging in is not pushing: `push=` on the build step below is what
       # decides that, and it stays false for a pull request. A fork's
@@ -114,7 +120,7 @@ jobs:
       # inline fetch if the read is not permitted.
       - name: Log in to ghcr.io
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: ${{ !inputs.publish }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -151,19 +157,20 @@ jobs:
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_RUNTIME_WEB=1
             ${{ matrix.image.extra_args }}
-          # push=false on a pull_request: build only, publish nothing.
-          outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          # Promotion validation calls this same reusable workflow with
+          # publish=false: build the release image, publish nothing.
+          outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=${{ inputs.publish }}
 
       # Digests only exist when something was pushed, so both steps and the whole
-      # merge job below are skipped on a pull request.
+      # merge job below are skipped in non-publishing validation.
       - name: Export digest
-        if: github.event_name != 'pull_request'
+        if: inputs.publish
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
+        if: inputs.publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
@@ -174,8 +181,8 @@ jobs:
   # tag it (sha, semver/version, latest).
   merge:
     needs: [prep, build]
-    # Nothing to merge when nothing was pushed. A PR stops after the build.
-    if: github.event_name != 'pull_request'
+    # Nothing to merge when validation intentionally pushed no digests.
+    if: inputs.publish
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/publish-llm.yml
+++ b/.github/workflows/publish-llm.yml
@@ -53,6 +53,11 @@ on:
         description: 'Approved release version; promotes the pinned build to :<version> + :latest'
         required: true
         type: string
+      publish:
+        description: 'Promote the pinned manifests; false validates that the exact promotion sources exist'
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: publish-llm-${{ github.ref }}
@@ -161,7 +166,7 @@ jobs:
       # Registry-side promotion of the pinned build. This intentionally does not
       # pull or rebuild the multi-gigabyte synthesis images during a release.
       - name: Promote to :${{ inputs.version }} and :latest
-        if: ${{ inputs.version != '' }}
+        if: ${{ inputs.version != '' && inputs.publish }}
         run: |
           set -euo pipefail
           pinned='${{ steps.have.outputs.pinned }}'
@@ -174,6 +179,19 @@ jobs:
             --tag "${image}:${{ inputs.version }}" \
             --tag "${image}:latest" \
             "$pinned"
+
+      # A promotion PR must prove the immutable source manifest exists. The
+      # real release runs the adjacent promotion command against this exact
+      # value; validation suppresses only the registry tag mutation.
+      - name: Validate release promotion source
+        if: ${{ inputs.version != '' && !inputs.publish }}
+        run: |
+          pinned='${{ steps.have.outputs.pinned }}'
+          docker manifest inspect "$pinned" >/dev/null || {
+            echo "::error::$pinned is not published; release promotion would fail"
+            exit 1
+          }
+          echo "validated release source $pinned"
 
       - name: Report
         run: |

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -7,10 +7,11 @@
 # endpoint (AIMEE_SERVER_URL / --server); see the thin-client cross-platform
 # proposal.
 #
-# This workflow is deliberately reusable-only. The sole caller is
-# auto-release.yml, after its tag job receives approval from the protected
-# `release` environment. Do not add tag-push or workflow-dispatch triggers here:
-# either would create a release path that bypasses the human approval.
+# This workflow is deliberately reusable-only. auto-release.yml calls it with
+# publish=true after release approval; main-merge-approval.yml calls the same
+# build and payload assembly with publish=false before main approval. Do not add
+# tag-push or workflow-dispatch triggers here: either would create a release path
+# that bypasses the human approval.
 name: release-thin-client
 
 on:
@@ -20,6 +21,11 @@ on:
         description: 'Version without leading v (e.g. 0.2.1)'
         required: true
         type: string
+      publish:
+        description: 'Publish/sign the GitHub Release; false builds and assembles the exact payload only'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -57,8 +63,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Resolve the approved version string to embed (without leading v) and
-      # ensure the gated tag job created exactly that tag.
+      # Resolve the version string to embed (without leading v). A real release
+      # also requires the gated tag. Promotion validation deliberately has no
+      # tag yet, but compiles the exact same versioned artifact matrix.
       - name: Resolve version
         id: ver
         shell: bash
@@ -68,10 +75,12 @@ jobs:
             echo "::error::approved release version must be MAJOR.MINOR.PATCH; got '${v:-<empty>}'"
             exit 1
           fi
-          git rev-parse -q --verify "refs/tags/v$v" >/dev/null || {
-            echo "::error::approved release tag v$v does not exist"
-            exit 1
-          }
+          if [ "${{ inputs.publish }}" = "true" ]; then
+            git rev-parse -q --verify "refs/tags/v$v" >/dev/null || {
+              echo "::error::approved release tag v$v does not exist"
+              exit 1
+            }
+          fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
       # --- Linux: authoritative make build of the lean thin client ---
@@ -244,9 +253,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Publish a GitHub Release when triggered by a tag push, or when a version
-    # was supplied via call/dispatch (the orchestrator created the tag first).
-    if: ${{ inputs.version != '' || startsWith(github.ref, 'refs/tags/') }}
     steps:
       # Scope to the thin-client binaries only. When invoked via auto-release
       # (workflow_call), the publish-images workflow shares this run and uploads
@@ -258,16 +264,39 @@ jobs:
           pattern: aimee-*
           path: dist
           merge-multiple: true
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
-      - name: Create checksums and keyless signature bundles
+
+      # This is part of both validation and publication. It proves the reusable
+      # matrix produced the complete payload that the release action will see,
+      # including the Windows filename and both Linux architectures.
+      - name: Validate payload and create checksums
         working-directory: dist
         run: |
+          for asset in \
+            aimee-linux-x86_64 \
+            aimee-linux-arm64 \
+            aimee-macos-universal \
+            aimee-windows-x86_64.exe; do
+            test -f "$asset" || { echo "::error::release payload is missing $asset"; exit 1; }
+          done
+          test "$(find . -maxdepth 1 -type f -name 'aimee-*' | wc -l)" -eq 4 || {
+            echo "::error::release payload contains an unexpected thin-client asset set"
+            find . -maxdepth 1 -type f -print
+            exit 1
+          }
           sha256sum aimee-* > SHA256SUMS
+
+      - name: Install Cosign
+        if: inputs.publish
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
+      - name: Create keyless signature bundles
+        if: inputs.publish
+        working-directory: dist
+        run: |
           for asset in aimee-* SHA256SUMS; do
             cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
           done
       - name: Publish release
+        if: inputs.publish
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           # Empty tag_name -> action falls back to the pushed tag (github.ref).

--- a/scripts/check-release-policy.sh
+++ b/scripts/check-release-policy.sh
@@ -59,6 +59,7 @@ require_job_permission() {
 auto_release="$repo_root/.github/workflows/auto-release.yml"
 main_approval="$repo_root/.github/workflows/main-merge-approval.yml"
 publish_images="$repo_root/.github/workflows/publish-images.yml"
+publish_llm="$repo_root/.github/workflows/publish-llm.yml"
 release_client="$repo_root/.github/workflows/release-thin-client.yml"
 
 require_reusable_only "$publish_images"
@@ -77,6 +78,14 @@ grep -Fq 'uses: ./.github/workflows/publish-images.yml' "$auto_release" ||
     fail "$auto_release must call the guarded image publisher"
 grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$auto_release" ||
     fail "$auto_release must call the guarded thin-client publisher"
+
+# Release and promotion validation must infer one version through one code path.
+# Copying the awk/tag logic back into either workflow recreates the exact drift
+# this gate exists to prevent.
+for workflow in "$auto_release" "$main_approval"; do
+    grep -Fq 'scripts/next-release-version.sh "$GITHUB_OUTPUT"' "$workflow" ||
+        fail "$workflow must use the shared next-release-version script"
+done
 
 # Both publishers create keyless signatures and request an OIDC token. GitHub
 # validates reusable-workflow permissions only when auto-release is triggered;
@@ -118,5 +127,36 @@ approval_job=$(awk '
 printf '%s\n' "$approval_job" |
     grep -Eq '^    environment:[[:space:]]+main-merge-approval[[:space:]]*$' ||
     fail "$main_approval must deploy through the protected main-merge-approval environment"
+
+# Main approval is the protected merge boundary. It must remain downstream of
+# the same reusable release workflows, all in non-publishing validation mode;
+# otherwise a green approval can race ahead of a build failure discovered only
+# after the merge to main.
+printf '%s\n' "$approval_job" |
+    grep -Fq 'needs: [thin-clients, llm-images, images]' ||
+    fail "$main_approval approval must wait for every release validation workflow"
+
+for release_job in thin-clients llm-images images; do
+    validation_block=$(job_block "$main_approval" "$release_job")
+    printf '%s\n' "$validation_block" | grep -Fq 'publish: false' ||
+        fail "$main_approval $release_job must validate without publishing"
+    publish_block=$(job_block "$auto_release" "$release_job")
+    printf '%s\n' "$publish_block" | grep -Fq 'publish: true' ||
+        fail "$auto_release $release_job must explicitly publish after approval"
+done
+
+grep -Fq 'uses: ./.github/workflows/release-thin-client.yml' "$main_approval" ||
+    fail "$main_approval must validate through the release thin-client workflow"
+grep -Fq 'uses: ./.github/workflows/publish-images.yml' "$main_approval" ||
+    fail "$main_approval must validate through the release image workflow"
+grep -Fq 'uses: ./.github/workflows/publish-llm.yml' "$main_approval" ||
+    fail "$main_approval must validate through the release LLM workflow"
+
+grep -Fq 'Validate payload and create checksums' "$release_client" ||
+    fail "$release_client must assemble and validate the payload before publishing"
+grep -Fq 'push=${{ inputs.publish }}' "$publish_images" ||
+    fail "$publish_images must use the explicit publish input for registry writes"
+grep -Fq 'Validate release promotion source' "$publish_llm" ||
+    fail "$publish_llm must validate pinned promotion sources without retagging them"
 
 echo "release-policy: approval topology is intact"

--- a/scripts/next-release-version.sh
+++ b/scripts/next-release-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+output_file=${1:-${GITHUB_OUTPUT:-}}
+
+if [ -z "$output_file" ]; then
+    echo "next-release-version: output file argument or GITHUB_OUTPUT is required" >&2
+    exit 2
+fi
+
+# The source tree declares MAJOR.MINOR. Tags determine the next patch in that
+# series. Both the real release and the testing -> main validation call this
+# script so the version embedded by validation cannot drift from the version
+# an approved release will build.
+series=$(awk '$1 == "#define" && $2 == "AIMEE_VERSION_SERIES" {gsub(/"/, "", $3); print $3; exit}' \
+    "$repo_root/src/headers/aimee_version.h")
+if ! [[ "$series" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "::error::AIMEE_VERSION_SERIES must be MAJOR.MINOR; got '${series:-<empty>}'" >&2
+    exit 1
+fi
+
+latest=$(git -C "$repo_root" tag --list "v${series}.*" --sort=-v:refname | head -n1)
+if [ -z "$latest" ]; then
+    next="${series}.0"
+else
+    patch=${latest##*.}
+    if ! [[ "$patch" =~ ^[0-9]+$ ]]; then
+        echo "::error::cannot read a patch number from tag $latest" >&2
+        exit 1
+    fi
+    next="${series}.$((patch + 1))"
+fi
+
+if git -C "$repo_root" rev-parse -q --verify "refs/tags/v${next}" >/dev/null; then
+    echo "::error::tag v${next} already exists; aborting to avoid clobbering a release" >&2
+    exit 1
+fi
+
+{
+    echo "version=$next"
+    echo "series=$series"
+    echo "latest=$latest"
+} >> "$output_file"
+
+echo "Next version: v${next} (series ${series}, highest in series ${latest:-<none>})"

--- a/src/windows/platform_ipc.c
+++ b/src/windows/platform_ipc.c
@@ -7,9 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-static WCHAR *path_to_pipe_name(const char *path)
+static int pipe_name_a(const char *path, char *buf, size_t buf_sz)
 {
-   static WCHAR pipe_name[256];
+   if (!buf || buf_sz == 0)
+      return -1;
+
    char username[128] = "user";
    DWORD user_len = GetEnvironmentVariableA("USERNAME", username, sizeof(username));
    if (user_len == 0 || user_len >= sizeof(username))
@@ -35,21 +37,40 @@ static WCHAR *path_to_pipe_name(const char *path)
       sanitized[si++] = 'a';
    sanitized[si] = '\0';
 
-   swprintf(pipe_name, sizeof(pipe_name) / sizeof(pipe_name[0]), L"\\\\.\\pipe\\%S-%S", sanitized,
-            username);
-   return pipe_name;
-}
+   static const char prefix[] = "\\\\.\\pipe\\";
+   const size_t prefix_len = sizeof(prefix) - 1;
+   if (buf_sz <= prefix_len + 2)
+      return -1;
 
-static void pipe_name_a(const char *path, char *buf, size_t buf_sz)
-{
-   WCHAR *wname = path_to_pipe_name(path);
-   snprintf(buf, buf_sz, "\\\\.\\pipe\\%S", wname + 9);
+   /* Windows caps a named-pipe path at 256 characters. Preserve the complete
+    * username when possible and use the remaining payload for the sanitized
+    * endpoint name. Common names are unchanged; unusually long inputs are
+    * bounded before they reach CreateNamedPipeA rather than being truncated by
+    * a wide/narrow printf conversion. */
+   const size_t payload_len = buf_sz - prefix_len - 1;
+   size_t username_len = strlen(username);
+   if (username_len > payload_len - 2)
+      username_len = payload_len - 2;
+   size_t sanitized_len = strlen(sanitized);
+   if (sanitized_len > payload_len - username_len - 1)
+      sanitized_len = payload_len - username_len - 1;
+
+   char *dst = buf;
+   memcpy(dst, prefix, prefix_len);
+   dst += prefix_len;
+   memcpy(dst, sanitized, sanitized_len);
+   dst += sanitized_len;
+   *dst++ = '-';
+   memcpy(dst, username, username_len);
+   dst[username_len] = '\0';
+   return 0;
 }
 
 int platform_ipc_listen(const char *path, int backlog)
 {
    char pipe_name[256];
-   pipe_name_a(path, pipe_name, sizeof(pipe_name));
+   if (pipe_name_a(path, pipe_name, sizeof(pipe_name)) != 0)
+      return -1;
    DWORD instances = (backlog > 0) ? (DWORD)backlog : PIPE_UNLIMITED_INSTANCES;
    HANDLE h = CreateNamedPipeA(pipe_name, PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
                                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, instances, 4096,
@@ -88,7 +109,8 @@ int platform_ipc_accept(int listen_fd)
 int platform_ipc_connect(const char *path, int timeout_ms)
 {
    char pipe_name[256];
-   pipe_name_a(path, pipe_name, sizeof(pipe_name));
+   if (pipe_name_a(path, pipe_name, sizeof(pipe_name)) != 0)
+      return -1;
    DWORD wait_ms = (timeout_ms <= 0) ? NMPWAIT_WAIT_FOREVER : (DWORD)timeout_ms;
 
    for (;;)
@@ -111,7 +133,8 @@ int platform_ipc_connect(const char *path, int timeout_ms)
 int platform_ipc_probe(const char *path)
 {
    char pipe_name[256];
-   pipe_name_a(path, pipe_name, sizeof(pipe_name));
+   if (pipe_name_a(path, pipe_name, sizeof(pipe_name)) != 0)
+      return -1;
    HANDLE h = CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING,
                           FILE_ATTRIBUTE_NORMAL, NULL);
    if (h == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
## Summary
- promote the Windows IPC repair that fixes the second v0.4.0 release failure
- make the testing-to-main gate exercise the exact release workflows before main approval
- share version resolution between promotion validation and publication

## Release parity gate
Do not merge until the Main merge approval workflow succeeds. It now runs the same reusable release paths in non-publishing mode:
- all four versioned thin-client release builds, payload assembly, asset validation, and checksums
- every release container image and architecture build
- validation of the immutable LLM manifests that release will promote
- the normal complete CI and release-policy suites

Only signing, registry mutation, GitHub Release publication, and tag creation remain behind the protected release approval after merge.

## Included fix
- replace the GCC 16-sensitive Windows wide/narrow printf conversion with bounded ANSI named-pipe construction
- preserve common named-pipe names and fail safely for invalid buffers

Closes the release gap exposed by failed run 33489149291.

Source repair and workflow changes were validated in #2948.