### PR TITLE
fix(deploy): make managed compose env readable

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -594,7 +594,11 @@ if [ -d "$DEPLOY_ENV_DIR" ]; then
         AIMEE_API_ENDPOINT="unix:$AIMEE_HOME/aimee-http.sock" \
         aimee config deploy-env \
         >"$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null; then
+        # The root shell owns the redirect, not the runuser child. Compose later
+        # opens the adjacent .env as the uid-1000 deploy worker, so retain the
+        # owner-only mode but transfer ownership before the atomic rename.
         chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null || true
+        chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null || true
         mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"
         log "wrote managed compose env ($DEPLOY_ENV_DIR/.env) from config"
     else

--- a/src/tests/test_deploy_compose_env.sh
+++ b/src/tests/test_deploy_compose_env.sh
@@ -69,6 +69,32 @@ grep -q 'mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"' "$entrypoint" 
     && r=yes || r=no
 check "written via a temp file and renamed into place" "yes" "$r"
 
+# The entrypoint owns this redirect, so the temp file starts root:root even
+# though `aimee config deploy-env` runs as the service account. Docker Compose
+# automatically opens the adjacent .env before it applies the worker's explicit
+# environment; root:root 0600 therefore makes every browser deploy fail before
+# the one-shot Vault bootstrap starts. Transfer only this root-created file to
+# the service account, retain 0600, and do it before the atomic rename.
+grep -q 'chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" && r=yes || r=no
+check "compose env remains owner-only" "yes" "$r"
+
+grep -q 'chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" && r=yes || r=no
+check "compose env is readable by the deploy worker" "yes" "$r"
+
+mode_line=$(grep -n 'chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" |
+                head -n1 | cut -d: -f1)
+owner_line=$(grep -n 'chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" |
+                 head -n1 | cut -d: -f1)
+rename_line=$(grep -n 'mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"' "$entrypoint" |
+                  head -n1 | cut -d: -f1)
+if [ -n "$mode_line" ] && [ -n "$owner_line" ] && [ -n "$rename_line" ] &&
+   [ "$mode_line" -lt "$owner_line" ] && [ "$owner_line" -lt "$rename_line" ]; then
+    r=ordered
+else
+    r=unsafe
+fi
+check "mode and owner are fixed before rename" "ordered" "$r"
+
 # 3. A failure to write must NOT stop the server. The file is a safety net for
 #    later compose callers; the server's own deploy path builds its child
 #    environment directly and works without it. Refusing to boot over it would


### PR DESCRIPTION
## Problem

The v0.4.0 server entrypoint writes `/opt/aimee/deploy/.env` through a root-shell redirect and leaves it `root:root 0600`. The deploy worker runs as uid 1000, and Docker Compose automatically reads the adjacent `.env` before starting the managed Vault bootstrap, so browser deploy fails with `permission denied`.

## Fix

Keep the file owner-only, transfer the root-created temp file to `aimee:aimee`, then atomically rename it. The deployment directory and Compose manifest remain root-owned and non-writable by the service account.

Regression coverage asserts mode retention, owner transfer, and ordering before rename. Removing the owner transfer makes the test fail.

## Validation

- Live v0.4.0 CT: managed KB deploy completed; authority/JWKS and server identity verified
- Live restart: `.env` recreated as `aimee:aimee 0600`; uid-1000 Compose parse passed
- `make -C src -j4 deploy-compose-env-test`
- `make -C src -j4 unit-tests` (664 binaries, all passed)
- `make -C src lint` (76 checks passed)
- `make -C src docs-gen-check`
- `sh -n deploy/container/server-entrypoint.sh`

## Compatibility and security

No format, API, or migration change. No credential is added to `.env`; it remains `0600`. Only the generated topology file changes ownership. The parent directory and Compose manifest remain root-owned.