### PR TITLE
fix: qualify 0.4.2 synthesis and memory validation

### DIFF
--- a/.github/workflows/publish-llm.yml
+++ b/.github/workflows/publish-llm.yml
@@ -6,16 +6,9 @@
 # pgvectorscale and torch on every push touching src/**, and pushed ~10 GB twice,
 # for artefacts whose real inputs change on the order of never.
 #
-# The guarantee is enforced TWICE, because a path filter is one careless edit away
-# from being wrong:
-#
-#   1. A narrow trigger. Only the files that actually determine these images.
-#   2. A skip-if-already-published check keyed on the inputs -- model, quant and
-#      llama.cpp version, all encoded in the tag. Even a broad or accidental
-#      trigger then costs one `docker manifest inspect` and stops.
-#
-# (2) is what makes this robust rather than aspirational: correctness does not
-# depend on the path list staying right.
+# Only a newer pinned upstream llama.cpp release authorizes an image build.
+# Wrapper/weight edits wait for that release. Exact content tags permit retries;
+# a runtime tag prevents publishing different images for the same runtime release.
 name: Publish synthesis images (E2B and E4B)
 
 on:
@@ -26,6 +19,8 @@ on:
       - "deploy/container/aimee-llm-entrypoint.sh"
       - "scripts/synthesis-model-table.sh"
       - ".github/workflows/publish-llm.yml"
+      - "scripts/model-image-inputs-changed.py"
+      - "scripts/check-synthesis-runtime-release.sh"
   # Image builds belong to integration merges. Release calls only promote
   # or validate existing manifests; they never rebuild model containers.
   workflow_call:
@@ -98,9 +93,8 @@ jobs:
       # the run reported success. That is precisely how the mTLS fix in this image
       # would have failed to ship.
       #
-      # So the sidecar's own sources are hashed into the tag. Content-addressed: a
-      # rebuild happens exactly when something that lands in the image changed, and
-      # never otherwise.
+      # The content tag also protects release promotion: wrapper changes waiting
+      # for an upstream release cannot silently promote an older implementation.
       - name: Has this exact build already been published?
         id: have
         run: |
@@ -120,6 +114,12 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Require a new published upstream runtime release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/testing' && inputs.version == '' && steps.have.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/check-synthesis-runtime-release.sh "ghcr.io/${OWNER}/${{ matrix.name }}" "${{ steps.have.outputs.llamacpp_version }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -142,7 +142,16 @@ jobs:
             LLAMACPP_VERSION=${{ steps.have.outputs.llamacpp_version }}
           tags: |
             ${{ steps.have.outputs.pinned }}
+            ghcr.io/${{ env.OWNER }}/${{ matrix.name }}:runtime-${{ steps.have.outputs.llamacpp_version }}
             ghcr.io/${{ env.OWNER }}/${{ matrix.name }}:testing
+
+      - name: Test published synthesis CPU portability
+        if: github.event_name == 'push' && github.ref == 'refs/heads/testing' && inputs.version == ''
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y qemu-user-static
+          docker pull "${{ steps.have.outputs.pinned }}"
+          bash scripts/test-synthesis-portability.sh "${{ steps.have.outputs.pinned }}"
 
       # Registry-side promotion of the pinned build. This intentionally does not
       # pull or rebuild the multi-gigabyte synthesis images during a release.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -128,3 +128,19 @@ ed7de9861abc301a488773bf0b3db84dc54e65c8:benchmarks/results/roi/large-repo-qwen3
 # release-test evidence, not authentication credentials or encryption keys.
 dd572bf21af4b0568433c38ec0f57f812239b99d:docs/validation/release-0.4.2-local-recall-2026-09-06/memory-local-recall.json:generic-api-key:49
 dd572bf21af4b0568433c38ec0f57f812239b99d:docs/validation/release-0.4.2-local-recall-2026-09-06/memory-recall-shared.json:generic-api-key:327
+
+# Verified false positives in PR #2964 release-validation evidence: generated
+# placement-e2e-* memory record identifiers, including confidence-test suffixes.
+# The fixture prefix is generated in tests/e2e/memory-placement-e2e.py; these
+# values identify stored facts and are not authentication credentials.
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/local-memory.json:generic-api-key:49
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/shared-memory.json:generic-api-key:322
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/local-memory.json:generic-api-key:49
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json:generic-api-key:123
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json:generic-api-key:175
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json:generic-api-key:19
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json:generic-api-key:45
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json:generic-api-key:71
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/local-memory.json:generic-api-key:49
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/shared-memory.json:generic-api-key:327
+d7956a3e2da5c7c5456140e80a20d3bdb4d1cbbe:docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/local-memory.json:generic-api-key:49

--- a/Dockerfile.llm
+++ b/Dockerfile.llm
@@ -27,8 +27,10 @@ ARG AIMEE_MODEL_MIRROR=""
 #
 # BUMPING THIS IS A SECURITY ACT. Building from a pinned tag makes this project the
 # vendor: upstream's CVE fixes do not arrive on their own.
-ARG LLAMACPP_VERSION=b10218
+ARG LLAMACPP_VERSION=b10219
 
+# Portable CPU dispatch: never bake the CI runner's ISA into the common binary.
+# CPU-specific backends are selected at runtime after detecting host features.
 # ---- llama.cpp, built from source ----------------------------------------------
 # LLAMA_CURL=ON, and the container still never downloads. Those are not in tension:
 # curl is what compiles in the -hf/-hfd RESOLUTION path, and MTP requires it. llama.cpp
@@ -75,6 +77,7 @@ RUN set -eux; \
     test -d /tmp/llamacpp-src/.git; \
     cmake -S /tmp/llamacpp-src -B /tmp/llamacpp-src/build \
         -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=ON \
+        -DGGML_NATIVE=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON \
         -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF \
         -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_SERVER=ON; \
     cmake --build /tmp/llamacpp-src/build --target llama-server -j"$(nproc)"; \
@@ -161,7 +164,7 @@ ARG LLAMACPP_VERSION
 # the same vendoring burden the LLAMACPP_VERSION comment above describes. stunnel
 # from apt inherits Debian's CVE fixes.
 #
-# llama-server itself cannot do this. The pinned b10218 offers --api-key and
+# llama-server itself cannot do this. The pinned b10219 offers --api-key and
 # --ssl-cert-file but has no client-certificate or CA verification flag at all,
 # which is unremarkable: terminating mTLS is not an inference server's job.
 # libgomp1 is llama-server's OpenMP runtime. It is NOT optional and it is easy to

--- a/deploy/container/optional-modules-lib.sh
+++ b/deploy/container/optional-modules-lib.sh
@@ -105,16 +105,9 @@ apply_optional_modules() {
     for _om_id in $(optional_modules_for_placement "$_om_placement"); do
         _om_intent="$(_module_intent "$_om_id")"
 
-        # runtime-web's browser UI has its own long-standing switch. If the
-        # operator turned the UI off and said nothing about the module, the
-        # module has nothing to serve, so follow the UI switch rather than
-        # leaving an idle process attached to the bus.
-        if [ "$_om_id" = "runtime-web" ] && [ -z "$_om_intent" ]; then
-            case "$(printf '%s' "${AIMEE_RUNTIME_WEB_ENABLED:-}" | tr '[:upper:]' '[:lower:]')" in
-                0|false|off|no) _om_intent=off ;;
-            esac
-        fi
-
+        # AIMEE_RUNTIME_WEB_ENABLED controls the browser process separately.
+        # The runtime-web module also classifies HTTP errors for API-only servers;
+        # retain it unless the operator explicitly disables that module.
         [ -n "$_om_intent" ] || continue
 
         _om_present=0

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07.md
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07.md
@@ -1,0 +1,163 @@
+# Published testing validation for 0.4.2 — NO GO until repairs ship
+
+The published candidate at `46e763cbc68adea6f419965285f58978e45da25c` is not
+ready to release. Its synthesis runtime crashes on a supported x86-64 host,
+malformed memory confidence is mishandled, and disabling the browser removes
+HTTP error classification. Repairs and regression tests are included in this
+working branch (repair commit `67b1b3611e`). Qualification of those repairs does not repair the already
+published images.
+
+Validation used a new disposable Debian 13 VM, **9433**, on `192.168.1.253`,
+with 8 vCPUs, 16 GiB RAM and an 80 GiB disk. Existing VM 9432 and production
+containers were left untouched. The source came from the exact candidate Git
+archive. The testing branch still named this candidate at the final branch check.
+Images were pulled from GHCR; [registry digests](release-0.4.2-testing-46e763c-2026-09-07/image-digests.jsonl)
+identify the published application, PostgreSQL, embedding and both synthesis variants.
+The [publication run](https://github.com/RakuenSoftware/aimee/actions/runs/34089084581)
+and [candidate CI](https://github.com/RakuenSoftware/aimee/actions/runs/34089084714)
+finished successfully. Green CI did not cover the failures below.
+
+## Bugs and regression coverage
+
+### Synthesis contains instructions from the CI build host
+
+Running the published E2B executable with `--list-devices` exited **132
+(illegal instruction)** on an Intel i7-14700K. The browser reached model deployment
+but the model container restarted repeatedly. `Dockerfile.llm` used llama.cpp's
+native CPU build defaults.
+
+The repair disables native tuning and builds dynamically selected CPU backends.
+It advances the upstream pin from `b10218` to the published
+[b10219 release](https://github.com/ggml-org/llama.cpp/releases/tag/b10219),
+which contains one CLI history change. This limits upstream changes while
+allowing the required newer runtime release to carry the portability repair.
+`scripts/test-synthesis-portability.sh` runs the actual image executable on the
+host and through QEMU with a Nehalem CPU that lacks AVX. Both `--version` and
+`--list-devices` must succeed. Publication now runs this regression for each model.
+The normal native mTLS regression also passed its certificate-isolation cases.
+
+### Memory confidence silently becomes certainty or a storage error
+
+The published HTTP store accepted a string, boolean or null confidence and stored
+`1.0`. Values `-1` and `2` returned HTTP 503 claiming the memory module was
+unavailable. Valid `0`, `0.25` and `1` survived round trips correctly. All 24
+concurrent synthetic Unicode writes returned distinct IDs and exact contents.
+
+The repair rejects malformed, non-finite and out-of-range values before storage,
+while retaining the default for an omitted confidence. Matching personal/shared
+HTTP, MCP mutation and direct KB store paths are covered by the implementation.
+`test_server_memory_get.c` exercises valid endpoints, fractional and omitted
+confidence and invalid values for both stores, including proving that rejection
+makes no backend call. It failed on the original implementation and passes on
+the repair. `memory-placement-e2e.py` now checks HTTP and MCP store/update/supersede
+rejections and successful boundary values against real services.
+
+### Disabling the browser disables HTTP error classification
+
+The expanded confidence tests initially returned HTTP 502 with a correct
+`invalid_argument` body in the browser-disabled topology. The module needed to
+map that kind to HTTP 400 had been removed by `AIMEE_RUNTIME_WEB_ENABLED=0`.
+
+The browser switch now leaves the runtime-web policy module attached. An explicit
+`AIMEE_MODULE_RUNTIME_WEB=0` retains its existing meaning. The changed shell
+regression failed before the repair and passes after it; the real deployment
+confidence tests require HTTP 400 with the browser disabled.
+
+### Synthesis rebuild policy
+
+For this task, “new underlying synthesis release” is implemented as a **newer
+pinned, published upstream llama.cpp build release**. A wrapper, Dockerfile base,
+weight table, application or workflow edit alone cannot authorize a new synthesis
+build. Such image-input edits wait for the next runtime pin advance. A release
+promotion still requires the exact content-addressed image to exist; it cannot
+silently promote an image missing queued source changes.
+
+A per-image `runtime-bNNNNN` registry marker prevents publishing different images
+for the same runtime release, including a reverted/reintroduced runtime pin.
+The exact content tag permits an idempotent retry. The gate checks the upstream
+release and refuses registry authentication or network failures instead of
+interpreting them as absence. Release calls only promote existing manifests.
+Tests exercise unchanged inputs, wrapper/weight-only edits, upgrades, downgrades,
+missing/duplicate pins, duplicate publication, unpublished releases and outages.
+
+## Validation results
+
+The [local check summary](release-0.4.2-testing-46e763c-2026-09-07/local-checks.json)
+records the full native suite (656 executable invocations), all 56 Python script
+suites, 26 published thin-client proxy tests with the installed Codex required,
+and all 77 lint checks. All passed. Candidate CI additionally passed its complete
+Go, PostgreSQL, sanitizer, static analysis and frontend jobs; the
+[job snapshot](release-0.4.2-testing-46e763c-2026-09-07/published-ci.tsv) distinguishes
+those published-candidate checks from local repair verification.
+
+Published images passed T1 (KB-only), T2 (separately deployed Server and KB), and
+T3 (KB-free Server). Those gates include independent Vault/store identities,
+personal/shared scope isolation, semantic retrieval, enrollment, restart, outage
+recovery and immutable first-boot role checks. The original suites omitted the
+newly discovered confidence cases.
+
+The final repaired application reruns passed:
+
+| Gate | Result |
+| --- | --- |
+| [Direct KB topology and invalid confidence](release-0.4.2-testing-46e763c-2026-09-07/final-T1/topology.json) | 12/12 |
+| [KB-free memory](release-0.4.2-testing-46e763c-2026-09-07/final-T3/local-memory.json) | 49/49 |
+| [Local semantic memory](release-0.4.2-testing-46e763c-2026-09-07/final-T3/semantic-memory.json) | 15/15 |
+| [Connected memory](release-0.4.2-testing-46e763c-2026-09-07/final-T2/shared-memory.json) | 138/138 |
+| [Immutable identities](release-0.4.2-testing-46e763c-2026-09-07/final-T2/identity.json) | 6/6 |
+
+Both synthesis variants were rebuilt through the complete `Dockerfile.llm`,
+including their baked model caches. Each passed the
+[E2B](release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e2b-portability.log) and
+[E4B](release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e4b-portability.log)
+CPU gates. Both also passed [native discovery, inference and anonymous-client refusal](release-0.4.2-testing-46e763c-2026-09-07/full-model-inference.json)
+through the managed mTLS composition, remaining healthy afterward. The anonymous
+probe requires an empty response, a TLS failure and a new stunnel refusal record;
+a diagnostic-text-only assertion proved sensitive to TLS connection teardown.
+[Local image identities](release-0.4.2-testing-46e763c-2026-09-07/repaired-images.txt)
+record the complete synthesis images and repaired application.
+
+The repair application overlays the published image with rebuilt Server/KB
+executables and the optional-module startup fix. The binaries were built with
+the published Bookworm ABI. Other application modules and assets remain the
+published candidate's artifacts. These local images are qualification artifacts,
+not published release images.
+
+Fresh LUKS storage and PostgreSQL 18 offline plaintext migration passed, including
+preserved records, restart, crash/WAL recovery, conflicting ownership, missing or
+corrupt Vault data and ciphertext preservation. This is not evidence that an
+arbitrary PostgreSQL major-version upgrade is supported.
+
+The repaired synthesis image completed [fresh browser setup](release-0.4.2-testing-46e763c-2026-09-07/browser-setup.json),
+[model retirement and restoration](release-0.4.2-testing-46e763c-2026-09-07/model-lifecycle.json),
+and [15-page navigation](release-0.4.2-testing-46e763c-2026-09-07/browser-navigation.json)
+without JavaScript errors. The mobile Settings screenshot was inspected.
+Browser credentials and screenshots remain private test artifacts.
+
+## Reproduction
+
+Use `tests/e2e/deployment-matrix.py --topology T1`, `T2` or `T3` with explicit
+`AIMEE_APPLICATION_IMAGE`, `AIMEE_POSTGRES_IMAGE`, `AIMEE_EMBEDDER_IMAGE` and
+`--output` on a disposable Linux Docker host. It creates and removes only its
+randomly named projects. The new confidence checks run within the usual matrix.
+Run `scripts/test-synthesis-portability.sh IMAGE` with `qemu-user-static` installed.
+For inference, the registered native `unit-test-synthesis-mtls-client` supports
+`--managed-live` inside an isolated managed application with its local synthesis
+service running. PostgreSQL storage reproduction uses
+`tests/e2e/postgres-luks-e2e.py`, with `--legacy-upgrade` for offline migration.
+
+Raw build/test logs and the disposable images are retained under `/opt/testing042`
+on VM 9433. The VM was shut down after validation to release compute resources.
+
+## Release decision and limits
+
+Do not promote the currently published candidate. Merge the repairs, publish and
+qualify the resulting `:testing` artifacts, then satisfy the existing protected
+release gates. The main-only repository lock check still fails: **the core
+vendored mirror differs from its repository pin**. It requires legitimate
+published repository commits and a release lock refresh; changing only digests
+would fabricate provenance. No release tags or production deployments were made.
+
+External vendor subscriptions, non-Linux installations and indefinite certificate
+renewal were not exercised. The existing one-year model certificate lifetime and
+PostgreSQL/Vault backup and migration requirements still apply.

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T1/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T1/topology.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "KB application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB boots with standardized PostgreSQL and local embedding",
+    "passed": true
+  },
+  {
+    "name": "KB shared memory module stores a record",
+    "passed": true
+  },
+  {
+    "name": "KB ranked search uses its local embedding service",
+    "passed": true
+  },
+  {
+    "name": "KB graph and memory retrieval survives the deepest worker path",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/identity.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/identity.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "server persists its first-boot identity",
+    "passed": true
+  },
+  {
+    "name": "server rejects a role change without modifying its identity",
+    "passed": true
+  },
+  {
+    "name": "server accepts the same image and role on restart",
+    "passed": true
+  },
+  {
+    "name": "kb persists its first-boot identity",
+    "passed": true
+  },
+  {
+    "name": "kb rejects a role change without modifying its identity",
+    "passed": true
+  },
+  {
+    "name": "kb accepts the same image and role on restart",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/local-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/local-memory.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "KB-free local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free session recall without hint",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free CLI recall",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [],
+        "active_context": [
+          {
+            "id": 1,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-e1d738f861",
+            "content": "Personal local-only fixture person@local.invalid 🦊",
+            "confidence": 1,
+            "memory_id": 1,
+            "text": "Personal local-only fixture person@local.invalid 🦊",
+            "store": "user",
+            "handle": "user:memory:1"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 26,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "KB-free MCP recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall rejects invalid store",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory store must be user or kb"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall reports unavailable local store",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall after retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired personal record excluded from recall",
+    "passed": true,
+    "detail": null
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/shared-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/shared-memory.json
@@ -1,0 +1,499 @@
+[
+  {
+    "name": "local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local store leaves KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "get returns exact local content for colliding ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB get selects the other record",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP store defaults to user",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP personal content stays local",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP update uses local ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP forget retires local ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI default get selects user",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI explicit get selects KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI store identifies local scope",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI supersede updates local record",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI mutations leave KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local stats",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected 'both'",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected ''",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid selectors leave KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local list",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "list returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local review",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "review returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local search",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "search returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP get preserves selected store {'id': 34}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP get preserves selected store {'handle': 'memory:34', 'scope': 'all'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local preference fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit shared recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit shared recall excludes personal preferences",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local supersede",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local mutation leaves colliding KB record unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "get corrected local memory",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local replacement content",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local memory survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "restart preserves corrected value",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local dependency outage fails list",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails get",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails recall",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails store",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails supersede",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails delete",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local outage never writes KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local dependency recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local get works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local recall works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local recall retains scoped ID and prompt text",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local session recall needs no hint or KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI recall works with KB offline",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [
+          {
+            "id": 37,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "preference",
+            "key": "preference-placement-e2e-fd255148d5",
+            "content": "Private preference person@local.invalid",
+            "confidence": 1,
+            "memory_id": 37,
+            "text": "Private preference person@local.invalid",
+            "store": "user",
+            "handle": "user:memory:37"
+          }
+        ],
+        "active_context": [
+          {
+            "id": 34,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-fd255148d5",
+            "content": "corrected local fixture",
+            "confidence": 1,
+            "memory_id": 34,
+            "text": "corrected local fixture",
+            "store": "user",
+            "handle": "user:memory:34"
+          },
+          {
+            "id": 37,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "preference",
+            "key": "preference-placement-e2e-fd255148d5",
+            "content": "Private preference person@local.invalid",
+            "confidence": 1,
+            "memory_id": 37,
+            "text": "Private preference person@local.invalid",
+            "store": "user",
+            "handle": "user:memory:37"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 67,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "MCP recall works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local store works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB outage is an HTTP failure",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "KB recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB memory process outage fails list",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "KB memory process outage fails get",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "user store works during KB memory process outage",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB memory process recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired local ID never resolves to KB collision",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory not found",
+        "kind": "not_found"
+      }
+    ]
+  },
+  {
+    "name": "local retirement leaves KB content unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit long KB store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit long KB get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB get preserves full long Unicode content",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "ordinary KB get hides retired record",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "memory not found",
+        "kind": "not_found",
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "historical retired KB get 2026-03-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical KB get preserves content and validity 2026-03-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical retired KB get 2026-07-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical KB get preserves content and validity 2026-07-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "personal email canaries absent from all KB tables",
+    "passed": true,
+    "detail": {
+      "table_count": 239,
+      "matching_tables": []
+    }
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T2/topology.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "KB application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB boots with standardized PostgreSQL and local embedding",
+    "passed": true
+  },
+  {
+    "name": "KB shared memory module stores a record",
+    "passed": true
+  },
+  {
+    "name": "KB ranked search uses its local embedding service",
+    "passed": true
+  },
+  {
+    "name": "KB graph and memory retrieval survives the deepest worker path",
+    "passed": true
+  },
+  {
+    "name": "Server boots without a KB connection",
+    "passed": true
+  },
+  {
+    "name": "Server application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB-free personal memory regression gate",
+    "passed": true
+  },
+  {
+    "name": "Enrolled optional KB, scope isolation, restart and outage regressions",
+    "passed": true
+  },
+  {
+    "name": "One application image and immutable first-boot identities",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/local-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/local-memory.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "KB-free local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free session recall without hint",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free CLI recall",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [],
+        "active_context": [
+          {
+            "id": 1,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-6439f024e5",
+            "content": "Personal local-only fixture person@local.invalid 🦊",
+            "confidence": 1,
+            "memory_id": 1,
+            "text": "Personal local-only fixture person@local.invalid 🦊",
+            "store": "user",
+            "handle": "user:memory:1"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 26,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "KB-free MCP recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall rejects invalid store",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory store must be user or kb"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall reports unavailable local store",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall after retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired personal record excluded from recall",
+    "passed": true,
+    "detail": null
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/semantic-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/semantic-memory.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "store personal semantic fixture",
+    "passed": true
+  },
+  {
+    "name": "real local vector persisted",
+    "passed": true
+  },
+  {
+    "name": "semantic recall succeeds",
+    "passed": true
+  },
+  {
+    "name": "semantic recall finds the nonlexical personal fixture",
+    "passed": true
+  },
+  {
+    "name": "CLI semantic recall finds the personal fixture",
+    "passed": true
+  },
+  {
+    "name": "recall recovers after Server restart",
+    "passed": true
+  },
+  {
+    "name": "semantic recall survives Server restart",
+    "passed": true
+  },
+  {
+    "name": "local lexical recall survives embedder outage",
+    "passed": true
+  },
+  {
+    "name": "outage retains personal record",
+    "passed": true
+  },
+  {
+    "name": "semantic recall recovers when local embedder returns",
+    "passed": true
+  },
+  {
+    "name": "recall after expiry",
+    "passed": true
+  },
+  {
+    "name": "expired vector cannot resurrect personal memory",
+    "passed": true
+  },
+  {
+    "name": "retire personal fixture",
+    "passed": true
+  },
+  {
+    "name": "recall after retirement",
+    "passed": true
+  },
+  {
+    "name": "retired vector cannot resurrect personal memory",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/T3/topology.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Server boots without a KB connection",
+    "passed": true
+  },
+  {
+    "name": "Server application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB-free personal memory regression gate",
+    "passed": true
+  },
+  {
+    "name": "Real local semantic recall, outage recovery and retirement gate",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/browser-navigation.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/browser-navigation.json
@@ -1,0 +1,107 @@
+[
+  {
+    "route": "/chat",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 947,
+    "errors": []
+  },
+  {
+    "route": "/dashboard",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 1117,
+    "errors": []
+  },
+  {
+    "route": "/logs",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 601,
+    "errors": []
+  },
+  {
+    "route": "/edit-workflows",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 1152,
+    "errors": []
+  },
+  {
+    "route": "/workflow-actions",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 907,
+    "errors": []
+  },
+  {
+    "route": "/providers",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 703,
+    "errors": []
+  },
+  {
+    "route": "/models",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 1084,
+    "errors": []
+  },
+  {
+    "route": "/personas",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 747,
+    "errors": []
+  },
+  {
+    "route": "/roles",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 791,
+    "errors": []
+  },
+  {
+    "route": "/roundtable",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 1624,
+    "errors": []
+  },
+  {
+    "route": "/projects",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 651,
+    "errors": []
+  },
+  {
+    "route": "/graph",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 568,
+    "errors": []
+  },
+  {
+    "route": "/editor",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 556,
+    "errors": []
+  },
+  {
+    "route": "/memory",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 983,
+    "errors": []
+  },
+  {
+    "route": "/settings",
+    "status": 200,
+    "title": "aimee",
+    "bodyChars": 40221,
+    "errors": []
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/browser-setup.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/browser-setup.json
@@ -1,0 +1,25 @@
+{
+  "checks": [
+    {
+      "name": "real login and healthy standalone browser without a KB warning",
+      "passed": true
+    },
+    {
+      "name": "wizard accepts a local primary model without an API key",
+      "passed": true
+    },
+    {
+      "name": "wizard reaches local-model deployment with no KB installation or database step",
+      "passed": true
+    },
+    {
+      "name": "browser deploy starts the selected model services",
+      "passed": true
+    },
+    {
+      "name": "optional KB Settings remains reachable and mobile UI has no JavaScript errors",
+      "passed": true
+    }
+  ],
+  "errors": []
+}

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/exploratory-memory.json
@@ -1,0 +1,194 @@
+[
+  {
+    "name": "confidence 0",
+    "passed": true,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 1,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b72111120",
+            "content": "synthetic confidence test",
+            "confidence": 0
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "confidence 0.25",
+    "passed": true,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 2,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b72111120.25",
+            "content": "synthetic confidence test",
+            "confidence": 0.25
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "confidence 1",
+    "passed": true,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 3,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b72111121",
+            "content": "synthetic confidence test",
+            "confidence": 1
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "confidence rejection -1",
+    "passed": false,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "confidence rejection 2",
+    "passed": false,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "confidence 'invalid'",
+    "passed": false,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 4,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b7211112invalid",
+            "content": "synthetic confidence test",
+            "confidence": 1
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "confidence False",
+    "passed": false,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 5,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b7211112False",
+            "content": "synthetic confidence test",
+            "confidence": 1
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "confidence None",
+    "passed": false,
+    "detail": [
+      200,
+      [
+        200,
+        {
+          "status": "ok",
+          "memory": {
+            "id": 6,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-85b7211112None",
+            "content": "synthetic confidence test",
+            "confidence": 1
+          },
+          "store": "user"
+        }
+      ]
+    ]
+  },
+  {
+    "name": "24 simultaneous stores return distinct IDs",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "24 concurrent contents read back exactly",
+    "passed": true,
+    "detail": null
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T1/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T1/topology.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "KB application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB boots with standardized PostgreSQL and local embedding",
+    "passed": true
+  },
+  {
+    "name": "KB shared memory module stores a record",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence -1",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence 1.01",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence False",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence None",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence 'invalid'",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence []",
+    "passed": true
+  },
+  {
+    "name": "Direct KB store rejects confidence {}",
+    "passed": true
+  },
+  {
+    "name": "KB ranked search uses its local embedding service",
+    "passed": true
+  },
+  {
+    "name": "KB graph and memory retrieval survives the deepest worker path",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/identity.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/identity.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "server persists its first-boot identity",
+    "passed": true
+  },
+  {
+    "name": "server rejects a role change without modifying its identity",
+    "passed": true
+  },
+  {
+    "name": "server accepts the same image and role on restart",
+    "passed": true
+  },
+  {
+    "name": "kb persists its first-boot identity",
+    "passed": true
+  },
+  {
+    "name": "kb rejects a role change without modifying its identity",
+    "passed": true
+  },
+  {
+    "name": "kb accepts the same image and role on restart",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/local-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/local-memory.json
@@ -1,0 +1,463 @@
+[
+  {
+    "name": "KB-free local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free session recall without hint",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free CLI recall",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [],
+        "active_context": [
+          {
+            "id": 1,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-51c4920507",
+            "content": "Personal local-only fixture person@local.invalid 🦊",
+            "confidence": 1,
+            "memory_id": 1,
+            "text": "Personal local-only fixture person@local.invalid 🦊",
+            "store": "user",
+            "handle": "user:memory:1"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 26,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "KB-free MCP recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall rejects invalid store",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory store must be user or kb"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall reports unavailable local store",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall after retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired personal record excluded from recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user HTTP rejects confidence -1",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence False",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence None",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence []",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence {}",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user stores confidence 0",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 34,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-51c4920507-confidence-0",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 0.25",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0.25",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 35,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-51c4920507-confidence-0.25",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0.25
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 1",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 36,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-51c4920507-confidence-1",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 1
+        },
+        "store": "user"
+      }
+    ]
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/shared-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/shared-memory.json
@@ -1,0 +1,1264 @@
+[
+  {
+    "name": "local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local store leaves KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "get returns exact local content for colliding ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB get selects the other record",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP store defaults to user",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP personal content stays local",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP update uses local ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP forget retires local ID",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI default get selects user",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI explicit get selects KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI store identifies local scope",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI supersede updates local record",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI mutations leave KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local stats",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected 'both'",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected ''",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid store rejected 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "invalid selectors leave KB unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local list",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "list returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local review",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "review returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local search",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "search returns local fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP get preserves selected store {'id': 37}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "MCP get preserves selected store {'handle': 'memory:37', 'scope': 'all'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local preference fixture",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit shared recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit shared recall excludes personal preferences",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local supersede",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local mutation leaves colliding KB record unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "get corrected local memory",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local replacement content",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local memory survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "restart preserves corrected value",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local dependency outage fails list",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails get",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails recall",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails store",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails supersede",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "local dependency outage fails delete",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "user memory module unavailable",
+        "kind": "unavailable",
+        "http_status": 503
+      }
+    ]
+  },
+  {
+    "name": "local outage never writes KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local dependency recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local get works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local recall works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local recall retains scoped ID and prompt text",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local session recall needs no hint or KB",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "CLI recall works with KB offline",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [
+          {
+            "id": 40,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "preference",
+            "key": "preference-placement-e2e-c9679101a1",
+            "content": "Private preference person@local.invalid",
+            "confidence": 1,
+            "memory_id": 40,
+            "text": "Private preference person@local.invalid",
+            "store": "user",
+            "handle": "user:memory:40"
+          }
+        ],
+        "active_context": [
+          {
+            "id": 37,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-c9679101a1",
+            "content": "corrected local fixture",
+            "confidence": 1,
+            "memory_id": 37,
+            "text": "corrected local fixture",
+            "store": "user",
+            "handle": "user:memory:37"
+          },
+          {
+            "id": 40,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "preference",
+            "key": "preference-placement-e2e-c9679101a1",
+            "content": "Private preference person@local.invalid",
+            "confidence": 1,
+            "memory_id": 40,
+            "text": "Private preference person@local.invalid",
+            "store": "user",
+            "handle": "user:memory:40"
+          },
+          {
+            "id": 36,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-51c4920507-confidence-1",
+            "content": "Synthetic confidence boundary fixture",
+            "confidence": 1,
+            "memory_id": 36,
+            "text": "Synthetic confidence boundary fixture",
+            "store": "user",
+            "handle": "user:memory:36"
+          },
+          {
+            "id": 35,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-51c4920507-confidence-0.25",
+            "content": "Synthetic confidence boundary fixture",
+            "confidence": 0.25,
+            "memory_id": 35,
+            "text": "Synthetic confidence boundary fixture",
+            "store": "user",
+            "handle": "user:memory:35"
+          },
+          {
+            "id": 34,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-51c4920507-confidence-0",
+            "content": "Synthetic confidence boundary fixture",
+            "confidence": 0,
+            "memory_id": 34,
+            "text": "Synthetic confidence boundary fixture",
+            "store": "user",
+            "handle": "user:memory:34"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 141,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "MCP recall works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local store works with KB offline",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit KB outage is an HTTP failure",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "http_status": 503,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "KB recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB memory process outage fails list",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "http_status": 503,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "KB memory process outage fails get",
+    "passed": true,
+    "detail": [
+      503,
+      {
+        "status": "error",
+        "message": "KB memory unavailable",
+        "kind": "unavailable",
+        "http_status": 503,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "user store works during KB memory process outage",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB memory process recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired local ID never resolves to KB collision",
+    "passed": true,
+    "detail": [
+      404,
+      {
+        "status": "error",
+        "message": "user memory not found",
+        "kind": "not_found",
+        "http_status": 404
+      }
+    ]
+  },
+  {
+    "name": "local retirement leaves KB content unchanged",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit long KB store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "explicit long KB get",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB get preserves full long Unicode content",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "ordinary KB get hides retired record",
+    "passed": true,
+    "detail": [
+      404,
+      {
+        "status": "error",
+        "message": "memory not found",
+        "kind": "not_found",
+        "http_status": 404,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "historical retired KB get 2026-03-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical KB get preserves content and validity 2026-03-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical retired KB get 2026-07-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "historical KB get preserves content and validity 2026-07-01T00:00:00Z",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "personal email canaries absent from all KB tables",
+    "passed": true,
+    "detail": {
+      "table_count": 239,
+      "matching_tables": []
+    }
+  },
+  {
+    "name": "user HTTP rejects confidence -1",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence False",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence None",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence []",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence {}",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user stores confidence 0",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 68,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-0",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 0.25",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0.25",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 69,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-0.25",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0.25
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 1",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 70,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-1",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 1
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence -1",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence False",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence None",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence []",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb HTTP rejects confidence {}",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "kb MCP store rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP update rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb MCP supersede rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "kb stores confidence 0",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "kb preserves confidence 0",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 39,
+          "tier": "L0",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-0",
+          "headline": "",
+          "content": "Synthetic confidence boundary fixture",
+          "use_cases": "",
+          "confidence": 0,
+          "use_count": 0,
+          "last_used_at": "",
+          "created_at": "",
+          "updated_at": "",
+          "source_session": "",
+          "provenance_category": "",
+          "retrieval_score": 0,
+          "hybrid_rank": 0
+        },
+        "active_context_missing": true,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "kb stores confidence 0.25",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "kb preserves confidence 0.25",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 40,
+          "tier": "L0",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-0.25",
+          "headline": "",
+          "content": "Synthetic confidence boundary fixture",
+          "use_cases": "",
+          "confidence": 0.25,
+          "use_count": 0,
+          "last_used_at": "",
+          "created_at": "",
+          "updated_at": "",
+          "source_session": "",
+          "provenance_category": "",
+          "retrieval_score": 0,
+          "hybrid_rank": 0
+        },
+        "active_context_missing": true,
+        "store": "kb"
+      }
+    ]
+  },
+  {
+    "name": "kb stores confidence 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "kb preserves confidence 1",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 41,
+          "tier": "L0",
+          "kind": "fact",
+          "key": "placement-e2e-c9679101a1-confidence-1",
+          "headline": "",
+          "content": "Synthetic confidence boundary fixture",
+          "use_cases": "",
+          "confidence": 1,
+          "use_count": 0,
+          "last_used_at": "",
+          "created_at": "",
+          "updated_at": "",
+          "source_session": "",
+          "provenance_category": "",
+          "retrieval_score": 0,
+          "hybrid_rank": 0
+        },
+        "active_context_missing": true,
+        "store": "kb"
+      }
+    ]
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T2/topology.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "KB application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB boots with standardized PostgreSQL and local embedding",
+    "passed": true
+  },
+  {
+    "name": "KB shared memory module stores a record",
+    "passed": true
+  },
+  {
+    "name": "KB ranked search uses its local embedding service",
+    "passed": true
+  },
+  {
+    "name": "KB graph and memory retrieval survives the deepest worker path",
+    "passed": true
+  },
+  {
+    "name": "Server boots without a KB connection",
+    "passed": true
+  },
+  {
+    "name": "Server application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB-free personal memory regression gate",
+    "passed": true
+  },
+  {
+    "name": "Enrolled optional KB, scope isolation, restart and outage regressions",
+    "passed": true
+  },
+  {
+    "name": "One application image and immutable first-boot identities",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/local-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/local-memory.json
@@ -1,0 +1,463 @@
+[
+  {
+    "name": "KB-free local store",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall returns personal text and scoped handle {'store': 'user'}",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free session recall without hint",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free CLI recall",
+    "passed": true,
+    "detail": {
+      "store": "user",
+      "recall": {
+        "identity": [],
+        "preferences": [],
+        "active_context": [
+          {
+            "id": 1,
+            "scope": {
+              "type": "user",
+              "value": "_user"
+            },
+            "tier": "L2",
+            "kind": "fact",
+            "key": "placement-e2e-f61b0b105b",
+            "content": "Personal local-only fixture person@local.invalid 🦊",
+            "confidence": 1,
+            "memory_id": 1,
+            "text": "Personal local-only fixture person@local.invalid 🦊",
+            "store": "user",
+            "handle": "user:memory:1"
+          }
+        ],
+        "open_commitments": [],
+        "reminders": [],
+        "directives": [],
+        "limit_tokens": 1024,
+        "used_tokens": 26,
+        "session_start": false,
+        "explain": []
+      }
+    }
+  },
+  {
+    "name": "KB-free MCP recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "recall rejects invalid store",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory store must be user or kb"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall survives restart",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall reports unavailable local store",
+    "passed": true,
+    "detail": [
+      502,
+      {
+        "status": "error",
+        "message": "user memory module unavailable"
+      }
+    ]
+  },
+  {
+    "name": "KB-free recall recovers",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free local retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "KB-free recall after retirement",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "retired personal record excluded from recall",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user HTTP rejects confidence -1",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence -1",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 1.01",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence False",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence False",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence None",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence None",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence 'invalid'",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence []",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence []",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user HTTP rejects confidence {}",
+    "passed": true,
+    "detail": [
+      400,
+      {
+        "status": "error",
+        "message": "memory.store confidence must be between 0 and 1",
+        "kind": "invalid_argument",
+        "http_status": 400
+      }
+    ]
+  },
+  {
+    "name": "user MCP store rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP update rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user MCP supersede rejects confidence {}",
+    "passed": true,
+    "detail": [
+      200,
+      "{\"status\": \"ok\", \"content\": [{\"type\": \"text\", \"text\": \"error: memory confidence must be between 0 and 1\"}]}"
+    ]
+  },
+  {
+    "name": "user stores confidence 0",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 34,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-f61b0b105b-confidence-0",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 0.25",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 0.25",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 35,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-f61b0b105b-confidence-0.25",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 0.25
+        },
+        "store": "user"
+      }
+    ]
+  },
+  {
+    "name": "user stores confidence 1",
+    "passed": true,
+    "detail": null
+  },
+  {
+    "name": "user preserves confidence 1",
+    "passed": true,
+    "detail": [
+      200,
+      {
+        "status": "ok",
+        "memory": {
+          "id": 36,
+          "scope": {
+            "type": "user",
+            "value": "_user"
+          },
+          "tier": "L2",
+          "kind": "fact",
+          "key": "placement-e2e-f61b0b105b-confidence-1",
+          "content": "Synthetic confidence boundary fixture",
+          "confidence": 1
+        },
+        "store": "user"
+      }
+    ]
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/semantic-memory.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/semantic-memory.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "store personal semantic fixture",
+    "passed": true
+  },
+  {
+    "name": "real local vector persisted",
+    "passed": true
+  },
+  {
+    "name": "semantic recall succeeds",
+    "passed": true
+  },
+  {
+    "name": "semantic recall finds the nonlexical personal fixture",
+    "passed": true
+  },
+  {
+    "name": "CLI semantic recall finds the personal fixture",
+    "passed": true
+  },
+  {
+    "name": "recall recovers after Server restart",
+    "passed": true
+  },
+  {
+    "name": "semantic recall survives Server restart",
+    "passed": true
+  },
+  {
+    "name": "local lexical recall survives embedder outage",
+    "passed": true
+  },
+  {
+    "name": "outage retains personal record",
+    "passed": true
+  },
+  {
+    "name": "semantic recall recovers when local embedder returns",
+    "passed": true
+  },
+  {
+    "name": "recall after expiry",
+    "passed": true
+  },
+  {
+    "name": "expired vector cannot resurrect personal memory",
+    "passed": true
+  },
+  {
+    "name": "retire personal fixture",
+    "passed": true
+  },
+  {
+    "name": "recall after retirement",
+    "passed": true
+  },
+  {
+    "name": "retired vector cannot resurrect personal memory",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/topology.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/final-T3/topology.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Server boots without a KB connection",
+    "passed": true
+  },
+  {
+    "name": "Server application metadata contains no database or enrollment credential",
+    "passed": true
+  },
+  {
+    "name": "KB-free personal memory regression gate",
+    "passed": true
+  },
+  {
+    "name": "Real local semantic recall, outage recovery and retirement gate",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/full-model-inference.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/full-model-inference.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "e2b native discovery and inference over managed mTLS",
+    "passed": true
+  },
+  {
+    "name": "e2b refuses anonymous TLS clients",
+    "passed": true
+  },
+  {
+    "name": "e2b stays healthy after inference",
+    "passed": true
+  },
+  {
+    "name": "e4b native discovery and inference over managed mTLS",
+    "passed": true
+  },
+  {
+    "name": "e4b refuses anonymous TLS clients",
+    "passed": true
+  },
+  {
+    "name": "e4b stays healthy after inference",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/image-digests.jsonl
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/image-digests.jsonl
@@ -1,0 +1,5 @@
+["ghcr.io/rakuensoftware/aimee@sha256:c30cfb5584b8a6f3c108112fdb02c1c5c5cd05d2d6de44031a443619f9a7aea3"]
+["ghcr.io/rakuensoftware/aimee-postgres@sha256:b40f8fdcaf0923718459252e8780042fd55655bc68dd64b755506253140d4606"]
+["ghcr.io/rakuensoftware/aimee-embedder-a25m@sha256:36f313ffc32f6b7df63b2c810cab6c9c9b056ec25b04a0b0ec9606075ef7bb99"]
+["ghcr.io/rakuensoftware/aimee-llm-e2b@sha256:00a3b743f6827e04e4aef6600fd8e58eabb3411412fb9e40ee5731d3a6f25ec9"]
+["ghcr.io/rakuensoftware/aimee-llm-e4b@sha256:741b703caa49d4cd727457c6ed3c2813d03aaa7bb6f28a8d84f07fd5ceda7697"]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/local-checks.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/local-checks.json
@@ -1,0 +1,31 @@
+{
+  "native_suite": {
+    "passed": true,
+    "executables": 656
+  },
+  "script_suites": {
+    "passed": true,
+    "suites": 56
+  },
+  "published_thin_client": {
+    "passed": true,
+    "tests": 26,
+    "artifact_run": 34089084581
+  },
+  "lint": {
+    "passed": true,
+    "checks": 77
+  },
+  "native_confidence_regression": {
+    "original_exit": 134,
+    "repaired_exit": 0
+  },
+  "headless_classifier_regression": {
+    "original_failed": true,
+    "repaired_passed": true
+  },
+  "repository_release_pins": {
+    "passed": false,
+    "error": "check_c_repository_lock: error: core vendored mirror differs from its repository pin"
+  }
+}

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/luks-fresh.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/luks-fresh.json
@@ -1,0 +1,49 @@
+{
+  "checks": [
+    {
+      "check": "no initdb or database files before Vault unlock",
+      "passed": true
+    },
+    {
+      "check": "first boot unlocks from Vault and starts PostgreSQL",
+      "passed": true
+    },
+    {
+      "check": "LUKS2 header has one keyslot and no TPM or enrollment tokens",
+      "passed": true
+    },
+    {
+      "check": "database reads work and raw storage contains no plaintext canary",
+      "passed": true
+    },
+    {
+      "check": "application restart reuses the already unlocked database",
+      "passed": true
+    },
+    {
+      "check": "concurrent container cannot take ownership of the same storage",
+      "passed": true
+    },
+    {
+      "check": "clean restart preserves the encrypted database and Vault key",
+      "passed": true
+    },
+    {
+      "check": "missing Vault key leaves existing ciphertext untouched and PostgreSQL locked",
+      "passed": true
+    },
+    {
+      "check": "restoring Vault recovers the original encrypted database",
+      "passed": true
+    },
+    {
+      "check": "container crash recovers the encrypted mapping and PostgreSQL WAL",
+      "passed": true
+    },
+    {
+      "check": "corrupt Vault fails closed without replacing credentials or formatting storage",
+      "passed": true
+    }
+  ],
+  "workspace": "/tmp/aimee-luks-e2e-1y1tg2od"
+}

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/luks-upgrade.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/luks-upgrade.json
@@ -1,0 +1,57 @@
+{
+  "checks": [
+    {
+      "check": "no initdb or database files before Vault unlock",
+      "passed": true
+    },
+    {
+      "check": "first boot unlocks from Vault and starts PostgreSQL",
+      "passed": true
+    },
+    {
+      "check": "offline plaintext cluster migrates intact into encrypted PostgreSQL",
+      "passed": true
+    },
+    {
+      "check": "verified legacy source remains unchanged for rollback",
+      "passed": true
+    },
+    {
+      "check": "LUKS2 header has one keyslot and no TPM or enrollment tokens",
+      "passed": true
+    },
+    {
+      "check": "database reads work and raw storage contains no plaintext canary",
+      "passed": true
+    },
+    {
+      "check": "application restart reuses the already unlocked database",
+      "passed": true
+    },
+    {
+      "check": "concurrent container cannot take ownership of the same storage",
+      "passed": true
+    },
+    {
+      "check": "clean restart preserves the encrypted database and Vault key",
+      "passed": true
+    },
+    {
+      "check": "missing Vault key leaves existing ciphertext untouched and PostgreSQL locked",
+      "passed": true
+    },
+    {
+      "check": "restoring Vault recovers the original encrypted database",
+      "passed": true
+    },
+    {
+      "check": "container crash recovers the encrypted mapping and PostgreSQL WAL",
+      "passed": true
+    },
+    {
+      "check": "corrupt Vault fails closed without replacing credentials or formatting storage",
+      "passed": true
+    }
+  ],
+  "workspace": "/tmp/aimee-luks-e2e-xj1fnmc3"
+}

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/model-lifecycle.json
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/model-lifecycle.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "switching to external embedding and disabling synthesis removes owned local model containers",
+    "passed": true
+  },
+  {
+    "name": "switching back recreates selected local models",
+    "passed": true
+  }
+]

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/published-ci.tsv
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/published-ci.tsv
@@ -1,0 +1,36 @@
+Static analysis and secret scanning	success
+change-scope	success
+Address and undefined-behavior sanitizers	success
+Complete script regression suite	success
+no-coauthor-trailers	skipped
+identity-mint-e2e	success
+build	success
+lsp-real-providers (ubuntu-24.04, linux)	success
+lsp-real-providers (macos-latest, macos)	success
+go-unit-tests	success
+build-integrity	success
+unit-tests-pg (1/3)	success
+db2-process-replay	success
+macos-build	success
+unit-tests-pg (2/3)	success
+unit-tests-pg (3/3)	success
+unit-tests (1/2)	success
+write-tier-enforce-live	success
+unit-tests (2/2)	success
+e2e-adoption	success
+pam-login-live	success
+integration-tests	success
+e2e-docker (T2)	success
+oidc-login-live	success
+vault-pkcs11-token	success
+p1-rls-gate	success
+windows-cmake	success
+init-migrate-service-test	success
+treesitter	success
+authz-residual-live	success
+memory-retrieval-eval	success
+windows-build	success
+e2e-docker (T3)	success
+lint	success
+e2e-docker (T1)	success
+unit-tests	success

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/repaired-images.txt
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/repaired-images.txt
@@ -1,0 +1,3 @@
+["testing042-app:repaired-v2"] sha256:3074fb957157bf5c2186db3030e419d79deab0705106f2a022a672d5b5457faf
+["testing042-synthesis-e2b:full-b10219"] sha256:2ad674ae19e57ffe4b4fe24d110d09bab7faf1c5d835875231391742ab60942c
+["testing042-synthesis-e4b:full-b10219"] sha256:17e63914816fccffad9c287dfdeac0a751bd70f18da706d65027cfe2e616d35d

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e2b-portability.log
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e2b-portability.log
@@ -1,0 +1,9 @@
+version: 1 (c629da5)
+built with GNU 14.2.0 for Linux x86_64
+version: 1 (c629da5)
+built with GNU 14.2.0 for Linux x86_64
+Available devices:
+  (none)
+Available devices:
+  (none)
+synthesis CPU portability: host and Nehalem passed

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e4b-portability.log
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-full-e4b-portability.log
@@ -1,0 +1,9 @@
+version: 1 (c629da5)
+built with GNU 14.2.0 for Linux x86_64
+version: 1 (c629da5)
+built with GNU 14.2.0 for Linux x86_64
+Available devices:
+  (none)
+Available devices:
+  (none)
+synthesis CPU portability: host and Nehalem passed

--- a/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-native-e2b.log
+++ b/docs/validation/release-0.4.2-testing-46e763c-2026-09-07/synthesis-native-e2b.log
@@ -1,0 +1,2 @@
+2026-09-07T07:28:17Z INFO  synthesis_mtls: client identity loaded for aimee-llm:8761
+PASS: native client discovers and generates with the real local synthesis model over managed mTLS

--- a/scripts/check-synthesis-runtime-release.sh
+++ b/scripts/check-synthesis-runtime-release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# A runtime release may publish each synthesis image only once. The caller has
+# already checked the exact content tag, so this also permits idempotent retries.
+set -euo pipefail
+image=${1:?image repository required}
+version=${2:?upstream release required}
+[[ $version =~ ^b[0-9]+$ ]] || { echo 'invalid upstream runtime release' >&2; exit 1; }
+release=$(gh api "repos/ggml-org/llama.cpp/releases/tags/$version" \
+    --jq 'select(.draft == false and .published_at != null) | .tag_name')
+[[ $release == "$version" ]] || { echo 'runtime has no published upstream release' >&2; exit 1; }
+# Do not interpret authentication, rate limiting or registry outages as absence.
+if detail=$(docker manifest inspect "${image}:runtime-${version}" 2>&1); then
+    echo "synthesis image already published for $version; select a new upstream release" >&2
+    exit 1
+elif ! [[ $detail =~ (manifest\ unknown|no\ such\ manifest|MANIFEST_UNKNOWN) ]]; then
+    echo 'cannot verify whether the synthesis runtime release was already published' >&2
+    exit 1
+fi
+echo "verified new published synthesis runtime $version"

--- a/scripts/model-image-inputs-changed.py
+++ b/scripts/model-image-inputs-changed.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Gate model image builds on their inputs changing in an integration merge.
+"""Gate synthesis on a newer upstream runtime release, embedders on changed inputs.
 
-Compare the previous integration head with the new head so an application,
-workflow or test edit cannot rebuild unchanged models. The publishing workflows
-run this gate on pushes to testing; pull requests never build model images.
+Wrapper and weight edits wait for the next synthesis runtime release. Publication
+also checks upstream release existence and the per-runtime registry marker.
 """
 import argparse
+import re
 import subprocess
 
 
@@ -25,12 +25,25 @@ INPUTS = {
 }
 
 
+def runtime_release(revision):
+    source = subprocess.check_output(
+        ['git', 'show', revision + ':Dockerfile.llm'], text=True)
+    pins = re.findall(r'^ARG LLAMACPP_VERSION=(.*)$', source, re.MULTILINE)
+    if len(pins) != 1 or not re.fullmatch(r'b[0-9]+', pins[0]):
+        raise ValueError('Dockerfile.llm must pin one upstream llama.cpp build release')
+    return int(pins[0][1:])
+
+
 def changed(kind, before, after):
     # Resolve revisions before diff: a missing commit must fail the gate rather
     # than be interpreted as changed inputs and trigger an expensive build.
     revisions = [subprocess.check_output(
         ['git', 'rev-parse', '--verify', '--end-of-options', ref + '^{commit}'],
         text=True).strip() for ref in (before, after)]
+    if kind == 'llm':
+        # Wrapper, model table and application edits wait for the next runtime
+        # release. Downgrades and reverts must never authorize a fresh build.
+        return runtime_release(revisions[1]) > runtime_release(revisions[0])
     result = subprocess.run(['git', 'diff', '--quiet', *revisions, '--', *INPUTS[kind]])
     if result.returncode not in (0, 1):
         raise subprocess.CalledProcessError(result.returncode, result.args)

--- a/scripts/test-synthesis-portability.sh
+++ b/scripts/test-synthesis-portability.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the shipped executable on the host and on x86-64 without AVX. No models,
+# credentials, network, or persistent resources are needed for these probes.
+set -euo pipefail
+image=${1:?usage: test-synthesis-portability.sh IMAGE}
+qemu=${AIMEE_TEST_QEMU_X86_64:-/usr/bin/qemu-x86_64-static}
+[[ -x $qemu ]] || { echo 'qemu-user-static is required for the CPU portability gate' >&2; exit 1; }
+llama=/opt/aimee/llama.cpp/llama-server
+for probe in --version --list-devices; do
+    timeout 60 docker run --rm --network none --entrypoint "$llama" "$image" "$probe"
+    timeout 60 docker run --rm --network none \
+        --mount "type=bind,src=$qemu,dst=/aimee-test-qemu,readonly" \
+        --entrypoint /aimee-test-qemu "$image" -cpu Nehalem "$llama" "$probe"
+done
+echo 'synthesis CPU portability: host and Nehalem passed'

--- a/scripts/tests/test_model_image_inputs_changed.py
+++ b/scripts/tests/test_model_image_inputs_changed.py
@@ -22,8 +22,8 @@ class ModelInputTests(unittest.TestCase):
         self.git('init', '-q')
         self.git('config', 'user.name', 'Fixture')
         self.git('config', 'user.email', 'fixture@example.invalid')
-        self.commit({'Dockerfile.llm': 'FROM base@sha256:old\n',
-                     'Dockerfile.embedder': 'FROM base@sha256:old\n'})
+        self.commit({'Dockerfile.llm': 'FROM base@sha256:old\nARG LLAMACPP_VERSION=b100\n',
+                     'Dockerfile.embedder': 'FROM base@sha256:old\nARG LLAMACPP_VERSION=b100\n'})
         self.base = self.git('rev-parse', 'HEAD')
 
     def git(self, *args):
@@ -45,8 +45,8 @@ class ModelInputTests(unittest.TestCase):
         return result.stdout.strip()
 
     def test_application_update_does_not_repeat_earlier_model_build(self):
-        image_change = self.commit({'Dockerfile.llm': 'FROM base@sha256:new\n',
-                                    'Dockerfile.embedder': 'FROM base@sha256:new\n'})
+        image_change = self.commit({'Dockerfile.llm': 'FROM base@sha256:new\nARG LLAMACPP_VERSION=b101\n',
+                                    'Dockerfile.embedder': 'FROM base@sha256:new\nARG LLAMACPP_VERSION=b101\n'})
         self.commit({'tests/e2e/recall.py': 'new readiness check\n',
                      'src/application.c': 'new application code\n'})
         for kind in module.INPUTS:
@@ -59,10 +59,35 @@ class ModelInputTests(unittest.TestCase):
             for path in paths:
                 with self.subTest(kind=kind, path=path):
                     before = self.git('rev-parse', 'HEAD')
-                    self.commit({path: 'updated image input\n'})
-                    self.assertEqual(self.classify(kind, before), 'changed=true')
+                    self.commit({path: 'updated image input\n' if path != 'Dockerfile.llm' else
+                                 'FROM base\nARG LLAMACPP_VERSION=b102\n'})
+                    expected = 'true' if kind == 'embedder' or path == 'Dockerfile.llm' else 'false'
+                    self.assertEqual(self.classify(kind, before), 'changed=' + expected)
                     other = 'embedder' if kind == 'llm' else 'llm'
                     self.assertEqual(self.classify(other, before), 'changed=false')
+
+    def test_wrapper_and_weight_changes_wait_for_new_runtime_release(self):
+        self.commit({'Dockerfile.llm': 'FROM updated-base\nARG LLAMACPP_VERSION=b100\n',
+                     'deploy/container/aimee-llm-entrypoint.sh': 'new wrapper\n',
+                     'scripts/synthesis-model-table.sh': 'new weights\n'})
+        self.assertEqual(self.classify('llm', self.base), 'changed=false')
+        self.commit({'Dockerfile.llm': 'FROM updated-base\nARG LLAMACPP_VERSION=b101\n'})
+        self.assertEqual(self.classify('llm', self.base), 'changed=true')
+
+    def test_runtime_downgrade_does_not_build(self):
+        before = self.commit({'Dockerfile.llm': 'ARG LLAMACPP_VERSION=b101\n'})
+        self.commit({'Dockerfile.llm': 'ARG LLAMACPP_VERSION=b100\n'})
+        self.assertEqual(self.classify('llm', before), 'changed=false')
+
+    def test_unpinned_and_duplicate_runtime_versions_fail_closed(self):
+        for source in ('FROM base\n', 'ARG LLAMACPP_VERSION=latest\n',
+                       'ARG LLAMACPP_VERSION=b101\nARG LLAMACPP_VERSION=b102\n',
+                       'ARG LLAMACPP_VERSION=b101\nARG LLAMACPP_VERSION=latest\n'):
+            self.commit({'Dockerfile.llm': source})
+            result = subprocess.run(['python3', '-I', str(SCRIPT), 'llm', self.base, 'HEAD'],
+                                    cwd=self.repo, capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn('changed=true', result.stdout)
 
     def test_workflow_edits_and_unused_model_dockerfile_do_not_rebuild(self):
         self.commit({'.github/workflows/publish-llm.yml': 'updated workflow\n',
@@ -80,7 +105,7 @@ class ModelInputTests(unittest.TestCase):
 
     def test_reverted_inputs_do_not_rebuild(self):
         self.commit({'Dockerfile.llm': 'temporary change\n'})
-        self.commit({'Dockerfile.llm': 'FROM base@sha256:old\n'})
+        self.commit({'Dockerfile.llm': 'FROM base@sha256:old\nARG LLAMACPP_VERSION=b100\n'})
         self.assertEqual(self.classify('llm', self.base), 'changed=false')
 
     def test_workflows_gate_builds_before_registry_or_builder_setup(self):

--- a/scripts/tests/test_synthesis_runtime_release.py
+++ b/scripts/tests/test_synthesis_runtime_release.py
@@ -1,0 +1,71 @@
+"""Exercise the actual release gate with simulated forge and registry results."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class RuntimeReleaseTests(unittest.TestCase):
+    def run_gate(self, published='b10219', registry='missing', forge_exit='0'):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            commands = {
+                'gh': '#!/bin/sh\nprintf "%s\\n" "$PUBLISHED"\nexit "$FORGE_EXIT"\n',
+                'docker': '''#!/bin/sh
+case "$REGISTRY" in
+ existing) echo '{}' ;;
+ missing) echo 'no such manifest: fixture' >&2; exit 1 ;;
+ outage) echo 'TLS handshake timeout' >&2; exit 1 ;;
+ denied) echo 'unauthorized' >&2; exit 1 ;;
+esac
+'''}
+            for name, content in commands.items():
+                path = root / name
+                path.write_text(content)
+                path.chmod(0o755)
+            return subprocess.run(['bash', str(ROOT / 'scripts/check-synthesis-runtime-release.sh'),
+                                   'ghcr.io/fixture/synthesis', 'b10219'],
+                                  env=dict(os.environ, PATH=directory+':'+os.environ['PATH'],
+                                           PUBLISHED=published, REGISTRY=registry, FORGE_EXIT=forge_exit),
+                                  capture_output=True, text=True)
+
+    def test_workflow_requires_release_gate_and_cpu_probe(self):
+        workflow = yaml.load((ROOT / '.github/workflows/publish-llm.yml').read_text(), Loader=yaml.BaseLoader)
+        steps = workflow['jobs']['build']['steps']
+        gate = next(i for i, step in enumerate(steps)
+                    if 'check-synthesis-runtime-release.sh' in step.get('run', ''))
+        build = next(i for i, step in enumerate(steps)
+                     if step.get('with', {}).get('file') == 'Dockerfile.llm')
+        probe = next(i for i, step in enumerate(steps)
+                     if 'test-synthesis-portability.sh' in step.get('run', ''))
+        self.assertLess(gate, build)
+        self.assertGreater(probe, build)
+        self.assertIn(':runtime-${{ steps.have.outputs.llamacpp_version }}', steps[build]['with']['tags'])
+        self.assertIn("steps.have.outputs.exists != 'true'", steps[gate]['if'])
+        self.assertIn("inputs.version == ''", steps[gate]['if'])
+        source = (ROOT / 'Dockerfile.llm').read_text()
+        for flag in ('GGML_NATIVE=OFF', 'GGML_BACKEND_DL=ON', 'GGML_CPU_ALL_VARIANTS=ON'):
+            self.assertIn('-D' + flag, source)
+
+    def test_new_published_runtime_and_missing_image_authorize_build(self):
+        self.assertEqual(self.run_gate().returncode, 0)
+
+    def test_same_runtime_never_rebuilds(self):
+        self.assertNotEqual(self.run_gate(registry='existing').returncode, 0)
+
+    def test_unpublished_runtime_and_forge_failure_refuse(self):
+        for kwargs in ({'published': ''}, {'published': 'b10218'}, {'forge_exit': '1'}):
+            self.assertNotEqual(self.run_gate(**kwargs).returncode, 0)
+
+    def test_registry_errors_cannot_authorize_a_build(self):
+        for registry in ('outage', 'denied'):
+            self.assertNotEqual(self.run_gate(registry=registry).returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -2065,6 +2065,9 @@ int kb_handle_memory_store(int fd, cJSON *req)
    cJSON *tier_j = cJSON_GetObjectItemCaseSensitive(req, "tier");
    cJSON *kind_j = cJSON_GetObjectItemCaseSensitive(req, "kind");
    cJSON *conf_j = cJSON_GetObjectItemCaseSensitive(req, "confidence");
+   if (conf_j &&
+       (!cJSON_IsNumber(conf_j) || !(conf_j->valuedouble >= 0.0 && conf_j->valuedouble <= 1.0)))
+      return kb_send_error(fd, "memory.store confidence must be between 0 and 1");
    cJSON *sid_j = cJSON_GetObjectItemCaseSensitive(req, "session_id");
    cJSON *use_cases_j = cJSON_GetObjectItemCaseSensitive(req, "use_cases");
    cJSON *epistemic_j = cJSON_GetObjectItemCaseSensitive(req, "epistemic_kind");

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -405,6 +405,14 @@ cJSON *tool_memory_mutate(cJSON *args)
       return text_content("error: missing 'verb' parameter");
    const char *verb = jv->valuestring;
 
+   const cJSON *input_confidence = cJSON_GetObjectItemCaseSensitive(args, "confidence");
+   if ((strcmp(verb, "store") == 0 || strcmp(verb, "update") == 0 ||
+        strcmp(verb, "supersede") == 0) &&
+       input_confidence &&
+       (!cJSON_IsNumber(input_confidence) ||
+        !(input_confidence->valuedouble >= 0.0 && input_confidence->valuedouble <= 1.0)))
+      return text_content("error: memory confidence must be between 0 and 1");
+
    int selection = server_memory_store_selection(args);
    if (selection < 0)
       return text_content("error: memory store must be user or kb");

--- a/src/server/server_memory.c
+++ b/src/server/server_memory.c
@@ -333,6 +333,11 @@ cJSON *memory_store_command(const cJSON *req, memory_authority_t authority)
    int selection = server_memory_store_selection(req);
    if (selection < 0)
       return memory_bad_store();
+   const cJSON *jconfidence = cJSON_GetObjectItemCaseSensitive(req, "confidence");
+   if (jconfidence && (!cJSON_IsNumber(jconfidence) ||
+                       !(jconfidence->valuedouble >= 0.0 && jconfidence->valuedouble <= 1.0)))
+      return server_error_kind_json(SERVER_ERR_INVALID_ARGUMENT,
+                                    "memory.store confidence must be between 0 and 1", NULL);
    if (selection)
       return memory_with_store(kb_memory_store_command(req, authority), "kb");
 

--- a/src/tests/test_optional_modules.sh
+++ b/src/tests/test_optional_modules.sh
@@ -99,16 +99,19 @@ else
     printf '  skip  on-adds-governance (module binary not installed on this host)\n'
 fi
 
-# 7. runtime-web follows the browser-UI switch when not named explicitly.
+# 7. Browser visibility does not disable the module that classifies HTTP errors.
 rw="$tmp/rw.modules"
 printf 'runtime-web\t/usr/local/libexec/aimee-modules/aimee-module-runtime-web\n' > "$rw"
 AIMEE_RUNTIME_WEB_ENABLED=0; export AIMEE_RUNTIME_WEB_ENABLED
 out=$(apply_optional_modules server "$rw" "$tmp")
-check "runtime-web module follows AIMEE_RUNTIME_WEB_ENABLED=0" "" "$(ids "$out")"
+check "headless server retains HTTP error classification" "runtime-web" "$(ids "$out")"
 # An explicit module setting wins over the UI switch.
 AIMEE_MODULE_RUNTIME_WEB=1; export AIMEE_MODULE_RUNTIME_WEB
 out=$(apply_optional_modules server "$rw" "$tmp")
 check "explicit AIMEE_MODULE_RUNTIME_WEB=1 overrides the UI switch" "runtime-web" "$(ids "$out")"
+AIMEE_MODULE_RUNTIME_WEB=0; export AIMEE_MODULE_RUNTIME_WEB
+out=$(apply_optional_modules server "$rw" "$tmp")
+check "explicit module disable remains supported" "" "$(ids "$out")"
 unset AIMEE_RUNTIME_WEB_ENABLED AIMEE_MODULE_RUNTIME_WEB
 
 # 8. kb placement gates its own set, and does not accept a server-only module.

--- a/src/tests/test_server_memory_get.c
+++ b/src/tests/test_server_memory_get.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 extern cJSON *memory_get_command(cJSON *request);
+extern cJSON *memory_store_command(const cJSON *request, memory_authority_t authority);
 
 static int calls, clears, result;
 static kb_valid_at_t answer;
@@ -55,10 +56,18 @@ cJSON *server_error_kind_json(const char *kind, const char *message, const char 
    return response;
 }
 
-static int user_calls, user_result;
+static int user_calls, user_result, store_calls;
+static double expected_confidence;
 
 cJSON *server_module_memory_data(const cJSON *request)
 {
+   const char *operation = cJSON_GetObjectItem(request, "operation")->valuestring;
+   if (strcmp(operation, "store") == 0)
+   {
+      store_calls++;
+      assert(cJSON_GetObjectItem(request, "confidence")->valuedouble == expected_confidence);
+      return cJSON_Parse("{\"records\":[{\"id\":42}]}");
+   }
    user_calls++;
    assert(strcmp(cJSON_GetObjectItem(request, "operation")->valuestring, "get") == 0);
    assert(cJSON_GetObjectItem(request, "id")->valuedouble == 42);
@@ -112,6 +121,62 @@ static void test_user_namespace(void)
    cJSON_Delete(request);
 }
 
+int kb_client_memory_insert_as(const char *tier, const char *kind, const char *key,
+                               const char *content, const char *use_cases, double confidence,
+                               const char *session_id, memory_authority_t authority, memory_t *out)
+{
+   (void)tier;
+   (void)kind;
+   (void)key;
+   (void)content;
+   (void)use_cases;
+   (void)session_id;
+   (void)authority;
+   store_calls++;
+   assert(confidence == expected_confidence);
+   out->id = 42;
+   return 0;
+}
+
+static void test_store_confidence(void)
+{
+   const char *invalid[] = {"-1", "1.01", "false", "null", "\"invalid\"", "[]", "{}", "1e999"};
+   const char *valid[] = {"0", "0.25", "1"};
+   for (int shared = 0; shared < 2; shared++)
+   {
+      for (unsigned i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++)
+      {
+         cJSON *request = cJSON_Parse("{\"key\":\"fixture\",\"content\":\"synthetic\"}");
+         cJSON_AddStringToObject(request, "store", shared ? "kb" : "user");
+         cJSON_AddItemToObject(request, "confidence", cJSON_Parse(invalid[i]));
+         int before = store_calls;
+         cJSON *reply = memory_store_command(request, MEMORY_AUTHORITY_MODEL);
+         cJSON *kind = cJSON_GetObjectItem(reply, "kind");
+         assert(cJSON_IsString(kind) &&
+                strcmp(kind->valuestring, SERVER_ERR_INVALID_ARGUMENT) == 0);
+         assert(store_calls == before);
+         cJSON_Delete(reply);
+         cJSON_Delete(request);
+      }
+      for (unsigned i = 0; i <= sizeof(valid) / sizeof(valid[0]); i++)
+      {
+         cJSON *request = cJSON_Parse("{\"key\":\"fixture\",\"content\":\"synthetic\"}");
+         cJSON_AddStringToObject(request, "store", shared ? "kb" : "user");
+         expected_confidence = 1.0;
+         if (i < sizeof(valid) / sizeof(valid[0]))
+         {
+            cJSON *value = cJSON_Parse(valid[i]);
+            expected_confidence = value->valuedouble;
+            cJSON_AddItemToObject(request, "confidence", value);
+         }
+         cJSON *reply = memory_store_command(request, MEMORY_AUTHORITY_MODEL);
+         assert(cJSON_GetObjectItem(reply, "id")->valuedouble == 42);
+         cJSON_Delete(reply);
+         cJSON_Delete(request);
+      }
+   }
+}
+
 int main(void)
 {
    test_user_namespace();
@@ -146,6 +211,7 @@ int main(void)
    }
    assert(calls == 6 && clears == calls);
    cJSON_Delete(request);
+   test_store_confidence();
    puts("server memory get: local privacy, explicit KB routing, temporal verdicts, and failures "
         "passed");
    return 0;

--- a/tests/e2e/deployment-matrix.py
+++ b/tests/e2e/deployment-matrix.py
@@ -144,6 +144,13 @@ def main():
             code, body = kb.kb_request('/v1/actions/memory.store', dict(key='shared-e2e-' + uuid.uuid4().hex,
                 content='Synthetic shared deployment fixture'))
             check('KB shared memory module stores a record', code == 200 and body.get('status') == 'ok')
+            for confidence in (-1, 1.01, False, None, 'invalid', [], {}):
+                code, body = kb.kb_request('/v1/actions/memory.store', dict(
+                    key='invalid-confidence-e2e', content='Synthetic shared fixture',
+                    confidence=confidence))
+                check('Direct KB store rejects confidence ' + repr(confidence),
+                      body.get('status') == 'error' and
+                      'confidence must be between 0 and 1' in body.get('message', ''))
             code, body = kb.kb_request('/v1/search', dict(query='shared deployment fixture', scope='all', max_results=3))
             check('KB ranked search uses its local embedding service', code == 200 and isinstance(body.get('hits'), list))
             code, body = kb.kb_request('/v1/actions/memory.find_facts', dict(query='shared deployment fixture', limit=3, graph_code_fusion_state='on'))

--- a/tests/e2e/memory-placement-e2e.py
+++ b/tests/e2e/memory-placement-e2e.py
@@ -93,6 +93,30 @@ class Gate:
         # The transport wraps the MCP content blocks in its result envelope.
         return code, json.dumps(body, ensure_ascii=False)
 
+    def confidence_contract(self, stores):
+        """Malformed confidence never becomes certainty or a storage outage."""
+        for store in stores:
+            for confidence in (-1, 1.01, False, None, 'invalid', [], {}):
+                payload = dict(store=store, key=self.prefix+'-confidence',
+                               content='Synthetic confidence fixture', confidence=confidence)
+                code, body = self.call('store', payload)
+                self.check(f'{store} HTTP rejects confidence {confidence!r}',
+                           code == 400 and body.get('kind') == 'invalid_argument', [code, body])
+                for verb in ('store', 'update', 'supersede'):
+                    code, body = self.mcp('mutate', dict(payload, verb=verb, id=1))
+                    self.check(f'{store} MCP {verb} rejects confidence {confidence!r}',
+                               'confidence must be between 0 and 1' in body, [code, body])
+            for confidence in (0, 0.25, 1):
+                row = self.good(f'{store} stores confidence {confidence}', self.call('store',
+                    dict(store=store, key=self.prefix+'-confidence-'+str(confidence),
+                         content='Synthetic confidence boundary fixture', confidence=confidence)))
+                if 'id' not in row:
+                    continue
+                code, body = self.call('get', dict(store=store, id=row['id']))
+                self.check(f'{store} preserves confidence {confidence}',
+                           code == 200 and body.get('memory', {}).get('confidence') == confidence,
+                           [code, body])
+
     def run_local(self):
         """First-boot regression on a composition containing only Server and its store."""
         content = 'Personal local-only fixture person@local.invalid 🦊'
@@ -125,6 +149,7 @@ class Gate:
         self.good('KB-free local retirement', self.call('delete', dict(id=mid)))
         bundle = self.good('KB-free recall after retirement', self.call('recall', dict(query=self.prefix)))
         self.check('retired personal record excluded from recall', bundle.get('recall', {}).get('active_context') == [])
+        self.confidence_contract(('user',))
         return all(c['passed'] for c in self.checks)
 
     def run(self):
@@ -266,6 +291,7 @@ class Gate:
             listing = self.good('0.4.1 upgrade list', self.call('list', dict(store='kb', scope='all', limit=64)))
             self.check('0.4.1 rows remain discoverable', all(any(r['id'] == old['id'] for r in listing.get('memories', [])) for old in rows))
         self.assert_no_personal_canary()
+        self.confidence_contract(('user', 'kb'))
         return all(c['passed'] for c in self.checks)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The published `testing-46e763c` synthesis image crashes with illegal instruction on an Intel i7-14700K. Memory writes also convert malformed confidence to `1.0` or return a misleading storage outage, and disabling the browser removes the module that classifies HTTP errors.

This fixes portable synthesis CPU dispatch, validates confidence consistently across Server/KB/MCP writes, and preserves HTTP error classification when the browser is disabled. Each defect has regression coverage. Synthesis publication now requires a newer pinned upstream llama.cpp release, verifies that the release exists, and prevents a second image publication for the same runtime release. The pin advances from b10218 to the published b10219 release; image-only wrapper changes wait for a runtime advance.

Validation passed on a new disposable VM: all three published deployment topologies; repaired KB, connected and KB-free deployments; 138 connected-memory, 49 personal-memory, 15 semantic-memory and six identity checks; fresh and migrated encrypted PostgreSQL; real browser setup, model retirement/restoration and 15-page navigation. Both complete synthesis images built and passed host/Nehalem CPU probes, native mTLS inference and anonymous-client refusal. The full native suite (656 executable invocations), all 56 Python script suites, 26 published client tests and all 77 lint checks passed.

The current published candidate remains **NO GO for 0.4.2** until repairs ship and the main-only repository release pins are legitimately refreshed. The core mirror currently differs from its published pin. This PR does not publish a release or modify production. CI on this PR still needs to complete.

Full evidence: [published candidate and repair report](docs/validation/release-0.4.2-testing-46e763c-2026-09-07.md).
