### PR TITLE
Release 0.4.1: fix managed deploy environment ownership

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -594,7 +594,11 @@ if [ -d "$DEPLOY_ENV_DIR" ]; then
         AIMEE_API_ENDPOINT="unix:$AIMEE_HOME/aimee-http.sock" \
         aimee config deploy-env \
         >"$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null; then
+        # The root shell owns the redirect, not the runuser child. Compose later
+        # opens the adjacent .env as the uid-1000 deploy worker, so retain the
+        # owner-only mode but transfer ownership before the atomic rename.
         chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null || true
+        chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp" 2>/dev/null || true
         mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"
         log "wrote managed compose env ($DEPLOY_ENV_DIR/.env) from config"
     else

--- a/src/tests/test_deploy_compose_env.sh
+++ b/src/tests/test_deploy_compose_env.sh
@@ -69,6 +69,32 @@ grep -q 'mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"' "$entrypoint" 
     && r=yes || r=no
 check "written via a temp file and renamed into place" "yes" "$r"
 
+# The entrypoint owns this redirect, so the temp file starts root:root even
+# though `aimee config deploy-env` runs as the service account. Docker Compose
+# automatically opens the adjacent .env before it applies the worker's explicit
+# environment; root:root 0600 therefore makes every browser deploy fail before
+# the one-shot Vault bootstrap starts. Transfer only this root-created file to
+# the service account, retain 0600, and do it before the atomic rename.
+grep -q 'chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" && r=yes || r=no
+check "compose env remains owner-only" "yes" "$r"
+
+grep -q 'chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" && r=yes || r=no
+check "compose env is readable by the deploy worker" "yes" "$r"
+
+mode_line=$(grep -n 'chmod 0600 "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" |
+                head -n1 | cut -d: -f1)
+owner_line=$(grep -n 'chown aimee:aimee "$DEPLOY_ENV_DIR/.env.tmp"' "$entrypoint" |
+                 head -n1 | cut -d: -f1)
+rename_line=$(grep -n 'mv -f "$DEPLOY_ENV_DIR/.env.tmp" "$DEPLOY_ENV_DIR/.env"' "$entrypoint" |
+                  head -n1 | cut -d: -f1)
+if [ -n "$mode_line" ] && [ -n "$owner_line" ] && [ -n "$rename_line" ] &&
+   [ "$mode_line" -lt "$owner_line" ] && [ "$owner_line" -lt "$rename_line" ]; then
+    r=ordered
+else
+    r=unsafe
+fi
+check "mode and owner are fixed before rename" "ordered" "$r"
+
 # 3. A failure to write must NOT stop the server. The file is a safety net for
 #    later compose callers; the server's own deploy path builds its child
 #    environment directly and works without it. Refusing to boot over it would


### PR DESCRIPTION
## Summary

- promote the confirmed managed deployment repair as v0.4.1
- retain mode 0600 on the generated Compose environment while assigning it to the uid-1000 aimee deploy worker
- add a regression test that requires ownership transfer before the atomic rename

## Incident and fix

The root entrypoint created /opt/aimee/deploy/.env as root:root with mode 0600. The deployment worker runs as aimee (uid 1000), and Docker Compose automatically reads that adjacent file before Vault bootstrap, producing permission denied and preventing the managed KB bearer from being sealed.

The fix changes ownership of the temporary file to aimee:aimee before its atomic rename. It preserves owner-only permissions and does not broaden bearer readability.

## Confirmed deployment evidence

The repair was exercised on the affected Proxmox CT deployment. A managed deploy completed successfully, the KB bearer was sealed into Vault, authority roots and signed JWKS verified, the server identity enrolled, and the server, KB, and store reported healthy. After a server restart, the environment remained aimee:aimee mode 0600 and the uid-1000 worker successfully evaluated the Compose configuration.

## Validation

- complete PR CI on #2951 passed, including sanitizers, static analysis and secret scanning, all Docker tiers, PostgreSQL matrices, Windows/macOS builds, and live authorization tests
- deploy-compose-env-test passed, with a negative mutation proving the new regression assertions fail when ownership transfer is removed
- 664 native unit-test binaries passed locally
- lint and generated-document checks passed
- promote-time refactor baseline check passed unchanged
- all 47 promote-time script-test groups passed
- shell syntax and diff checks passed

## Release

The checked release version resolver proposes v0.4.1 from latest v0.4.0 in declared series 0.4. Do not merge until the Main merge approval workflow succeeds. After merge, approve the protected release environment only for v0.4.1.