### PR TITLE
ci: parallelize native analyzers and separate secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,21 +37,66 @@ permissions:
   contents: read
 
 jobs:
-  secure-development-gates:
-    name: Static analysis and secret scanning
+  cppcheck-shards:
+    name: Cppcheck (${{ matrix.shard }}/8)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Install cppcheck dependencies
+        run: sudo apt-get update && sudo apt-get install -y cppcheck build-essential pkg-config libpq-dev libssl-dev libpam0g-dev zlib1g-dev libzstd-dev libp11-kit-dev python3-yaml
+      - name: Analyze source batch
+        working-directory: src
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: make cppcheck STATIC_ANALYSIS_STRICT=1 CPPCHECK_ARGS="--shard-index $SHARD --shard-count 8 --report build/cppcheck/cppcheck-$SHARD.xml"
+      - name: Retain diagnostics for the combined ratchet
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: cppcheck-${{ matrix.shard }}
+          path: src/build/cppcheck/cppcheck-${{ matrix.shard }}.xml
+          if-no-files-found: error
+          retention-days: 7
+
+  clang-tidy-shards:
+    name: Clang-tidy (${{ matrix.shard }}/8)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Install clang-tidy dependencies
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy build-essential pkg-config libpq-dev libssl-dev libpam0g-dev zlib1g-dev libzstd-dev libp11-kit-dev python3-yaml
+      - name: Analyze source batch
+        working-directory: src
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: make clang-tidy STATIC_ANALYSIS_STRICT=1 CLANG_TIDY_ARGS="--shard-index $SHARD --shard-count 8"
+      - name: Retain analyzer diagnostics
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: clang-tidy-${{ matrix.shard }}
+          path: src/build/clang-tidy.log
+          if-no-files-found: error
+          retention-days: 7
+
+  secret-scanning:
+    name: Secret scanning
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
-          # Gitleaks scans commit history, so a one-commit checkout is not enough.
           fetch-depth: 0
-      - name: Install native analyzers
-        run: sudo apt-get update && sudo apt-get install -y cppcheck clang-tidy build-essential pkg-config libpq-dev libssl-dev libpam0g-dev zlib1g-dev libzstd-dev libp11-kit-dev python3-yaml
-      - name: Run mandatory native static analysis
-        working-directory: src
-        run: make static-analysis STATIC_ANALYSIS_STRICT=1
       - name: Scan the complete Git history for secrets
         env:
           GITLEAKS_VERSION: 8.30.1
@@ -65,6 +110,36 @@ jobs:
           printf '%s  %s\n' "$GITLEAKS_SHA256" "$archive" | sha256sum --check --strict
           tar -xzf "$archive" -C "$RUNNER_TEMP" gitleaks
           "$RUNNER_TEMP/gitleaks" git --no-banner --redact --verbose --log-opts=HEAD .
+
+  # Keep the existing required-check name; every analyzer batch and the full
+  # history scan must pass. Apply the debt ceiling to the SUM of all cppcheck
+  # reports, never an independent allowance for each shard.
+  secure-development-gates:
+    name: Static analysis and secret scanning
+    needs: [cppcheck-shards, clang-tidy-shards, secret-scanning]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Confirm every analyzer and secret scan passed
+        env:
+          CPPCHECK_RESULT: ${{ needs.cppcheck-shards.result }}
+          CLANG_TIDY_RESULT: ${{ needs.clang-tidy-shards.result }}
+          SECRET_SCAN_RESULT: ${{ needs.secret-scanning.result }}
+        run: |
+          for result in "$CPPCHECK_RESULT" "$CLANG_TIDY_RESULT" "$SECRET_SCAN_RESULT"; do
+            [ "$result" = success ] || { echo "Security gate dependency: $result" >&2; exit 1; }
+          done
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Collect every cppcheck report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: cppcheck-*
+          path: src/build/cppcheck
+          merge-multiple: true
+      - name: Enforce the combined diagnostic baseline
+        working-directory: src
+        run: python3 -I -S ../scripts/run-cppcheck-ratchet.py --reports-dir build/cppcheck --shard-count 8
 
   script-tests:
     name: Complete script regression suite

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -52,6 +52,15 @@ def analyze(executable, database, source):
     return result.returncode, result.stdout
 
 
+def shard_sources(sources, index, count):
+    if count < 1 or not 0 <= index < count:
+        raise ValueError('shard count must be positive and index must be in range')
+    selected = sorted(set(sources))[index::count]
+    if not selected:
+        raise ValueError('shard has no production sources')
+    return selected
+
+
 def self_test():
     with tempfile.TemporaryDirectory() as temp:
         directory = Path(temp)
@@ -80,6 +89,8 @@ def main():
     parser.add_argument('--self-test', action='store_true')
     parser.add_argument('--executable', default='clang-tidy')
     parser.add_argument('--jobs', type=int, default=min(4, os.cpu_count() or 2))
+    parser.add_argument('--shard-index', type=int, default=0)
+    parser.add_argument('--shard-count', type=int, default=1)
     parser.add_argument('--log', type=Path, default=ROOT / 'src/build/clang-tidy.log')
     args = parser.parse_args()
     if args.self_test:
@@ -87,6 +98,8 @@ def main():
         return 0
     if args.jobs < 1:
         parser.error('--jobs must be positive')
+    if args.shard_count < 1 or not 0 <= args.shard_index < args.shard_count:
+        parser.error('shard count must be positive and index must be in range')
     generated = subprocess.run(['make', 'agent_help_data.h', 'tool_prompts_data.h',
         'schema_data.h', 'kb/http/openapi_data.h', 'server/openapi_server_data.h'],
         cwd=ROOT / 'src', text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -100,10 +113,11 @@ def main():
         return plan.returncode
     try:
         entries = compilation_database(plan.stdout, ROOT / 'src')
+        sources = shard_sources([entry['file'] for entry in entries], args.shard_index, args.shard_count)
     except ValueError as error:
         print('clang-tidy: ' + str(error), file=sys.stderr)
         return 2
-    sources = sorted({entry['file'] for entry in entries})
+    print(f'clang-tidy: shard {args.shard_index + 1}/{args.shard_count}; {len(sources)} sources', flush=True)
     args.log.parent.mkdir(parents=True, exist_ok=True)
     failures, warnings = 0, 0
     with tempfile.TemporaryDirectory(prefix='aimee-tidy-') as temp, args.log.open('w') as report:
@@ -116,7 +130,7 @@ def main():
                 if code:
                     failures += 1
                     print(f'clang-tidy: failed {sources[index - 1]} (exit {code})', flush=True)
-                if index % 100 == 0:
+                if index % 25 == 0:
                     report.flush()
                     print(f'clang-tidy: checked {index}/{len(sources)} sources', flush=True)
     print(f'clang-tidy: {len(sources)} sources; {warnings} warnings; {failures} process failures; report {args.log}')

--- a/scripts/run-cppcheck-ratchet.py
+++ b/scripts/run-cppcheck-ratchet.py
@@ -82,11 +82,55 @@ def excess(
     ]
 
 
+def shard_sources(sources: list[str], index: int, count: int) -> list[str]:
+    if count < 1 or not 0 <= index < count:
+        raise ValueError("shard count must be positive and index must be in range")
+    selected = sorted(set(sources))[index::count]
+    if not selected:
+        raise ValueError("shard has no production sources")
+    return selected
+
+
+def merge_reports(directory: Path, count: int):
+    expected = {directory / f"cppcheck-{index}.xml" for index in range(count)}
+    if count < 1 or set(directory.glob("*.xml")) != expected:
+        raise ValueError("expected exactly one report from every cppcheck shard")
+    actual = Counter()
+    details = {}
+    for path in sorted(expected):
+        counts, messages = parse_report(path)
+        actual.update(counts)
+        for key, values in messages.items():
+            details.setdefault(key, []).extend(values)
+    return actual, details
+
+
+def check_diagnostics(actual, details, baseline) -> int:
+    failures = excess(actual, baseline)
+    if failures:
+        print("cppcheck-ratchet: new or increased diagnostics", file=sys.stderr)
+        for key, count, allowed in failures:
+            print(f"  {key[0]}:{key[1]} count={count} baseline={allowed}", file=sys.stderr)
+            for detail in details.get(key, [])[:5]:
+                print("    " + detail, file=sys.stderr)
+        return 1
+    known = sum(actual.values())
+    ceiling = sum(baseline.values())
+    print(f"cppcheck-ratchet: ok ({known} known diagnostics; ceiling {ceiling}; no increase)")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--shard-index", type=int, default=0)
+    parser.add_argument("--shard-count", type=int, default=1)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--reports-dir", type=Path)
     parser.add_argument("sources", nargs="*")
     args = parser.parse_args()
+    if args.shard_count < 1 or not 0 <= args.shard_index < args.shard_count:
+        parser.error("shard count must be positive and index must be in range")
     try:
         expected_version, baseline = load_baseline()
     except (OSError, json.JSONDecodeError, ValueError) as exc:
@@ -100,8 +144,22 @@ def main() -> int:
             return 1
         print("cppcheck-ratchet: plant test passed")
         return 0
+    if args.reports_dir is not None:
+        if args.sources or args.report is not None or args.shard_index != 0:
+            parser.error("report aggregation cannot be combined with an analyzer invocation")
+        try:
+            actual, details = merge_reports(args.reports_dir, args.shard_count)
+        except (ET.ParseError, OSError, ValueError) as exc:
+            print(f"cppcheck-ratchet: invalid shard reports: {exc}", file=sys.stderr)
+            return 2
+        return check_diagnostics(actual, details, baseline)
     if not args.sources:
         parser.error("at least one source is required")
+    try:
+        sources = shard_sources(args.sources, args.shard_index, args.shard_count)
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(f"cppcheck: shard {args.shard_index + 1}/{args.shard_count}; {len(sources)} sources", flush=True)
     version = subprocess.run(
         ["cppcheck", "--version"], capture_output=True, check=False, text=True
     )
@@ -126,7 +184,7 @@ def main() -> int:
             "--xml-version=2",
             "-Iheaders",
             "-Ivendor/headers",
-            *args.sources,
+            *sources,
         ]
         completed = subprocess.run(command, stderr=report, check=False)
         if completed.returncode != 0:
@@ -138,18 +196,10 @@ def main() -> int:
         except (ET.ParseError, OSError, ValueError) as exc:
             print(f"cppcheck-ratchet: invalid analyzer report: {exc}", file=sys.stderr)
             return 2
-    failures = excess(actual, baseline)
-    if failures:
-        print("cppcheck-ratchet: new or increased diagnostics", file=sys.stderr)
-        for key, count, allowed in failures:
-            print(f"  {key[0]}:{key[1]} count={count} baseline={allowed}", file=sys.stderr)
-            for detail in details.get(key, [])[:5]:
-                print("    " + detail, file=sys.stderr)
-        return 1
-    known = sum(actual.values())
-    ceiling = sum(baseline.values())
-    print(f"cppcheck-ratchet: ok ({known} known diagnostics; ceiling {ceiling}; no increase)")
-    return 0
+        if args.report is not None:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_bytes(Path(report.name).read_bytes())
+    return check_diagnostics(actual, details, baseline)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_static_analysis_shards.py
+++ b/scripts/tests/test_static_analysis_shards.py
@@ -1,0 +1,132 @@
+"""Ensure parallel analysis covers every source and keeps the combined debt gate."""
+import collections
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+import xml.etree.ElementTree as ET
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_runner(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / 'scripts' / name)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+tidy = load_runner('run-clang-tidy.py')
+cppcheck = load_runner('run-cppcheck-ratchet.py')
+WORKFLOW = yaml.safe_load((ROOT / '.github/workflows/ci.yml').read_text())['jobs']
+
+
+def write_report(path, identifier='known', count=1):
+    root = ET.Element('results')
+    errors = ET.SubElement(root, 'errors')
+    for line in range(count):
+        error = ET.SubElement(errors, 'error', id=identifier, msg='fixture diagnostic')
+        ET.SubElement(error, 'location', file='fixture.c', line=str(line + 1))
+    ET.ElementTree(root).write(path)
+
+
+class AnalysisShardsTests(unittest.TestCase):
+    def test_ci_batches_cover_each_source_once(self):
+        sources = [f'source-{i:04}.c' for i in range(1081)]
+        for runner, job in ((tidy, 'clang-tidy-shards'), (cppcheck, 'cppcheck-shards')):
+            indices = WORKFLOW[job]['strategy']['matrix']['shard']
+            self.assertEqual(indices, list(range(len(indices))))
+            batches = [runner.shard_sources(list(reversed(sources)) + sources[:5], i, len(indices))
+                       for i in indices]
+            self.assertEqual(collections.Counter(s for batch in batches for s in batch),
+                             collections.Counter(sources))
+            self.assertLessEqual(max(map(len, batches)) - min(map(len, batches)), 1)
+            self.assertEqual(runner.shard_sources(sources, 0, 1), sources)
+            command = next(s['run'] for s in WORKFLOW[job]['steps'] if s.get('name') == 'Analyze source batch')
+            self.assertIn(f'--shard-count {len(indices)}', command)
+
+    def test_invalid_or_empty_batches_fail(self):
+        for runner in (tidy, cppcheck):
+            for index, count in ((0, 0), (-1, 8), (8, 8), (1, 2)):
+                with self.subTest(runner=runner.__name__, index=index, count=count):
+                    with self.assertRaises(ValueError):
+                        runner.shard_sources(['one.c'], index, count)
+
+    def test_clang_failure_survives_partitioning_and_full_database_is_retained(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            src = root / 'src'
+            src.mkdir()
+            files = [src / f'sample-{i}.c' for i in range(16)]
+            for file in files:
+                file.touch()
+            plan = '\n'.join(f'gcc -c {file.name} -o {file.stem}.o' for file in files)
+            seen = []
+            def analyze(executable, database, source):
+                import json
+                entries = json.loads((database / 'compile_commands.json').read_text())
+                self.assertEqual(len(entries), len(files))
+                seen.append(source)
+                return (17, 'error: planted failure\n') if source == str(files[3]) else (0, '')
+            outcomes = []
+            for index in range(8):
+                argv = ['tidy', '--shard-index', str(index), '--shard-count', '8', '--log', str(root / 'tidy.log')]
+                with patch.object(tidy, 'ROOT', root), patch.object(sys, 'argv', argv), \
+                     patch.object(tidy.subprocess, 'run', return_value=subprocess.CompletedProcess([], 0, plan, '')), \
+                     patch.object(tidy, 'analyze', side_effect=analyze):
+                    outcomes.append(tidy.main())
+            self.assertEqual(collections.Counter(seen), collections.Counter(map(str, files)))
+            self.assertEqual(collections.Counter(outcomes), {0: 7, 1: 1})
+
+    def test_cppcheck_combines_counts_before_applying_ceiling(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            for index in range(2):
+                write_report(directory / f'cppcheck-{index}.xml', count=2)
+            actual, details = cppcheck.merge_reports(directory, 2)
+            self.assertEqual(actual[('known', 'fixture.c')], 4)
+            baseline = collections.Counter({('known', 'fixture.c'): 3})
+            self.assertEqual(cppcheck.check_diagnostics(actual, details, baseline), 1)
+            baseline[('known', 'fixture.c')] = 4
+            self.assertEqual(cppcheck.check_diagnostics(actual, details, baseline), 0)
+            write_report(directory / 'cppcheck-1.xml', identifier='newFinding')
+            self.assertEqual(cppcheck.check_diagnostics(*cppcheck.merge_reports(directory, 2), baseline), 1)
+
+    def test_missing_extra_and_malformed_cppcheck_reports_fail(self):
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            write_report(directory / 'cppcheck-0.xml')
+            with self.assertRaises(ValueError):
+                cppcheck.merge_reports(directory, 2)
+            write_report(directory / 'cppcheck-1.xml')
+            write_report(directory / 'cppcheck-2.xml')
+            with self.assertRaises(ValueError):
+                cppcheck.merge_reports(directory, 2)
+            (directory / 'cppcheck-2.xml').unlink()
+            (directory / 'cppcheck-1.xml').write_text('<results/>')
+            with self.assertRaises(ValueError):
+                cppcheck.merge_reports(directory, 2)
+
+    def test_required_gate_rejects_non_successful_dependencies(self):
+        gate = WORKFLOW['secure-development-gates']
+        self.assertEqual(set(gate['needs']), {'cppcheck-shards', 'clang-tidy-shards', 'secret-scanning'})
+        self.assertEqual(gate['if'], '${{ always() }}')
+        step = gate['steps'][0]
+        for result in ('success', 'failure', 'cancelled', 'skipped', ''):
+            for key in step['env']:
+                env = {name: 'success' for name in step['env']}
+                env[key] = result
+                run = subprocess.run(['bash', '-e', '-c', step['run']], env=env, capture_output=True)
+                self.assertEqual(run.returncode == 0, result == 'success')
+        self.assertNotIn('needs', WORKFLOW['secret-scanning'])
+        checkout = WORKFLOW['secret-scanning']['steps'][0]
+        self.assertEqual(checkout['with']['fetch-depth'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -2797,11 +2797,13 @@ coverage-check: coverage
 # --- Static analysis ---
 
 STATIC_ANALYSIS_STRICT ?= 0
+CPPCHECK_ARGS ?=
+CLANG_TIDY_ARGS ?=
 
 cppcheck:
 	@if command -v cppcheck >/dev/null 2>&1; then \
 		python3 -I -S ../scripts/run-cppcheck-ratchet.py --self-test && \
-		python3 -I -S ../scripts/run-cppcheck-ratchet.py $(ALL_SRCS); \
+		python3 -I -S ../scripts/run-cppcheck-ratchet.py $(CPPCHECK_ARGS) $(ALL_SRCS); \
 	elif [ "$(STATIC_ANALYSIS_STRICT)" = "1" ]; then \
 		echo "ERROR: cppcheck not found. Install with: apt install cppcheck  (Fedora/RHEL: dnf install cppcheck)"; exit 1; \
 	else \
@@ -2811,7 +2813,7 @@ cppcheck:
 clang-tidy:
 	@if command -v clang-tidy >/dev/null 2>&1; then \
 		python3 -I -S ../scripts/run-clang-tidy.py --self-test && \
-		python3 -I -S ../scripts/run-clang-tidy.py; \
+		python3 -I -S ../scripts/run-clang-tidy.py $(CLANG_TIDY_ARGS); \
 	elif [ "$(STATIC_ANALYSIS_STRICT)" = "1" ]; then \
 		echo "ERROR: clang-tidy not found. Install with: apt install clang-tidy  (Fedora/RHEL: dnf install clang-tools-extra)"; exit 1; \
 	else \


### PR DESCRIPTION
The security job previously ran cppcheck for 24 minutes, then clang-tidy for 17 minutes, and only then scanned Git history for secrets. This splits cppcheck and clang-tidy into independent eight-batch matrices and starts full-history secret scanning independently.

Every existing production source is still analyzed with the same flags, analyzer version checks, and diagnostic policy. Cppcheck XML reports are combined before enforcing the unchanged debt baseline; missing reports or failed, canceled, or skipped dependencies fail the existing `Static analysis and secret scanning` required check. Analyzer reports are retained as CI artifacts. The default local `make static-analysis` remains a complete unsharded run.

Validation: actionlint passes; both existing runner self-tests and six new regression tests pass. Tests cover complete/disjoint batches, invalid or empty batches, compiler failure propagation, retained compilation flags/database, combined diagnostic ceilings, missing/malformed reports, and required-check failure handling. The actual production source inventories were also checked across all eight batches.
