### PR TITLE
Release 0.4.4: restore setup, indexing and audit shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,30 @@ jobs:
           make -C src docs-gen-check
           git diff --check
 
+  frontend-tests:
+    needs: change-scope
+    if: ${{ !cancelled() && (needs.change-scope.result != 'success' || needs.change-scope.outputs.docs_only != 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci --no-audit --no-fund
+      - name: Frontend unit tests and production build
+        working-directory: frontend
+        run: |
+          npm test
+          npm run build
+      - name: Install the pinned browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - name: First boot and clone recovery in the built browser
+        working-directory: frontend
+        run: npm run test:browser
+      - name: Confirm browser failures block the required gate
+        run: python3 -I scripts/tests/test_frontend_release_gate.py
+
   # Go unit tests, which until now ran in NO job that a pull request into testing
   # could reach.
   #
@@ -1040,7 +1064,7 @@ jobs:
   # makes the already-separate real-Postgres RLS gate part of that required
   # result instead of running it redundantly in every unit build.
   unit-tests:
-    needs: [change-scope, unit-test-shards, unit-test-shards-pg, db2-process-replay, p1-rls-gate, go-unit-tests, lsp-real-providers]
+    needs: [change-scope, unit-test-shards, unit-test-shards-pg, db2-process-replay, p1-rls-gate, go-unit-tests, frontend-tests, lsp-real-providers]
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1054,6 +1078,7 @@ jobs:
           DB2_REPLAY_RESULT: ${{ needs.db2-process-replay.result }}
           P1_RESULT: ${{ needs.p1-rls-gate.result }}
           GO_RESULT: ${{ needs.go-unit-tests.result }}
+          FRONTEND_RESULT: ${{ needs.frontend-tests.result }}
           LSP_REAL_RESULT: ${{ needs.lsp-real-providers.result }}
         run: |
           if [ "$CHANGE_SCOPE_RESULT" = success ] && [ "$DOCS_ONLY" = true ]; then
@@ -1084,11 +1109,15 @@ jobs:
             echo "Go unit-test result: $GO_RESULT" >&2
             exit 1
           }
+          [ "$FRONTEND_RESULT" = success ] || {
+            echo "Frontend unit/browser result: $FRONTEND_RESULT" >&2
+            exit 1
+          }
           [ "$LSP_REAL_RESULT" = success ] || {
             echo "Real-provider LSP result: $LSP_REAL_RESULT" >&2
             exit 1
           }
-          echo "All unit-test shards (sqlite and real Postgres), DB2 process replay, the P1 RLS gate, the Go unit tests, and the real-provider LSP baseline passed."
+          echo "All unit-test shards (sqlite and real Postgres), DB2 process replay, the P1 RLS gate, the Go unit tests, frontend unit/browser tests, and the real-provider LSP baseline passed."
 
   # The data-plane identity mint, end to end, against a live Postgres and a live
   # signed-HWM KMS helper.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Start at the [documentation index](docs/README.md).
 | Document | Use it for |
 |----------|------------|
 | [Quickstart](docs/QUICKSTART.md) | Install, enroll, verify. |
-| [What's new](docs/WHATS_NEW.md) | Everything 0.4.0 changed, and what it removed. |
+| [What's new](docs/WHATS_NEW.md) | Current patch fixes and the 0.4 deployment changes. |
 | [Upgrading](docs/UPGRADING.md) | Migrate storage and preserve instance identity. |
 | [Manual](MANUAL.md) | Day-to-day use and operations. |
 | [Architecture](docs/ARCHITECTURE.md) | Processes, storage, trust, request flow. |

--- a/dependencies/aimee-application-sources.lock.json
+++ b/dependencies/aimee-application-sources.lock.json
@@ -92,7 +92,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "881ad919dc63c816151d1767e2edbebc54dbd292ec049815e6e114e7edd7331b",
+      "source_sha256": "2bcee03b7a2734eab6220a2f295381070bb5e8a8dee9204ca4be6a5bc0b12e0c",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 7,
@@ -201,7 +201,7 @@
       "placements": [
         "server"
       ],
-      "source_sha256": "a2561bb532a90a3f2d62da2c88a9f83d04c5cf6572cd622d12876ad8ed915d28",
+      "source_sha256": "3a0430c4bfe28924bed47197d7608bee3ba03f3e366a1716a367c6d54295175f",
       "runtime": "go",
       "principal_class": 1,
       "principal_ref": 12,
@@ -301,7 +301,7 @@
         "server",
         "kb"
       ],
-      "source_sha256": "867ea560c9fd55471cd68c6f79adde9d05c2ca8287914d201ceaadf918eb95fe"
+      "source_sha256": "d0ed15d0872bfc2c0188089fb23d7d9192a1eed4c9c1db89d0574ba58f15956b"
     },
     {
       "id": "sandbox",
@@ -600,7 +600,7 @@
       "placements": [
         "kb"
       ],
-      "source_sha256": "5911e836e1d96c42dbf169f4602a18d2a63f5ab442522cebf75e4c6c031e23c3",
+      "source_sha256": "36b90f5a600cb7cecf6d10c18b4996dbe9e001962a16c2e4b5903a270ac3dc9e",
       "runtime": "c",
       "principal_class": 1,
       "principal_ref": 29,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -4,6 +4,12 @@ This page describes the current testing tree. `Done` means the path is implement
 its normal tests. `Gated` means it ships behind configuration or deployment requirements. `Next`
 means the contract or branch exists but is not part of the integrated path yet.
 
+The 0.4.4 candidate repairs first-boot setup, clone progress, private index publication and
+retrieval, detached runner admission, and audit hashing during shutdown. See the
+[release validation](validation/release-0.4.4-2026-09-08.md) for tested configurations and remaining
+release gates. Detached source spans read the last published snapshot; workspace registration
+alone does not start a client runner.
+
 ## Runtime
 
 | Feature | State | Boundary |

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,4 +1,31 @@
-# What's new in 0.4.0
+# What's new
+
+## 0.4.4 repairs setup and private indexing
+
+0.4.4 is a patch for existing 0.4.x installations. Keep the instance volumes, account,
+client identities, and memories when upgrading. Release validation is recorded in
+[the 0.4.4 report](validation/release-0.4.4-2026-09-08.md).
+
+- A fresh account opens the setup wizard even when the browser remembers dismissing setup
+  on a previous installation.
+- Organization cloning reports each repository as it completes. If a response is lost,
+  the wizard and Projects page check the published inventory before continuing. An
+  unconfirmed clone pauses the queue; a confirmed clone is not submitted twice.
+- Private code scans and graph queries have separate bounded deadlines. Graph expansion
+  joins references and definitions around the requested files, allowing large repositories
+  to answer search and blast-radius requests without the previous whole-repository join.
+- Source spans recover bounded, hashed content from the published private index, including
+  detached client uploads. They are snapshots: publish a new scan to refresh them.
+  A file's edit blast radius no longer makes an otherwise readable source file sensitive.
+- Hidden configuration files are excluded from collection, and the private index accepts
+  the collector's explicit `.gitmodules` build manifest. These files previously caused
+  entire repository scans to fail. Hidden directories and credential files remain excluded.
+- Registering a detached workspace no longer claims that a runner is connected. Requests
+  fail promptly when no client is serving it, instead of occupying shared request slots.
+- Audit SHA-256 remains deterministic after OpenSSL cleanup. Existing damaged audit segments
+  still fail verification; this patch does not silently rewrite or discard audit evidence.
+
+## 0.4.0 changed the deployment and runtime
 
 0.4.0 is a one-way upgrade. It removes the combined image, the work queue, the generic inference gateway,
 the interactive TUI, and the generic RPC transport, and it will not read a 0.2 deployment back.

--- a/docs/validation/release-0.4.4-2026-09-08.md
+++ b/docs/validation/release-0.4.4-2026-09-08.md
@@ -64,7 +64,9 @@ python3 scripts/test-private-index-live.py --client /path/to/aimee \
 ```
 
 The built-browser regressions run with `npm --prefix frontend run test:browser` after
-building the frontend and installing Playwright's pinned Chromium.
+building the frontend and installing Playwright's pinned Chromium. The recovery fixture holds
+publication until the browser observes the checking state, so overlapping inventory polls
+cannot race the status assertion. Five consecutive runs of all five scenarios passed.
 
 ## Wider validation caught the hidden-file publication failure
 

--- a/docs/validation/release-0.4.4-2026-09-08.md
+++ b/docs/validation/release-0.4.4-2026-09-08.md
@@ -102,8 +102,12 @@ This live appliance uses standalone Server with its private PostgreSQL and embed
 no shared KB configured. Local native tests skip checks requiring a separate PostgreSQL
 store fixture, signed KMS services, tmux, or root-only fixtures. PostgreSQL memory and code
 coverage above uses an isolated disposable database, never the appliance's live database.
-Windows, macOS, full topology/container CI, and protected promotion remain release gates;
-this report does not claim those were exercised by the local Linux run.
+The final PR commit `bb3fdaa6bb` passed all 58 CI checks, including Windows and macOS builds,
+the full sanitizer and script suites, PostgreSQL/workflow gates, and all four container
+topologies with encrypted-storage recovery, upgrade, and rollback.
+[CI results](release-0.4.4-2026-09-08/ci-final.json) retain each check URL.
+PR #2975 merged that tree into `testing` at `ec4717297e`. Protected promotion and release
+approval remain; these CI results are separate from the local Linux run described above.
 
 The optional server-side `git_verify` auto-discovery cannot inspect this detached client's
 Makefile. Equivalent repository Make targets were run on the client and their results are

--- a/docs/validation/release-0.4.4-2026-09-08.md
+++ b/docs/validation/release-0.4.4-2026-09-08.md
@@ -42,7 +42,7 @@ requests and counts.
 | Native unit suite | Passed; 637 test binaries scheduled, with environment-dependent skips below. |
 | Go unit suite | Passed across all three Go modules, including C/Go bus interoperability. |
 | Repository lint | All 77 checks passed. |
-| Script suite | All 58 existing script test files passed; the added frontend gate test also passed. |
+| Script suite | All 58 existing script test files passed; the added frontend and upgrade-log gate tests also passed. |
 | Frontend | Clean `npm ci`, 209 tests in 26 files, TypeScript, and production build passed. |
 | Built-browser regressions | Five scenarios passed: first boot with old dismissal, lost responses and HTTP 503 on both clone screens. |
 | PostgreSQL memory gate | Passed with race detection: private code regressions, privacy separation, content gate, and the 105-case retrieval corpus in both Server and KB placement. |
@@ -76,6 +76,15 @@ manifest. One such file aborted the whole scan.
 The collector regression failed on the original implementation and passed after aligning
 these contracts. Hidden configuration files are excluded; `.gitmodules` remains an explicit
 manifest exception. All 18 affected repositories subsequently published on the live instance.
+
+## CI exposed a race in the upgrade test's log assertion
+
+The first CI run passed init/migrate routing but exited 141 at the historical-store test's
+final log assertion. Under `pipefail`, `grep -q` closed a matching log stream early and caused
+Docker to receive SIGPIPE. The assertion now drains the stream while preserving both missing
+message and producer-error failures. A regression with a large stream reproduced exit 141
+before the fix and passed all three outcomes afterwards. The complete upgrade test then
+passed against disposable PostgreSQL containers for both `aimee_store` and `aimee_shared`.
 
 ## Audit recovery retained the original evidence
 

--- a/docs/validation/release-0.4.4-2026-09-08.md
+++ b/docs/validation/release-0.4.4-2026-09-08.md
@@ -1,0 +1,99 @@
+# 0.4.4 restores setup and private indexing on the deployed corpus
+
+The Linux candidate `0.4.4-rc1` is deployed in LXC 103 as a local application image.
+It includes the fixes in the image; the earlier binary and GUI hotfix mounts were removed.
+The repository release script proposes **0.4.4** after **v0.4.3**. No release tag or public
+artifact has been published by this preparation.
+
+## Every registered project published, and restart preserved the data
+
+The candidate published **74 projects and 23,022 files**: all 73 server clones plus the
+registered local Aimee checkout. A controlled container restart preserved those counts and
+the IDs, keys, and content hashes of both personal memories. The original deployment memory
+remained intact; the second memory records the verified published-span and runner contract.
+Readiness returned true and the container has no automatic restarts.
+
+[Deployment hashes](release-0.4.4-2026-09-08/deployment.json) identify the image and its server,
+thin client, memory/workspace module, and GUI payload. The Linux candidate thin client used
+the existing enrolled mTLS identity. [Persistence evidence](release-0.4.4-2026-09-08/persistence.json)
+contains counts and memory hashes, without memory contents or credentials.
+
+## Live tests exercised content and recovery
+
+[90 post-restart checks](release-0.4.4-2026-09-08/live-checks.json) passed across six projects:
+the local and server Aimee indexes, Wolf, Fenrir, Moonlight Common C, and Moonlight Qt. They
+cover symbol lookup, structure, hashed source spans, callers, blast radius, hybrid retrieval,
+investigation, missing and sensitive paths, memory retrieval, and 16 concurrent memory
+requests. A separate 54-check run passed before restart.
+
+The real GUI authenticated through PAM, displayed all 73 existing clones, and loaded
+**Set up this instance** without a server-unavailable response. It then cloned three public
+Pallets repositories through the organization flow. Dropping one actual completed response
+triggered inventory recovery; each repository was submitted exactly once. All three test
+clones and the temporary managed test account were removed. Existing accounts and clones
+were preserved. [Browser evidence](release-0.4.4-2026-09-08/browser-checks.json) records the
+requests and counts.
+
+## Regressions now run in the release gates
+
+| Validation | Result |
+| --- | --- |
+| Full local gate | `make verify-local` passed: complete Linux build, lint, unit tests, Go tests, and linkage. |
+| Native unit suite | Passed; 637 test binaries scheduled, with environment-dependent skips below. |
+| Go unit suite | Passed across all three Go modules, including C/Go bus interoperability. |
+| Repository lint | All 77 checks passed. |
+| Script suite | All 58 existing script test files passed; the added frontend gate test also passed. |
+| Frontend | Clean `npm ci`, 209 tests in 26 files, TypeScript, and production build passed. |
+| Built-browser regressions | Five scenarios passed: first boot with old dismissal, lost responses and HTTP 503 on both clone screens. |
+| PostgreSQL memory gate | Passed with race detection: private code regressions, privacy separation, content gate, and the 105-case retrieval corpus in both Server and KB placement. |
+| Workspace race tests | Passed, including never-polled and stale runner admission. |
+| Native sanitizers | Collector, source span, module deadlines, and audit hash tests passed ASan/UBSan with leak detection. |
+
+The PostgreSQL gate selects every `TestPrivateCode*` test, including large graphs, missing
+files, manifest publication, source bounds, and publication drift. The new frontend CI job
+runs unit tests and the built-browser scenarios. Its result is included in the required
+`unit-tests` aggregate; a regression proves failed, cancelled, and skipped browser jobs block
+that aggregate for code changes.
+
+Run the reusable live check against an enrolled client and existing corpus:
+
+```bash
+python3 scripts/test-private-index-live.py --client /path/to/aimee \
+  --sample aimee=memory_insert --sample games-on-whales/wolf=die \
+  --memory-key aimee-deployment --min-projects 2 --output /tmp/index-checks.json
+```
+
+The built-browser regressions run with `npm --prefix frontend run test:browser` after
+building the frontend and installing Playwright's pinned Chromium.
+
+## Wider validation caught the hidden-file publication failure
+
+Eighteen server clones had no published generation before this candidate. The collector
+accepted hidden configuration filenames, including `.mcp.json`, that the private index
+rejected. The index also rejected the collector's explicitly supported `.gitmodules`
+manifest. One such file aborted the whole scan.
+
+The collector regression failed on the original implementation and passed after aligning
+these contracts. Hidden configuration files are excluded; `.gitmodules` remains an explicit
+manifest exception. All 18 affected repositories subsequently published on the live instance.
+
+## Audit recovery retained the original evidence
+
+The original 0.4.3 audit segment contained one invalid final row, sequence 1,152,239. All
+preceding 1,152,238 row hashes were independently verified. The original SQLite files and
+their hashes remain in `/var/lib/aimee/audit/recovery-20260908-index-repair`; the new segment
+begins with an `audit.recovery` record identifying that evidence. No audit verification was
+disabled. Golden row hashes and checkpoint MACs remain valid after `OPENSSL_cleanup()`.
+
+## Release review still covers configurations outside this appliance
+
+This live appliance uses standalone Server with its private PostgreSQL and embedder; it has
+no shared KB configured. Local native tests skip checks requiring a separate PostgreSQL
+store fixture, signed KMS services, tmux, or root-only fixtures. PostgreSQL memory and code
+coverage above uses an isolated disposable database, never the appliance's live database.
+Windows, macOS, full topology/container CI, and protected promotion remain release gates;
+this report does not claim those were exercised by the local Linux run.
+
+The optional server-side `git_verify` auto-discovery cannot inspect this detached client's
+Makefile. Equivalent repository Make targets were run on the client and their results are
+recorded above; remote auto-discovery is not claimed as validated by this release check.

--- a/docs/validation/release-0.4.4-2026-09-08/browser-checks.json
+++ b/docs/validation/release-0.4.4-2026-09-08/browser-checks.json
@@ -1,0 +1,42 @@
+[
+  {
+    "route": "/api/auth/me",
+    "status": 200
+  },
+  {
+    "route": "/api/setup/account",
+    "status": 200
+  },
+  {
+    "route": "/api/git/projects",
+    "status": 200,
+    "projects": 73
+  },
+  {
+    "route": "/api/config",
+    "status": 200
+  },
+  {
+    "page": "Projects and setup wizard",
+    "errors": [],
+    "failed": [],
+    "text": "Set up this instance\n×\n\nEverything required is configured. 🎉\n\n✅\nAccount\nlogin secured\n✅\nProvider\nprimary: codex\n✅\nEmbedding\nlocal memory embedder configured\n✅\nGit Identity\ncommit author stored in the Vault\n✅\nConnection\n1 host connected\n✅\nProject\n73 projects cloned\nDeploy local model services\nRe-deploy\nDeploy the selected local embedding and optional synthesis services.\n🟢\naimee-aimee-embedder-1\nrunning (healthy)\nFinish"
+  },
+  {
+    "page": "Real organization cloning",
+    "batches": [
+      [
+        "markupsafe"
+      ],
+      [
+        "itsdangerous"
+      ],
+      [
+        "click"
+      ]
+    ],
+    "lostResponseRecovered": true,
+    "projectsBefore": 73,
+    "projectsAfter": 76
+  }
+]

--- a/docs/validation/release-0.4.4-2026-09-08/ci-final.json
+++ b/docs/validation/release-0.4.4-2026-09-08/ci-final.json
@@ -1,0 +1,358 @@
+{
+  "commit": "bb3fdaa6bb",
+  "application_commit": "11cd30b611",
+  "pr": "https://github.com/RakuenSoftware/aimee/pull/2975",
+  "base": "testing",
+  "recorded_at": "2026-09-08T20:11:16.890585+00:00",
+  "checks": [
+    {
+      "name": "Address and undefined-behavior sanitizers",
+      "status": "pass",
+      "duration": "15m1s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509577"
+    },
+    {
+      "name": "Clang-tidy (0/8)",
+      "status": "pass",
+      "duration": "2m17s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509539"
+    },
+    {
+      "name": "Clang-tidy (1/8)",
+      "status": "pass",
+      "duration": "2m56s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509294"
+    },
+    {
+      "name": "Clang-tidy (2/8)",
+      "status": "pass",
+      "duration": "1m37s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509470"
+    },
+    {
+      "name": "Clang-tidy (3/8)",
+      "status": "pass",
+      "duration": "2m33s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509393"
+    },
+    {
+      "name": "Clang-tidy (4/8)",
+      "status": "pass",
+      "duration": "2m51s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509433"
+    },
+    {
+      "name": "Clang-tidy (5/8)",
+      "status": "pass",
+      "duration": "2m41s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509463"
+    },
+    {
+      "name": "Clang-tidy (6/8)",
+      "status": "pass",
+      "duration": "2m30s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509505"
+    },
+    {
+      "name": "Clang-tidy (7/8)",
+      "status": "pass",
+      "duration": "1m49s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509362"
+    },
+    {
+      "name": "Complete script regression suite",
+      "status": "pass",
+      "duration": "12m56s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509327"
+    },
+    {
+      "name": "Cppcheck (0/8)",
+      "status": "pass",
+      "duration": "2m41s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509588"
+    },
+    {
+      "name": "Cppcheck (1/8)",
+      "status": "pass",
+      "duration": "2m3s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509560"
+    },
+    {
+      "name": "Cppcheck (2/8)",
+      "status": "pass",
+      "duration": "4m34s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509500"
+    },
+    {
+      "name": "Cppcheck (3/8)",
+      "status": "pass",
+      "duration": "7m27s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509446"
+    },
+    {
+      "name": "Cppcheck (4/8)",
+      "status": "pass",
+      "duration": "2m23s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509276"
+    },
+    {
+      "name": "Cppcheck (5/8)",
+      "status": "pass",
+      "duration": "4m45s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509476"
+    },
+    {
+      "name": "Cppcheck (6/8)",
+      "status": "pass",
+      "duration": "1m20s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509696"
+    },
+    {
+      "name": "Cppcheck (7/8)",
+      "status": "pass",
+      "duration": "2m5s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509670"
+    },
+    {
+      "name": "Secret scanning",
+      "status": "pass",
+      "duration": "1m21s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509034"
+    },
+    {
+      "name": "Static analysis and secret scanning",
+      "status": "pass",
+      "duration": "12s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102216993103"
+    },
+    {
+      "name": "authz-residual-live",
+      "status": "pass",
+      "duration": "7m41s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648926"
+    },
+    {
+      "name": "build",
+      "status": "pass",
+      "duration": "3m54s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648668"
+    },
+    {
+      "name": "build-integrity",
+      "status": "pass",
+      "duration": "2m45s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648507"
+    },
+    {
+      "name": "change-scope",
+      "status": "pass",
+      "duration": "22s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509394"
+    },
+    {
+      "name": "db2-process-replay",
+      "status": "pass",
+      "duration": "1m33s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648902"
+    },
+    {
+      "name": "e2e-adoption",
+      "status": "pass",
+      "duration": "2m53s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648806"
+    },
+    {
+      "name": "e2e-docker (T1)",
+      "status": "pass",
+      "duration": "8m19s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649032"
+    },
+    {
+      "name": "e2e-docker (T2)",
+      "status": "pass",
+      "duration": "11m7s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649201"
+    },
+    {
+      "name": "e2e-docker (T2-luks)",
+      "status": "pass",
+      "duration": "14m47s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649071"
+    },
+    {
+      "name": "e2e-docker (T3)",
+      "status": "pass",
+      "duration": "9m24s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649026"
+    },
+    {
+      "name": "frontend-tests",
+      "status": "pass",
+      "duration": "57s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648690"
+    },
+    {
+      "name": "fuzz",
+      "status": "pass",
+      "duration": "27s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555805/job/102214119472"
+    },
+    {
+      "name": "go-unit-tests",
+      "status": "pass",
+      "duration": "3m4s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649175"
+    },
+    {
+      "name": "identity-mint-e2e",
+      "status": "pass",
+      "duration": "1m0s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648790"
+    },
+    {
+      "name": "init-migrate-service-test",
+      "status": "pass",
+      "duration": "2m36s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648980"
+    },
+    {
+      "name": "integration-tests",
+      "status": "pass",
+      "duration": "2m33s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648943"
+    },
+    {
+      "name": "lint",
+      "status": "pass",
+      "duration": "2m48s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648586"
+    },
+    {
+      "name": "lsp-real-providers (macos-latest, macos)",
+      "status": "pass",
+      "duration": "2m43s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648914"
+    },
+    {
+      "name": "lsp-real-providers (ubuntu-24.04, linux)",
+      "status": "pass",
+      "duration": "2m27s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648873"
+    },
+    {
+      "name": "macos-build",
+      "status": "pass",
+      "duration": "4m21s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648891"
+    },
+    {
+      "name": "memory-retrieval-eval",
+      "status": "pass",
+      "duration": "1m5s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648904"
+    },
+    {
+      "name": "no-coauthor-trailers",
+      "status": "pass",
+      "duration": "20s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214509481"
+    },
+    {
+      "name": "oidc-login-live",
+      "status": "pass",
+      "duration": "1m38s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648964"
+    },
+    {
+      "name": "p1-rls-gate",
+      "status": "pass",
+      "duration": "42s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648849"
+    },
+    {
+      "name": "pam-login-live",
+      "status": "pass",
+      "duration": "3m20s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214649065"
+    },
+    {
+      "name": "pins",
+      "status": "pass",
+      "duration": "2m27s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555873/job/102214119202"
+    },
+    {
+      "name": "release-policy",
+      "status": "pass",
+      "duration": "11s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555807/job/102214118907"
+    },
+    {
+      "name": "treesitter",
+      "status": "pass",
+      "duration": "52s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648798"
+    },
+    {
+      "name": "unit-tests",
+      "status": "pass",
+      "duration": "4s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102217826867"
+    },
+    {
+      "name": "unit-tests (1/2)",
+      "status": "pass",
+      "duration": "3m30s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648540"
+    },
+    {
+      "name": "unit-tests (2/2)",
+      "status": "pass",
+      "duration": "3m51s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648603"
+    },
+    {
+      "name": "unit-tests-pg (1/3)",
+      "status": "pass",
+      "duration": "9m30s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648623"
+    },
+    {
+      "name": "unit-tests-pg (2/3)",
+      "status": "pass",
+      "duration": "3m2s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648624"
+    },
+    {
+      "name": "unit-tests-pg (3/3)",
+      "status": "pass",
+      "duration": "3m10s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648789"
+    },
+    {
+      "name": "vault-pkcs11-token",
+      "status": "pass",
+      "duration": "33s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648907"
+    },
+    {
+      "name": "windows-build",
+      "status": "pass",
+      "duration": "3m6s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648978"
+    },
+    {
+      "name": "windows-cmake",
+      "status": "pass",
+      "duration": "2m44s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648945"
+    },
+    {
+      "name": "write-tier-enforce-live",
+      "status": "pass",
+      "duration": "3m18s",
+      "url": "https://github.com/RakuenSoftware/aimee/actions/runs/34271555763/job/102214648881"
+    }
+  ],
+  "public_release_published": false
+}

--- a/docs/validation/release-0.4.4-2026-09-08/deployment.json
+++ b/docs/validation/release-0.4.4-2026-09-08/deployment.json
@@ -1,0 +1,15 @@
+{
+  "candidate": "0.4.4-rc1",
+  "image_id": "sha256:911d2a89bfe464cba1fcb67fd1f0cdaecd51dafbf6318fd7754fe1d227d64aee",
+  "server": "LXC 103",
+  "sha256": {
+    "/usr/local/bin/aimee-server": "e77823e6671006e834f5f657a85d283c1598d60e2a20330aedf678ba46db6fc9",
+    "/usr/local/bin/aimee": "f0f612dbd0220cb31cf4a9f3355b38023f69a507397cbb1eb6c96e302054330f",
+    "/usr/local/libexec/aimee-modules/aimee-module-memory": "d57d32f9ca3c2f4c672c4e5d4adb4291ee2469b5c50a16e7f30969ddcf6a493c",
+    "/usr/local/libexec/aimee-modules/aimee-module-workspace": "d57d32f9ca3c2f4c672c4e5d4adb4291ee2469b5c50a16e7f30969ddcf6a493c",
+    "/usr/local/share/aimee-runtime-web/index.html": "2e0d542962a74f615320993463accc6a09bcdf26a3062f17b8d911c37a1de272"
+  },
+  "ready_after_restart": true,
+  "restart_count": 0,
+  "hotfix_mounts": false
+}

--- a/docs/validation/release-0.4.4-2026-09-08/live-checks.json
+++ b/docs/validation/release-0.4.4-2026-09-08/live-checks.json
@@ -1,0 +1,1032 @@
+[
+  {
+    "command": [
+      "index",
+      "overview"
+    ],
+    "seconds": 0.731,
+    "passed": true,
+    "projects": 74
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "memory_insert",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.817,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "src/headers/memory.h",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.751,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "src/headers/memory.h",
+      "382",
+      "387",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.638,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "memory_insert",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.85,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "src/headers/memory.h",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 1.058,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "memory_insert",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 3.923,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "memory_insert",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 6.11,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.75,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.799,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.723,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.753,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "aimee"
+    ],
+    "seconds": 0.76,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "memory_insert",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.782,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "src/headers/memory.h",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.701,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "src/headers/memory.h",
+      "382",
+      "387",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.79,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "memory_insert",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.817,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "src/headers/memory.h",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 1.227,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "memory_insert",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 4.532,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "memory_insert",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 5.729,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.727,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.787,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.808,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.675,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "rakuensoftware/aimee"
+    ],
+    "seconds": 0.761,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "die",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.718,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "scripts/wolf-input-diag.sh",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.778,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "scripts/wolf-input-diag.sh",
+      "46",
+      "51",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.689,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "die",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.789,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "scripts/wolf-input-diag.sh",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.727,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "die",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 2.675,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "die",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 3.191,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.626,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.778,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.695,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.814,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "games-on-whales/wolf"
+    ],
+    "seconds": 0.714,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "main",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.73,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "cmd/moonlight-proxy/main.go",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.727,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "cmd/moonlight-proxy/main.go",
+      "20",
+      "25",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.764,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "main",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.677,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "cmd/moonlight-proxy/main.go",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.723,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "main",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 1.54,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "main",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 2.401,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.65,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.685,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.686,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.781,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "games-on-whales/fenrir"
+    ],
+    "seconds": 0.763,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "LiStartConnection",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.746,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "src/Connection.c",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.758,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "src/Connection.c",
+      "209",
+      "214",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.835,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "LiStartConnection",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.758,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "src/Connection.c",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.722,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "LiStartConnection",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.913,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "LiStartConnection",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 2.017,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.741,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.848,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.74,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.738,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "games-on-whales/moonlight-common-c"
+    ],
+    "seconds": 0.753,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "find",
+      "main",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.764,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "app/main.cpp",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.76,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "app/main.cpp",
+      "307",
+      "312",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.798,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "callers",
+      "main",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.733,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "blast-radius",
+      "app/main.cpp",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.78,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "hybrid",
+      "main",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 2.347,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "investigate",
+      "main",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 2.344,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      ".env",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.679,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "../outside.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.743,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "/etc/passwd",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.756,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "span",
+      "__aimee_missing_source__.c",
+      "1",
+      "2",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.788,
+    "passed": true
+  },
+  {
+    "command": [
+      "index",
+      "structure",
+      "__aimee_missing_source__.c",
+      "--project",
+      "games-on-whales/moonlight-qt"
+    ],
+    "seconds": 0.727,
+    "passed": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.101,
+    "passed": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.06,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.057,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.057,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.057,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.059,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.059,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.059,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 2.056,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.605,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.605,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.605,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.605,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.602,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.602,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 1.601,
+    "passed": true,
+    "concurrent": true
+  },
+  {
+    "command": [
+      "memory",
+      "search",
+      "aimee-private-code-spans"
+    ],
+    "seconds": 3.165,
+    "passed": true,
+    "concurrent": true
+  }
+]

--- a/docs/validation/release-0.4.4-2026-09-08/local-checks.json
+++ b/docs/validation/release-0.4.4-2026-09-08/local-checks.json
@@ -1,0 +1,111 @@
+{
+  "frontend_tests": 209,
+  "frontend_test_files": 26,
+  "native_unit_binaries": 637,
+  "native_unit_environment_skips": true,
+  "repository_lint_checks": 77,
+  "script_test_files_before_browser_gate": 58,
+  "browser_release_scenarios": 5,
+  "postgres_memory_gate": "passed with race detection, 105-case corpus for Server and KB plus privacy and all private-index regressions",
+  "sanitizers": [
+    {
+      "test": "code-collect",
+      "exit_code": 0
+    },
+    {
+      "test": "code-span",
+      "exit_code": 0
+    },
+    {
+      "test": "module-json-call",
+      "exit_code": 0
+    },
+    {
+      "test": "audit-worm-chain",
+      "exit_code": 0
+    }
+  ],
+  "source_base": "b65d8385a6",
+  "candidate": "0.4.4-rc1",
+  "published_release": false,
+  "final_validation": [
+    {
+      "name": "verify-local",
+      "command": [
+        "make",
+        "-C",
+        "src",
+        "-j8",
+        "verify-local",
+        "GIT_VERSION=v0.4.4-rc1",
+        "AIMEE_VERIFY_TEST_JOBS=2"
+      ],
+      "seconds": 286.08,
+      "exit_code": 0
+    },
+    {
+      "name": "frontend-ci",
+      "command": [
+        "npm",
+        "--prefix",
+        "frontend",
+        "ci",
+        "--no-audit",
+        "--no-fund"
+      ],
+      "seconds": 0.99,
+      "exit_code": 0
+    },
+    {
+      "name": "frontend-tests-final",
+      "command": [
+        "npm",
+        "--prefix",
+        "frontend",
+        "test"
+      ],
+      "seconds": 2.74,
+      "exit_code": 0
+    },
+    {
+      "name": "frontend-build-final",
+      "command": [
+        "npm",
+        "--prefix",
+        "frontend",
+        "run",
+        "build"
+      ],
+      "seconds": 4.33,
+      "exit_code": 0
+    },
+    {
+      "name": "browser-final",
+      "command": [
+        "node",
+        "scripts/test-setup-browser.cjs"
+      ],
+      "seconds": 10.84,
+      "exit_code": 0
+    },
+    {
+      "name": "ci-gate-test",
+      "command": [
+        "python3",
+        "-I",
+        "scripts/tests/test_frontend_release_gate.py"
+      ],
+      "seconds": 0.03,
+      "exit_code": 0
+    },
+    {
+      "name": "release-policy",
+      "command": [
+        "bash",
+        "scripts/check-release-policy.sh"
+      ],
+      "seconds": 0.03,
+      "exit_code": 0
+    }
+  ]
+}

--- a/docs/validation/release-0.4.4-2026-09-08/persistence.json
+++ b/docs/validation/release-0.4.4-2026-09-08/persistence.json
@@ -1,0 +1,2 @@
+{"projects" : 74, "published" : 74, "files" : 23022, "memories" : [{"id":1,"key":"aimee-deployment","content_hash":"5fd8e94f98eb7d7956e0d62d53494eaf"}, 
+ {"id":2,"key":"aimee-private-code-spans","content_hash":"a888e4157af2ae6a3986530604952ef2"}]}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^4.4.1",
         "jsdom": "^26.1.0",
+        "playwright": "1.55.0",
         "typescript": "~5.8.3",
         "vite": "^6.3.1",
         "vite-plugin-singlefile": "^2.0.1",
@@ -2298,6 +2299,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "build:console": "tsc -b && vite build --config vite.console.config.ts",
     "check": "tsc -b",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:browser": "node ../scripts/test-setup-browser.cjs"
   },
   "dependencies": {
     "@rakuensoftware/smoothgui": "file:vendor/rakuensoftware-smoothgui-0.11.0.tgz",
@@ -22,6 +23,7 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "jsdom": "^26.1.0",
+    "playwright": "1.55.0",
     "typescript": "~5.8.3",
     "vite": "^6.3.1",
     "vite-plugin-singlefile": "^2.0.1",

--- a/frontend/src/components/SetupChip.test.tsx
+++ b/frontend/src/components/SetupChip.test.tsx
@@ -2,38 +2,70 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import SetupChip from './SetupChip';
+import { DISMISSED_KEY } from '../setup/setupState';
 
-const mocks = vi.hoisted(() => ({ open: vi.fn() }));
+const mocks = vi.hoisted(() => ({ open: vi.fn(), accountReady: true }));
 
 vi.mock('../setup/configApi', () => ({
   loadConfig: async () => ({ provider: 'claude', embedder_url: 'http://embedder' }),
 }));
 
 vi.mock('../setup/setupSignals', () => ({
-  fetchSetupAccountReady: async () => true,
+  fetchSetupAccountReady: async () => mocks.accountReady,
   fetchProjectCount: async () => 1,
   fetchHostCount: async () => 0,
   fetchGitIdentityReady: async () => false,
 }));
 
-vi.mock('../setup/setupState', () => ({
+vi.mock('../setup/setupState', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../setup/setupState')>(),
   requestOpenWizard: mocks.open,
-  isDismissed: () => true,
-  SETUP_UPDATED_EVENT: 'aimee-setup-updated',
 }));
 
 afterEach(() => {
   cleanup();
   mocks.open.mockClear();
+  mocks.accountReady = true;
+  localStorage.clear();
 });
 
 describe('Setup chip Git-identity recovery', () => {
   it('keeps one actionable item visible after identity is skipped', async () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
     render(<SetupChip />);
     const chip = await waitFor(() => screen.getByRole('button', { name: /Setup — 1 left/ }));
 
     fireEvent.click(chip);
 
     expect(mocks.open).toHaveBeenCalledOnce();
+  });
+});
+
+describe('First-boot setup after reinstall', () => {
+  it('opens automatically despite a Finish flag left by the previous install', async () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    mocks.accountReady = false;
+    render(<SetupChip />);
+
+    await waitFor(() => expect(mocks.open).toHaveBeenCalledOnce());
+    expect(screen.getByRole('button', { name: /Setup — 2 left/ })).toBeTruthy();
+
+    fireEvent.focus(window);
+    await waitFor(() => expect(screen.getByRole('button', { name: /Setup — 2 left/ })).toBeTruthy());
+    expect(mocks.open).toHaveBeenCalledOnce();
+  });
+
+  it('honors dismissal once the server account is set up', async () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    render(<SetupChip />);
+
+    await screen.findByRole('button', { name: /Setup — 1 left/ });
+    expect(mocks.open).not.toHaveBeenCalled();
+  });
+
+  it('opens incomplete setup in a new browser', async () => {
+    render(<SetupChip />);
+
+    await waitFor(() => expect(mocks.open).toHaveBeenCalledOnce());
   });
 });

--- a/frontend/src/components/SetupChip.tsx
+++ b/frontend/src/components/SetupChip.tsx
@@ -9,7 +9,8 @@ import { requestOpenWizard, isDismissed, SETUP_UPDATED_EVENT } from '../setup/se
  * against the cloned project inventory, and shows how many required steps remain.
  * Hidden entirely once ready. Clicking it opens the wizard. On first load, if the
  * instance is not ready and the wizard hasn't been dismissed, it auto-opens the
- * wizard once. All heavy lifting is in the tested setup/ modules. */
+ * wizard once. Pending first-boot account setup overrides browser dismissal,
+ * which can survive reinstalling the server at the same address. */
 
 export default function SetupChip() {
   const [cfg, setCfg] = useState<ConfigMap | null>(null);
@@ -46,14 +47,14 @@ export default function SetupChip() {
     [cfg, accountReady, projectCount, hostsConnected, gitIdentityReady],
   );
 
-  // Auto-open the wizard once per page load when unconfigured and not dismissed.
+  // A browser's old Finish flag cannot complete a fresh server's account setup.
   const autoOpened = useRef(false);
   useEffect(() => {
-    if (readiness && !readiness.ready && !isDismissed() && !autoOpened.current) {
+    if (readiness && !readiness.ready && (!accountReady || !isDismissed()) && !autoOpened.current) {
       autoOpened.current = true;
       requestOpenWizard();
     }
-  }, [readiness]);
+  }, [readiness, accountReady]);
 
   if (!readiness || readiness.ready) return null;
 

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -4,6 +4,7 @@ import ConnectHosts from '../setup/ConnectHosts';
 import { useSessions } from '../SessionContext';
 import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef, type ProjectDetail, type ProjectDeleteResponse } from '../setup/ownerUrl';
 import { notifySetupUpdated } from '../setup/setupState';
+import { cloneRepos, type CloneProgress } from '../setup/cloneRepos';
 
 /* Git projects (webchat-git WP-F2). The page is focused on managing repos: it
  * lists the user's cloned projects, connects new ones, and runs per-project git
@@ -77,6 +78,9 @@ export default function Projects() {
   const [orgSelected, setOrgSelected] = useState<Record<string, boolean>>({});
   const [orgProvider, setOrgProvider] = useState('');
   const [orgResults, setOrgResults] = useState<({ name: string; ok: boolean; error?: string | null } & CloneKbAnnotations)[]>([]);
+  const [cloneProgress, setCloneProgress] = useState<CloneProgress | null>(null);
+  const orgSelectedCount = orgRepos.filter(r => orgSelected[r.name] &&
+    !repoAlreadyCloned(r, orgRef?.owner || '', projects, details)).length;
   // Post-clone notices (org placement, kb indexing) for the single-repo form.
   const [cloneNotes, setCloneNotes] = useState<string[]>([]);
   // Delete flow: the ref pending confirmation and the typed-ref gate. The
@@ -94,8 +98,8 @@ export default function Projects() {
     } catch { /* server unavailable — leave list empty */ }
   }, []);
 
-  const loadProjects = useCallback(async () => {
-    setErr('');
+  const loadProjects = useCallback(async (clearError = true) => {
+    if (clearError) setErr('');
     try {
       const r = await api('/api/git/projects', { method: 'GET' });
       const d: GitProjectsResponse = await r.json();
@@ -104,12 +108,24 @@ export default function Projects() {
       setProjects(ps);
       setDetails(d.details || []);
       setSelected(s => (s && ps.includes(s) ? s : ps[0] || ''));
+      return d;
     } catch {
       setErr('aimee-server unavailable');
     }
   }, []);
 
   useEffect(() => { loadProjects(); loadHosts(); }, [loadProjects, loadHosts]);
+  useEffect(() => {
+    const refresh = () => { void loadProjects(false); };
+    const timer = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') refresh();
+    }, 5000);
+    window.addEventListener('focus', refresh);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener('focus', refresh);
+    };
+  }, [loadProjects]);
 
   // Close the Connect-account modal on Escape (works regardless of focus).
   useEffect(() => {
@@ -150,10 +166,15 @@ export default function Projects() {
         if (d.org_note) notes.push(d.org_note);
         if (d.kb_indexed === false) notes.push(`not indexed in the knowledge base — ${d.kb_reason || 'knowledge service unavailable'}`);
         setCloneNotes(notes);
-        await loadProjects(); await loadHosts(); setSelected(d.name || '');
-        notifySetupUpdated();
+        await loadHosts(); setSelected(d.name || '');
       }
-    } finally { setBusy(false); }
+    } catch {
+      setErr('No clone result received. It may still finish on the server. Refresh projects before retrying.');
+    } finally {
+      await loadProjects(false);
+      notifySetupUpdated();
+      setBusy(false);
+    }
   }
 
   // Enumerate an owner/org's repositories (wizard parity: /api/git/org-repos).
@@ -187,21 +208,20 @@ export default function Projects() {
 
   async function cloneOrgSelected() {
     if (!orgRef) return;
-    const chosen = orgRepos.filter(r => orgSelected[r.name]).map(r => ({ name: r.name, clone_url: r.clone_url }));
+    const chosen = orgRepos.filter(r => orgSelected[r.name] && !repoAlreadyCloned(r, orgRef.owner, projects, details))
+      .map(r => ({ name: r.name, clone_url: r.clone_url }));
     if (chosen.length === 0) { setErr('Select at least one repository.'); return; }
-    setBusy(true); setErr('');
+    setBusy(true); setErr(''); setOrgResults([]);
     try {
-      const r = await api('/api/git/clone-org', {
-        method: 'POST',
-        body: JSON.stringify({ host: orgRef.host, owner: orgRef.owner, repos: chosen }),
-      });
-      const d = await r.json().catch(() => ({}));
-      if (!r.ok) { setErr(d.error || `clone failed (${r.status})`); return; }
-      setOrgResults(d.results || []);
-      setUrl('');
-      await loadProjects();
-      notifySetupUpdated();
-    } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
+      const error = await cloneRepos(orgRef, chosen, api,
+        (result) => setOrgResults((previous) => [...previous, result]), async () => {
+          const inventory = await loadProjects(false);
+          notifySetupUpdated();
+          return inventory;
+        }, { onProgress: setCloneProgress });
+      if (error) setErr(error);
+      else setUrl('');
+    } finally { setBusy(false); }
   }
 
   function openDelete(ref: string) {
@@ -304,12 +324,18 @@ export default function Projects() {
               </div>
               <div>
                 <Button variant="primary" size="sm"
-                  disabled={busy || orgRepos.filter(r => orgSelected[r.name]).length === 0}
+                  disabled={busy || orgSelectedCount === 0}
                   title="Clone the checked repositories as new projects."
                   onClick={cloneOrgSelected}>
-                  Clone selected ({orgRepos.filter(r => orgSelected[r.name]).length})
+                  Clone selected ({orgSelectedCount})
                 </Button>
               </div>
+            </div>
+          )}
+          {cloneProgress && (
+            <div role="status" aria-live="polite">
+              {cloneProgress.phase === 'checking' ? 'Checking completed clone' : 'Cloning'} {cloneProgress.name}
+              {' '}({cloneProgress.current} of {cloneProgress.total})
             </div>
           )}
           {orgResults.length > 0 && (

--- a/frontend/src/setup/ConnectWorkspace.test.tsx
+++ b/frontend/src/setup/ConnectWorkspace.test.tsx
@@ -1,0 +1,59 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import ConnectWorkspace from './ConnectWorkspace';
+
+vi.mock('@rakuensoftware/smoothgui', () => ({
+  Button: ({ children, variant: _variant, ...props }: React.PropsWithChildren<{ variant?: string }>) =>
+    <button {...props}>{children}</button>,
+}));
+
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.useRealTimers(); });
+
+it('shows a checkout published after its clone response was lost, and excludes it from retry', async () => {
+  const repo = { name: 'a', clone_url: 'https://github.com/example/a.git' };
+  let published = false;
+  const request = vi.fn(async (path: string) => {
+    if (path === '/api/git/clone-org') {
+      published = true;
+      throw new TypeError('Failed to fetch');
+    }
+    if (path.startsWith('/api/git/org-repos')) return new Response(JSON.stringify({ repos: [repo] }));
+    if (path === '/api/git/projects') return new Response(JSON.stringify({
+      projects: published ? ['example/a'] : [],
+      details: published ? [{ ref: 'example/a', org: 'example', name: 'a', remote: repo.clone_url }] : [],
+    }));
+    throw new Error(`Unexpected request: ${path}`);
+  });
+  vi.stubGlobal('fetch', request);
+  const changed = vi.fn();
+  render(<ConnectWorkspace onDone={() => {}} onProjectsChanged={changed} />);
+  fireEvent.change(screen.getByPlaceholderText(/owner URL/), { target: { value: 'github.com/example' } });
+  fireEvent.click(screen.getByRole('button', { name: 'List repositories' }));
+  fireEvent.click(await screen.findByRole('button', { name: 'Clone selected (1)' }));
+
+  await screen.findByText('cloned');
+  expect(screen.queryByText(/No clone result|unavailable/)).toBeNull();
+  expect(screen.getByText('cloned')).toBeTruthy();
+  expect(screen.getByText(/Workspace has 1 project: example\/a/)).toBeTruthy();
+  await waitFor(() => expect(changed).toHaveBeenLastCalledWith(1));
+  expect((screen.getByRole('button', { name: 'Clone selected (0)' }) as HTMLButtonElement).disabled).toBe(true);
+  expect(request.mock.calls.filter(([path]) => path === '/api/git/clone-org')).toHaveLength(1);
+});
+
+it('discovers a checkout that finishes later without a click or page reload', async () => {
+  vi.useFakeTimers();
+  let published = false;
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+    projects: published ? ['example/late'] : [], details: [],
+  }))));
+  await act(async () => {
+    render(<ConnectWorkspace onDone={() => {}} />);
+  });
+  expect(screen.queryByText(/Workspace has/)).toBeNull();
+  published = true;
+
+  await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+
+  expect(screen.getByText(/Workspace has 1 project: example\/late/)).toBeTruthy();
+});

--- a/frontend/src/setup/ConnectWorkspace.tsx
+++ b/frontend/src/setup/ConnectWorkspace.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@rakuensoftware/smoothgui';
-import { parseOwner, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
+import { parseOwner, repoAlreadyCloned, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
+import { cloneRepos, type CloneProgress, type CloneResult } from './cloneRepos';
 import { notifySetupUpdated } from './setupState';
 
 /* Wizard — Workspaces & projects. A workspace is your collection of projects: the
@@ -42,13 +43,6 @@ interface Repo {
   private?: boolean;
 }
 
-interface CloneResult extends CloneKbAnnotations {
-  name: string;
-  ok: boolean;
-  project?: string | null;
-  error?: string | null;
-}
-
 export interface ConnectWorkspaceProps {
   /** Continue to the wizard summary. */
   onDone: () => void;
@@ -67,24 +61,39 @@ export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectW
   const [details, setDetails] = useState<ProjectDetail[]>([]);
   const [listing, setListing] = useState(false);
   const [cloning, setCloning] = useState(false);
+  const [progress, setProgress] = useState<CloneProgress | null>(null);
   const [err, setErr] = useState('');
+  const [projectsError, setProjectsError] = useState('');
 
   const loadProjects = useCallback(async () => {
     try {
       const r = await api('/api/git/projects', { method: 'GET' });
       const d: GitProjectsResponse = await r.json();
       if (r.ok) {
+        setProjectsError('');
         setProjects(d.projects || []);
         setDetails(d.details || []);
         onProjectsChanged?.((d.projects || []).length);
+        return d;
+      } else {
+        setProjectsError(d.error || 'Could not refresh projects.');
       }
     } catch {
-      /* server unavailable — leave empty */
+      setProjectsError('Could not refresh projects. The last loaded list is shown.');
     }
   }, [onProjectsChanged]);
 
   useEffect(() => {
     loadProjects();
+    const refresh = () => { void loadProjects(); };
+    window.addEventListener('focus', refresh);
+    const timer = window.setInterval(() => {
+      if (document.visibilityState !== 'hidden') refresh();
+    }, 5000);
+    return () => {
+      window.removeEventListener('focus', refresh);
+      window.clearInterval(timer);
+    };
   }, [loadProjects]);
 
   async function listRepos() {
@@ -132,35 +141,30 @@ export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectW
   async function cloneSelected() {
     const parsed = parseOwner(ownerInput);
     if (!parsed) return;
-    const chosen = repos.filter((r) => selected[r.name]).map((r) => ({ name: r.name, clone_url: r.clone_url }));
+    const chosen = repos.filter((r) => selected[r.name] && !repoAlreadyCloned(r, parsed.owner, projects, details))
+      .map((r) => ({ name: r.name, clone_url: r.clone_url }));
     if (chosen.length === 0) {
       setErr('Select at least one repository.');
       return;
     }
     setCloning(true);
     setErr('');
+    setResults([]);
     try {
-      const r = await api('/api/git/clone-org', {
-        method: 'POST',
-        body: JSON.stringify({ host: parsed.host, owner: parsed.owner, repos: chosen }),
-      });
-      const d = await r.json().catch(() => ({}));
-      if (!r.ok) {
-        setErr(d.error || `clone failed (${r.status})`);
-        return;
-      }
-      setResults(d.results || []);
-      await loadProjects();
-      notifySetupUpdated();
-    } catch {
-      setErr('aimee-server unavailable');
+      const error = await cloneRepos(parsed, chosen, api,
+        (result) => setResults((previous) => [...previous, result]), async () => {
+          const inventory = await loadProjects();
+          notifySetupUpdated();
+          return inventory;
+        }, { onProgress: setProgress });
+      if (error) setErr(error);
     } finally {
       setCloning(false);
     }
   }
 
-  const selectedCount = repos.filter((r) => selected[r.name]).length;
   const ownerName = parseOwner(ownerInput)?.owner || '';
+  const selectedCount = repos.filter((r) => selected[r.name] && !repoAlreadyCloned(r, ownerName, projects, details)).length;
   const toggleAll = (on: boolean) => {
     const sel: Record<string, boolean> = {};
     for (const r of repos) sel[r.name] = on && !repoAlreadyCloned(r, ownerName, projects, details);
@@ -178,9 +182,9 @@ export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectW
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
           <input style={{ ...input, flex: 2, minWidth: 240 }}
             placeholder="owner URL (e.g. github.com/RakuenSoftware)"
-            value={ownerInput} onChange={(e) => setOwnerInput(e.target.value)}
+            disabled={cloning} value={ownerInput} onChange={(e) => setOwnerInput(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter' && ownerInput.trim() && !listing) listRepos(); }} />
-          <Button variant="primary" disabled={listing || !ownerInput.trim()} onClick={listRepos}>
+          <Button variant="primary" disabled={cloning || listing || !ownerInput.trim()} onClick={listRepos}>
             {listing ? 'Listing…' : 'List repositories'}
           </Button>
         </div>
@@ -220,6 +224,13 @@ export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectW
         </section>
       )}
 
+      {progress && (
+        <div role="status" aria-live="polite">
+          {progress.phase === 'checking' ? 'Checking completed clone' : 'Cloning'} {progress.name}
+          {' '}({progress.current} of {progress.total})
+        </div>
+      )}
+
       {results.length > 0 && (
         <section style={{ display: 'grid', gap: 3 }}>
           <div style={{ fontSize: 12.5, fontWeight: 700 }}>Clone results</div>
@@ -243,9 +254,11 @@ export default function ConnectWorkspace({ onDone, onProjectsChanged }: ConnectW
       )}
 
       {err && <div style={{ fontSize: 12.5, color: 'var(--sg-danger-dark)' }}>{err}</div>}
+      {projectsError && <div style={{ fontSize: 12.5, color: 'var(--sg-danger-dark)' }}>{projectsError}</div>}
 
       <div>
-        <Button variant="primary" onClick={onDone}>
+        <Button onClick={() => { void loadProjects(); }}>Refresh projects</Button>
+        <Button variant="primary" disabled={cloning} onClick={onDone}>
           {projects.length > 0 ? 'Done' : 'Continue'}
         </Button>
       </div>

--- a/frontend/src/setup/cloneRepos.test.ts
+++ b/frontend/src/setup/cloneRepos.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cloneRepos } from './cloneRepos';
+
+const owner = { host: 'github.com', owner: 'example' };
+const repos = ['a', 'b', 'c'].map(name => ({ name, clone_url: `https://github.com/example/${name}.git` }));
+const reply = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status });
+
+describe('Repository clone progress and recovery', () => {
+  it('finishes and refreshes each repository before starting the next request', async () => {
+    const events: string[] = [];
+    const request = vi.fn(async (_path: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.host).toBe(owner.host);
+      expect(body.owner).toBe(owner.owner);
+      expect(body.repos).toHaveLength(1);
+      const name = body.repos[0].name;
+      events.push(`request:${name}`);
+      return reply({ results: [{ name, ok: true, project: `example/${name}` }] });
+    });
+
+    expect(await cloneRepos(owner, repos, request,
+      result => { events.push(`result:${result.name}`); },
+      async () => { events.push('refresh'); })).toBeNull();
+
+    expect(events).toEqual(['request:a', 'result:a', 'refresh', 'request:b', 'result:b', 'refresh', 'request:c', 'result:c', 'refresh']);
+  });
+
+  it('retains completed results and refreshes after a lost response without resubmitting', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce(reply({ results: [{ name: 'a', ok: true }] }))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const result = vi.fn();
+    const refresh = vi.fn(async () => {});
+
+    const error = await cloneRepos(owner, repos, request, result, refresh, { recoveryAttempts: 1 });
+
+    expect(error).toContain('Could not confirm the clone of b');
+    expect(error).toContain('queue is paused');
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(result).toHaveBeenCalledExactlyOnceWith({ name: 'a', ok: true });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [503, { error: 'git: aimee-server unavailable' }],
+    [504, { error: 'timeout' }],
+    [200, { results: [] }],
+    [200, { results: [{ name: 'different-repo', ok: true }] }],
+  ])('refreshes inventory when status %s carries no reliable clone outcome', async (status, data) => {
+    const request = vi.fn(async () => reply(data, status));
+    const result = vi.fn();
+    const refresh = vi.fn(async () => {});
+
+    expect(await cloneRepos(owner, repos, request, result, refresh, { recoveryAttempts: 1 })).toContain('Completed repositories will continue to appear');
+    expect(result).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it('reports a confirmed repository failure and continues the remaining selection', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce(reply({ results: [{ name: 'a', ok: false, error: 'repository not found' }] }))
+      .mockResolvedValueOnce(reply({ results: [{ name: 'b', ok: true }] }));
+    const result = vi.fn();
+
+    expect(await cloneRepos(owner, repos.slice(0, 2), request, result, async () => {})).toBeNull();
+    expect(result.mock.calls.map(([r]) => r.ok)).toEqual([false, true]);
+  });
+
+  it('waits for a late publication after a lost response, then continues without cloning it twice', async () => {
+    const request = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(reply({ results: [{ name: 'b', ok: true }] }));
+    const refresh = vi.fn()
+      .mockResolvedValueOnce({ projects: [], details: [] })
+      .mockResolvedValue({ projects: ['example/a'], details: [
+        { ref: 'example/a', remote: 'https://github.com/EXAMPLE/a' },
+      ] });
+    const result = vi.fn();
+    const progress = vi.fn();
+
+    expect(await cloneRepos(owner, repos.slice(0, 2), request, result, refresh,
+      { onProgress: progress, recoveryDelayMs: 0 })).toBeNull();
+
+    expect(request.mock.calls.map(([, init]) => JSON.parse(init.body).repos[0].name)).toEqual(['a', 'b']);
+    expect(result.mock.calls.map(([r]) => r.project || r.name)).toEqual(['example/a', 'b']);
+    expect(progress.mock.calls.map(([p]) => p && `${p.phase}:${p.name}`))
+      .toEqual(['cloning:a', 'checking:a', 'cloning:b', null]);
+  });
+
+  it('does not treat a matching name from another remote as a successful clone', async () => {
+    const request = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    const refresh = vi.fn().mockResolvedValue({ details: [
+      { ref: 'other/a', remote: 'https://github.com/other/a.git' },
+    ] });
+    const result = vi.fn();
+
+    expect(await cloneRepos(owner, repos, request, result, refresh, { recoveryAttempts: 1 }))
+      .toContain('Could not confirm');
+    expect(result).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/setup/cloneRepos.ts
+++ b/frontend/src/setup/cloneRepos.ts
@@ -1,0 +1,93 @@
+import { canonicalRemote, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef } from './ownerUrl';
+
+export interface CloneRepo {
+  name: string;
+  clone_url: string;
+}
+
+export interface CloneResult extends CloneKbAnnotations {
+  name: string;
+  ok: boolean;
+  project?: string | null;
+  error?: string | null;
+}
+
+export interface CloneProgress {
+  name: string;
+  current: number;
+  total: number;
+  phase: 'cloning' | 'checking';
+}
+
+type Request = (path: string, init?: RequestInit) => Promise<Response>;
+type Refresh = () => Promise<GitProjectsResponse | void>;
+interface Options {
+  onProgress?: (progress: CloneProgress | null) => void;
+  recoveryAttempts?: number;
+  recoveryDelayMs?: number;
+}
+
+/** Give each repo its own deadline. A lost response is reconciled against the
+ * published inventory before the queue advances; it never resubmits that clone. */
+export async function cloneRepos(
+  owner: OwnerRef,
+  repos: CloneRepo[],
+  request: Request,
+  onResult: (result: CloneResult) => void,
+  refreshProjects: Refresh,
+  { onProgress, recoveryAttempts = 30, recoveryDelayMs = 2000 }: Options = {},
+): Promise<string | null> {
+  try {
+    for (const [index, repo] of repos.entries()) {
+      const progress = { name: repo.name, current: index + 1, total: repos.length };
+      onProgress?.({ ...progress, phase: 'cloning' });
+      let result: CloneResult | undefined;
+      let error: string | undefined;
+      try {
+        const response = await request('/api/git/clone-org', {
+          method: 'POST',
+          body: JSON.stringify({ ...owner, repos: [repo] }),
+        });
+        const data = await response.json();
+        if (!response.ok) {
+          if (![502, 503, 504].includes(response.status)) {
+            error = typeof data.error === 'string' ? data.error : `Clone request failed (${response.status}).`;
+          }
+        } else if (Array.isArray(data.results) && data.results.length === 1 &&
+            data.results[0]?.name === repo.name && typeof data.results[0].ok === 'boolean') {
+          result = data.results[0];
+        }
+      } catch {
+        // A transport/parse failure says nothing about whether git completed.
+      }
+      if (result) {
+        onResult(result);
+        await refreshProjects();
+        continue;
+      }
+      if (error) {
+        await refreshProjects();
+        return error;
+      }
+      onProgress?.({ ...progress, phase: 'checking' });
+      const remote = canonicalRemote(repo.clone_url);
+      for (let attempt = 0; attempt < recoveryAttempts; attempt++) {
+        if (attempt > 0) await new Promise(resolve => setTimeout(resolve, recoveryDelayMs));
+        const inventory = await refreshProjects();
+        const published = remote && inventory?.details?.find(project =>
+          project.remote && canonicalRemote(project.remote) === remote);
+        if (published) {
+          result = { name: repo.name, ok: true, project: published.ref };
+          break;
+        }
+      }
+      if (!result) {
+        return `Could not confirm the clone of ${repo.name}. The remaining queue is paused. Completed repositories will continue to appear in the project list.`;
+      }
+      onResult(result);
+    }
+    return null;
+  } finally {
+    onProgress?.(null);
+  }
+}

--- a/scripts/test-private-index-live.py
+++ b/scripts/test-private-index-live.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Read-only release checks against a configured, populated Aimee thin client.
+
+Example: python3 scripts/test-private-index-live.py --client /path/to/aimee \
+  --sample aimee=memory_insert --sample games-on-whales/wolf=die \
+  --memory-key aimee-deployment --min-projects 2 --output /tmp/index-checks.json
+No credentials, source contents, or memory contents are written to the report.
+"""
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import re
+import subprocess
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", default="aimee")
+    parser.add_argument("--sample", action="append", required=True, metavar="PROJECT=SYMBOL")
+    parser.add_argument("--memory-key", required=True)
+    parser.add_argument("--min-projects", type=int, default=1)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    results = []
+
+    def call(command, allow_error=False):
+        start = time.monotonic()
+        proc = subprocess.run([args.client, "--json", *command], text=True,
+                              capture_output=True, timeout=45)
+        elapsed = round(time.monotonic() - start, 3)
+        if proc.returncode:
+            raise AssertionError(f"{command}: CLI exit {proc.returncode}")
+        try:
+            reply = json.loads(proc.stdout)
+        except ValueError as exc:
+            raise AssertionError(f"{command}: non-JSON reply") from exc
+        if isinstance(reply, dict) and "span" in reply:
+            reply = reply["span"]
+        if isinstance(reply, dict) and not allow_error:
+            assert not reply.get("error") and reply.get("status") != "error", command
+        return reply, {"command": command, "seconds": elapsed, "passed": True}
+
+    overview, record = call(["index", "overview"])
+    assert isinstance(overview, list) and len(overview) >= args.min_projects
+    record["projects"] = len(overview)
+    results.append(record)
+    for sample in args.sample:
+        project, symbol = sample.split("=", 1)
+        reply, record = call(["index", "find", symbol, "--project", project])
+        hits = reply["hits"]
+        assert hits and all(hit["project"] == project for hit in hits), sample
+        results.append(record)
+        path = hits[0]["file_path"]
+        line = max(1, hits[0].get("line", 1))
+        reply, record = call(["index", "structure", path, "--project", project])
+        assert any(d["name"].lower() == symbol.lower() for d in reply["definitions"]), sample
+        results.append(record)
+        reply, record = call(["index", "span", path, str(line), str(line + 5), "--project", project])
+        assert reply["content"] and reply["line_count"] > 0, sample
+        assert re.fullmatch(r"[0-9a-f]{64}", reply["source_version"]), sample
+        results.append(record)
+        reply, record = call(["index", "callers", symbol, "--project", project])
+        assert isinstance(reply["hits"], list), sample
+        results.append(record)
+        reply, record = call(["index", "blast-radius", path, "--project", project])
+        assert reply.get("result_status") == "ok" and reply.get("file") == path, sample
+        assert isinstance(reply.get("dependencies"), list) and isinstance(reply.get("dependents"), list)
+        results.append(record)
+        for operation in ("hybrid", "investigate"):
+            reply, record = call(["index", operation, symbol, "--project", project])
+            assert reply.get("hits") or reply.get("results"), (sample, operation)
+            results.append(record)
+        for path in (".env", "../outside.c", "/etc/passwd", "__aimee_missing_source__.c"):
+            reply, record = call(["index", "span", path, "1", "2", "--project", project], True)
+            assert isinstance(reply.get("error"), str) and reply["error"], (sample, path)
+            results.append(record)
+        reply, record = call(["index", "structure", "__aimee_missing_source__.c", "--project", project])
+        assert reply["definitions"] == [], sample
+        results.append(record)
+    reply, record = call(["memory", "search", args.memory_key])
+    assert args.memory_key in json.dumps(reply), "existing memory was not retrieved"
+    results.append(record)
+    # Exercise shared request capacity while detached workspaces are registered.
+    command = ["memory", "search", args.memory_key]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for reply, record in pool.map(lambda _: call(command), range(16)):
+            assert args.memory_key in json.dumps(reply)
+            record["concurrent"] = True
+            results.append(record)
+    args.output.write_text(json.dumps(results, indent=2) + "\n")
+    print(f"private index live: {len(results)} checks passed across {len(args.sample)} projects")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-setup-browser.cjs
+++ b/scripts/test-setup-browser.cjs
@@ -13,7 +13,7 @@ const fs = require('fs');
   page.on('pageerror',e=>errors.push(e.message));
   const inventory=wizard?{projects:[],details:[]}:{projects:Array.from({length:73},(_,i)=>`existing/repo-${i}`),details:[]};
   const repos=['first','second','third'].map(name=>({name,clone_url:`https://github.com/clone-check/${name}.git`}));
-  let lateReads=0, lateRepo=null;
+  let recoveryObserved=false, lateRepo=null;
   const publish=repo=>{
    inventory.projects.push('clone-check/'+repo.name);
    inventory.details.push({ref:'clone-check/'+repo.name,org:'clone-check',name:repo.name,remote:repo.clone_url});
@@ -28,7 +28,7 @@ const fs = require('fs');
    if(p==='/api/config') data={config:{provider:'test',embedder_model:'bekko-a25m'}};
    if(p==='/api/vault/credentials') data={credentials:[{agent:'git',cred:'author_name'},{agent:'git',cred:'author_email'}]};
    if(p==='/api/git/projects') {
-    if(lateRepo && ++lateReads===2) {publish(lateRepo);lateRepo=null;}
+    if(lateRepo && recoveryObserved) {publish(lateRepo);lateRepo=null;}
     data=inventory;
    }
    if(p==='/api/git/credentials') data={hosts:['github.com']};
@@ -53,6 +53,9 @@ const fs = require('fs');
   await scope.getByRole('button',{name:'List repositories',exact:true}).click();
   await scope.getByRole('button',{name:'Clone selected (3)',exact:true}).click();
   await scope.getByRole('status').filter({hasText:'Checking completed clone second (2 of 3)'}).waitFor();
+  // Inventory polling may overlap with reconciliation. Hold publication until
+  // this assertion observes the checking state, independent of runner speed.
+  recoveryObserved=true;
   await scope.getByRole('button',{name:'Clone selected (0)',exact:true}).waitFor();
   const cloned=await scope.getByText('cloned',{exact:true}).count();
   if(JSON.stringify(batches)!==JSON.stringify([['first'],['second'],['third']])||cloned!==3||errors.length) throw Error(JSON.stringify({wizard,batches,cloned,errors}));

--- a/scripts/test-setup-browser.cjs
+++ b/scripts/test-setup-browser.cjs
@@ -1,0 +1,83 @@
+/* Built-browser release regressions. Run after npm --prefix frontend run build. */
+const { chromium } = require('../frontend/node_modules/playwright');
+const fs = require('fs');
+(async()=>{
+ const html=fs.readFileSync(process.argv[2] || require('path').join(__dirname,'../frontend/dist/index.html'),'utf8');
+ const browser=await chromium.launch({headless:true,...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE ? {executablePath:process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE} : {}),args:['--no-sandbox']});
+ try {
+ for (const wizard of [false,true]) for (const lostResponse of [true,false]) {
+  const context=await browser.newContext();
+  await context.addInitScript(()=>localStorage.setItem('aimee_setup_dismissed','1'));
+  const page=await context.newPage(); page.setDefaultTimeout(15000);
+  const errors=[],batches=[];
+  page.on('pageerror',e=>errors.push(e.message));
+  const inventory=wizard?{projects:[],details:[]}:{projects:Array.from({length:73},(_,i)=>`existing/repo-${i}`),details:[]};
+  const repos=['first','second','third'].map(name=>({name,clone_url:`https://github.com/clone-check/${name}.git`}));
+  let lateReads=0, lateRepo=null;
+  const publish=repo=>{
+   inventory.projects.push('clone-check/'+repo.name);
+   inventory.details.push({ref:'clone-check/'+repo.name,org:'clone-check',name:repo.name,remote:repo.clone_url});
+  };
+  await page.route('http://gui-check.test/**',async route=>{
+   const p=new URL(route.request().url()).pathname;
+   let data={};
+   if(!p.startsWith('/api/')) return route.fulfill({contentType:'text/html',body:html});
+   if(p==='/api/auth/me') data={username:'admin'};
+   if(p==='/api/chat/session') data={csrf:'test'};
+   if(p==='/api/setup/account') data={complete:true};
+   if(p==='/api/config') data={config:{provider:'test',embedder_model:'bekko-a25m'}};
+   if(p==='/api/vault/credentials') data={credentials:[{agent:'git',cred:'author_name'},{agent:'git',cred:'author_email'}]};
+   if(p==='/api/git/projects') {
+    if(lateRepo && ++lateReads===2) {publish(lateRepo);lateRepo=null;}
+    data=inventory;
+   }
+   if(p==='/api/git/credentials') data={hosts:['github.com']};
+   if(p==='/api/git/org-repos') data={provider:'github',repos};
+   if(p==='/api/git/clone-org') {
+    const body=route.request().postDataJSON(); batches.push(body.repos.map(r=>r.name));
+    const repo=body.repos[0];
+    if(repo.name==='second') {lateRepo=repo;return lostResponse ? route.abort('failed') : route.fulfill({status:503,contentType:'application/json',body:JSON.stringify({error:'aimee-server unavailable'})});}
+    publish(repo);
+    data={results:[{name:repo.name,ok:true,project:'clone-check/'+repo.name}]};
+   }
+   return route.fulfill({contentType:'application/json',body:JSON.stringify(data)});
+  });
+  await page.goto('http://gui-check.test/projects');
+  await page.getByRole('button',{name:'Got it',exact:true}).click();
+  if(wizard) {
+   await page.evaluate(()=>window.dispatchEvent(new CustomEvent('aimee:open-setup-wizard')));
+   await page.getByText('Workspaces & projects',{exact:true}).waitFor();
+  }
+  const scope=wizard?page.getByRole('dialog',{name:'Setup wizard'}):page;
+  await scope.getByPlaceholder(wizard?/owner URL/:/repo URL/).fill('github.com/clone-check');
+  await scope.getByRole('button',{name:'List repositories',exact:true}).click();
+  await scope.getByRole('button',{name:'Clone selected (3)',exact:true}).click();
+  await scope.getByRole('status').filter({hasText:'Checking completed clone second (2 of 3)'}).waitFor();
+  await scope.getByRole('button',{name:'Clone selected (0)',exact:true}).waitFor();
+  const cloned=await scope.getByText('cloned',{exact:true}).count();
+  if(JSON.stringify(batches)!==JSON.stringify([['first'],['second'],['third']])||cloned!==3||errors.length) throw Error(JSON.stringify({wizard,batches,cloned,errors}));
+  if(await scope.getByText(/unavailable|Could not confirm/).count()) throw Error('Spurious clone error remains');
+  console.log(JSON.stringify({screen:wizard?'setup wizard':'Projects',failure:lostResponse?'lost response':'HTTP 503',batches,lateCloneRecovered:true,cloned,errors}));
+  await context.close();
+ }
+ // A reinstall at the same origin must override a prior Finish flag.
+ const context=await browser.newContext();
+ await context.addInitScript(()=>localStorage.setItem('aimee_setup_dismissed','1'));
+ const page=await context.newPage();page.setDefaultTimeout(15000);
+ await page.route('http://gui-check.test/**',async route=>{
+  const path=new URL(route.request().url()).pathname;
+  if(!path.startsWith('/api/'))return route.fulfill({contentType:'text/html',body:html});
+  const fixtures={
+   '/api/auth/me':{username:'firstboot'},'/api/chat/session':{csrf:'test'},
+   '/api/setup/account':{complete:false,username:'firstboot'},
+   '/api/config':{config:{}},'/api/git/projects':{projects:[],details:[]},
+   '/api/git/credentials':{hosts:[]},'/api/vault/credentials':{credentials:[]},
+  };
+  await route.fulfill({contentType:'application/json',body:JSON.stringify(fixtures[path]||{})});
+ });
+ await page.goto('http://gui-check.test/projects');
+ await page.getByRole('dialog',{name:'Setup wizard'}).getByText('Secure your account',{exact:true}).waitFor();
+ console.log(JSON.stringify({screen:'first boot',oldDismissalOverridden:true}));
+ await context.close();
+ } finally {await browser.close();}
+})().catch(e=>{console.error(e);process.exit(1)});

--- a/scripts/tests/test_frontend_release_gate.py
+++ b/scripts/tests/test_frontend_release_gate.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""The browser regression lane must block the required aggregate CI status."""
+import os
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class FrontendReleaseGateTests(unittest.TestCase):
+    def test_browser_failure_blocks_required_gate(self):
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        lane = workflow.split("  frontend-tests:\n", 1)[1].split("  go-unit-tests:\n", 1)[0]
+        for command in ("npm ci", "npm test", "npm run build", "npx playwright install", "npm run test:browser"):
+            self.assertIn(command, lane)
+        aggregate = workflow.split("\n  unit-tests:\n", 1)[1]
+        aggregate = re.split(r"\n  [a-z][a-z0-9-]*:\n", aggregate, maxsplit=1)[0]
+        self.assertIn("frontend-tests", aggregate.split("\n", 1)[0])
+        self.assertIn("FRONTEND_RESULT: ${{ needs.frontend-tests.result }}", aggregate)
+        run = aggregate.split("        run: |\n", 1)[1]
+        script = "\n".join(line[10:] for line in run.splitlines() if line.startswith("          "))
+        env = dict(os.environ, CHANGE_SCOPE_RESULT="success", DOCS_ONLY="false",
+                   SHARDS_RESULT="success", SHARDS_PG_RESULT="success", DB2_REPLAY_RESULT="success",
+                   P1_RESULT="success", GO_RESULT="success", LSP_REAL_RESULT="success")
+        for result in ("success", "failure", "cancelled", "skipped"):
+            with self.subTest(result=result):
+                proc = subprocess.run(["bash", "-c", script], env=dict(env, FRONTEND_RESULT=result), capture_output=True)
+                self.assertEqual(proc.returncode == 0, result == "success")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_postgres_store_upgrade.sh
+++ b/scripts/tests/test_postgres_store_upgrade.sh
@@ -178,6 +178,7 @@ for _ in $(seq 1 30); do
   sleep 1
 done
 test "$(docker inspect -f '{{.State.Running}}' "$repaired_container")" = false
-docker logs "$repaired_container" 2>&1 | grep -q 'both aimee_shared and aimee_store exist'
+# Drain the log stream: grep -q can SIGPIPE Docker under pipefail.
+docker logs "$repaired_container" 2>&1 | grep 'both aimee_shared and aimee_store exist' >/dev/null
 
 echo "postgres-store-upgrade: ok ($LEGACY_STORE_DB)"

--- a/scripts/tests/test_postgres_store_upgrade_logs.py
+++ b/scripts/tests/test_postgres_store_upgrade_logs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Exercise the upgrade assertion with streamed Docker logs under pipefail."""
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class UpgradeLogAssertionTest(unittest.TestCase):
+    def test_stream_is_drained_and_failures_are_preserved(self):
+        source = (ROOT / "scripts/tests/test_postgres_store_upgrade.sh").read_text()
+        assertion = next(line for line in source.splitlines()
+                         if line.startswith('docker logs "$repaired_container"'))
+        with tempfile.TemporaryDirectory() as directory:
+            producer = pathlib.Path(directory) / "logs.py"
+            producer.write_text(
+                "import signal, sys\n"
+                "signal.signal(signal.SIGPIPE, signal.SIG_DFL)\n"
+                "if sys.argv[1] != 'missing':\n"
+                "    print('both aimee_shared and aimee_store exist', flush=True)\n"
+                "for _ in range(256):\n"
+                "    print('subsequent diagnostic ' * 4096, flush=True)\n"
+                "sys.exit(7 if sys.argv[1] == 'failed' else 0)\n"
+            )
+            # Use positional parameters rather than interpolate paths into shell code.
+            command = ('set -euo pipefail\n'
+                       'repaired_container=test\n'
+                       'producer=$1; mode=$2\n'
+                       'docker() { python3 "$producer" "$mode"; }\n' + assertion)
+            for mode, expected in [('matched', 0), ('missing', 1), ('failed', 7)]:
+                with self.subTest(mode=mode):
+                    result = subprocess.run(['bash', '-c', command, 'test', str(producer), mode],
+                                            capture_output=True, text=True, timeout=30)
+                    self.assertEqual(result.returncode, expected, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server-go/modules/memory/code_index.go
+++ b/server-go/modules/memory/code_index.go
@@ -58,6 +58,10 @@ type CodeFile struct {
 	Imports        []string         `json:"imports"`
 }
 type CodeIndexRequest struct {
+	FilePath      string     `json:"file_path"`
+	LineStart     int        `json:"line_start"`
+	LineEnd       int        `json:"line_end"`
+	MaxLines      int        `json:"max_lines"`
 	Route         string     `json:"route"`
 	Project       string     `json:"project"`
 	Root          string     `json:"root_path"`
@@ -89,8 +93,11 @@ func validCodePath(p string) bool {
 	if p == "" || len(p) > 4096 || strings.ContainsAny(p, "\\\x00\r\n") || path.IsAbs(p) || path.Clean(p) != p || p == ".." || strings.HasPrefix(p, "../") {
 		return false
 	}
-	for _, c := range strings.Split(p, "/") {
-		if strings.HasPrefix(c, ".") {
+	components := strings.Split(p, "/")
+	for i, c := range components {
+		// The collector explicitly includes this build manifest. Other hidden
+		// files and every hidden directory remain outside the code corpus.
+		if strings.HasPrefix(c, ".") && !(i == len(components)-1 && c == ".gitmodules") {
 			return false
 		}
 	}

--- a/server-go/modules/memory/code_index_test.go
+++ b/server-go/modules/memory/code_index_test.go
@@ -2,9 +2,13 @@ package memory
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	store "github.com/JBailes/aimee/server-go/db"
 	"github.com/jackc/pgx/v5"
@@ -264,4 +268,184 @@ func TestCodeVectorsRejectStaleContentAndModel(t *testing.T) {
 		t.Fatal(err)
 	}
 	search(0)
+}
+
+func TestPrivateCodeIndexLargeGraphAndMissingFile(t *testing.T) {
+	t.Setenv("AIMEE_GRAPH_FUSION", "on")
+	ctx, s, db := codeFixture(t)
+	if err := s.ensureCodeIndex(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// A repository-sized graph: each file has several definitions and calls.
+	// A file-first join expands millions of unrelated pairs before matching names.
+	_, err := db.Exec(ctx, `INSERT INTO user_code_projects(name,root,generation) VALUES('large','/fixture/large',1);
+ INSERT INTO user_code_files(project,path,content,definitions,calls,fingerprint)
+ SELECT 'large', 'file-'||i||'.c', CASE WHEN i=1 THEN 'quasar' ELSE 'source' END,
+ (SELECT jsonb_agg(jsonb_build_object('name','symbol-'||i||'-'||d,'line',d,'line_end',d,'kind','function')) FROM generate_series(1,20) d),
+ (SELECT jsonb_agg(jsonb_build_object('callee','symbol-'||(i%1500+1)||'-'||c,'caller','entry','line',c)) FROM generate_series(1,20) c),
+ md5(i::text) FROM generate_series(1,1500) i`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bounded, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	raw, err := s.CodeIndex(bounded, CodeIndexRequest{Route: "/v1/code/hybrid?project=large&query=quasar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reply struct {
+		Hits []struct {
+			Path string `json:"file_path"`
+		}
+	}
+	if err := json.Unmarshal(raw, &reply); err != nil || len(reply.Hits) != 3 {
+		t.Fatalf("graph neighbors missing: %s (%v)", raw, err)
+	}
+	for _, route := range []string{"/v1/code/structure?project=large&file_path=missing.c", "/v1/code/structure?project=missing&file_path=missing.c"} {
+		raw, err = s.CodeIndex(ctx, CodeIndexRequest{Route: route})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var structure struct {
+			Definitions []CodeDefinition `json:"definitions"`
+		}
+		if err := json.Unmarshal(raw, &structure); err != nil || structure.Definitions == nil || len(structure.Definitions) != 0 {
+			t.Fatalf("missing file: %s (%v)", raw, err)
+		}
+	}
+}
+
+func TestPrivateCodeMissingBlastRadius(t *testing.T) {
+	ctx, s, _ := codeFixture(t)
+	raw, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/blast-radius?project=missing&file_path=missing.c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reply struct {
+		Resolved   bool
+		Dependents []string
+	}
+	if err := json.Unmarshal(raw, &reply); err != nil || reply.Resolved || reply.Dependents == nil {
+		t.Fatalf("missing file: %s (%v)", raw, err)
+	}
+}
+
+func TestPrivateCodePublishedSpan(t *testing.T) {
+	ctx, s, _ := codeFixture(t)
+	_, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/scan", Project: "detached", Root: "/unreadable/client/path", Files: []CodeFile{{Path: "main.c", Content: "one\ntwo\nthree\n"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "detached", FilePath: "main.c", LineStart: 2, LineEnd: 100, MaxLines: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var span struct {
+		Content   string
+		Truncated bool
+		LineCount int    `json:"line_count"`
+		Version   string `json:"source_version"`
+	}
+	if err := json.Unmarshal(raw, &span); err != nil || span.Content != "two\n" || !span.Truncated || span.LineCount != 1 || len(span.Version) != 64 {
+		t.Fatalf("span: %s (%v)", raw, err)
+	}
+	for _, path := range []string{"../main.c", "/etc/passwd", ".env", "missing.c"} {
+		raw, err = s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "detached", FilePath: path})
+		if err != nil || !strings.Contains(string(raw), `"error"`) {
+			t.Fatalf("path %s: %s (%v)", path, raw, err)
+		}
+	}
+}
+
+// A repository with a submodule manifest must publish atomically, while hidden
+// credential/config paths are rejected before changing the published generation.
+func TestPrivateCodeManifestPublication(t *testing.T) {
+	ctx, s, _ := codeFixture(t)
+	call := func(phase string, files []CodeFile, count int) {
+		t.Helper()
+		_, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/scan", Project: "manifest", Root: "/fixture/manifest", ScanID: "first", Phase: phase, Files: files, ExpectedFiles: count})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	call("begin", nil, 0)
+	call("stage", []CodeFile{{Path: ".gitmodules", Content: "[submodule]"}, {Path: "nested/.gitmodules", Content: "[submodule]"}, {Path: "source.c", Content: "int visible;"}}, 0)
+	call("seal", nil, 3)
+	raw, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/project-stats?project=manifest"})
+	var stats struct{ Files int }
+	if err != nil || json.Unmarshal(raw, &stats) != nil || stats.Files != 3 {
+		t.Fatalf("publication: %s (%v)", raw, err)
+	}
+	for _, path := range []string{".mcp.json", "nested/.env.production.json", ".git/config", ".gitmodules/source.c", "nested/.gitmodules/config", "x/../.gitmodules"} {
+		_, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/scan", Project: "manifest", Root: "/fixture/manifest", Files: []CodeFile{{Path: path, Content: "hidden"}}})
+		if err == nil {
+			t.Fatalf("hidden path accepted: %s", path)
+		}
+	}
+	raw, err = s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "manifest", FilePath: "source.c", LineStart: 1, LineEnd: 1})
+	if err != nil || !strings.Contains(string(raw), `"generation":1`) || !strings.Contains(string(raw), "int visible;") {
+		t.Fatalf("rejected scan changed publication: %s (%v)", raw, err)
+	}
+}
+
+func TestPrivateCodePublishedSpanBoundsAndDrift(t *testing.T) {
+	ctx, s, _ := codeFixture(t)
+	files := []CodeFile{{Path: "short.c", Content: "one\ntwo\nthree"}, {Path: "empty.c", Content: ""}, {Path: "many.c", Content: strings.Repeat("line\n", 450)}, {Path: "wide.c", Content: "ok\n" + strings.Repeat("x", 65536) + "\n"}}
+	publish := func(phase, scan string, files []CodeFile) {
+		t.Helper()
+		_, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/scan", Project: "spans", Root: "/unreadable/client", Phase: phase, ScanID: scan, Files: files, ExpectedFiles: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	publish("", "", files)
+	for _, tc := range []struct {
+		name, path                   string
+		start, end, max, lines, last int
+		truncated                    bool
+		content                      string
+	}{
+		{"defaults", "short.c", 0, 0, 0, 1, 1, false, "one\n"},
+		{"unterminated last line", "short.c", 2, 3, 400, 2, 3, false, "two\nthree"},
+		{"short file not truncated", "short.c", 1, 1000, 400, 3, 3, false, "one\ntwo\nthree"},
+		{"past EOF", "short.c", 90, 100, 400, 0, 0, false, ""},
+		{"empty", "empty.c", 1, 10, 400, 0, 0, false, ""},
+		{"hard line cap", "many.c", 1, 1000, 1000, 400, 400, true, strings.Repeat("line\n", 400)},
+		{"byte cap", "wide.c", 1, 2, 400, 1, 1, true, "ok\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "spans", FilePath: tc.path, LineStart: tc.start, LineEnd: tc.end, MaxLines: tc.max})
+			var reply struct {
+				Content    string
+				LineCount  int `json:"line_count"`
+				LineEnd    int `json:"line_end"`
+				Truncated  bool
+				Version    string `json:"source_version"`
+				Generation int
+				Freshness  string
+			}
+			if err != nil || json.Unmarshal(raw, &reply) != nil {
+				t.Fatalf("span: %s (%v)", raw, err)
+			}
+			if reply.Content != tc.content || reply.LineCount != tc.lines || reply.LineEnd != tc.last || reply.Truncated != tc.truncated || reply.Generation != 1 || reply.Freshness != "published" {
+				t.Fatalf("incorrect span: %+v", reply)
+			}
+			for _, file := range files {
+				if file.Path == tc.path && reply.Version != fmt.Sprintf("%x", sha256.Sum256([]byte(file.Content))) {
+					t.Fatal("version does not hash the whole published file")
+				}
+			}
+		})
+	}
+	publish("begin", "next", nil)
+	publish("stage", "next", []CodeFile{{Path: "short.c", Content: "changed\n"}})
+	raw, err := s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "spans", FilePath: "short.c", LineStart: 1, LineEnd: 1})
+	if err != nil || !strings.Contains(string(raw), `"content":"one\n"`) {
+		t.Fatalf("staged bytes escaped: %s (%v)", raw, err)
+	}
+	publish("seal", "next", nil)
+	raw, err = s.CodeIndex(ctx, CodeIndexRequest{Route: "/v1/code/span", Project: "spans", FilePath: "short.c", LineStart: 1, LineEnd: 1})
+	if err != nil || !strings.Contains(string(raw), `"content":"changed\n"`) || !strings.Contains(string(raw), `"generation":2`) {
+		t.Fatalf("new generation not visible: %s (%v)", raw, err)
+	}
 }

--- a/server-go/modules/memory/code_query.go
+++ b/server-go/modules/memory/code_query.go
@@ -2,10 +2,14 @@ package memory
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
+	store "github.com/JBailes/aimee/server-go/db"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -38,6 +42,8 @@ func (s *postgresDataStore) queryCode(ctx context.Context, route *url.URL, req C
 		limit = 128
 	}
 	switch route.Path {
+	case "/v1/code/span":
+		return s.codeSpan(ctx, project, req)
 	case "/v1/code/projects":
 		return s.codeJSON(ctx, `SELECT json_build_object('projects',COALESCE(json_agg(p),'[]'::json))::text FROM
 (SELECT name,root,scanned_at,generation FROM user_code_projects WHERE generation>0 ORDER BY name LIMIT $1) p`, limit)
@@ -59,8 +65,8 @@ WHERE ($1='' OR f.project=$1) AND lower(d->>'name')=lower($2) ORDER BY f.project
 FROM user_code_files f CROSS JOIN LATERAL jsonb_array_elements(f.calls) c
 WHERE ($1='' OR f.project=$1) AND c->>'callee'=$2 ORDER BY f.project,f.path,line LIMIT $3) h`, project, q.Get("symbol"), limit)
 	case "/v1/code/structure":
-		return s.codeJSON(ctx, `SELECT json_build_object('definitions',definitions,'imports',imports,'calls',calls)::text
-FROM user_code_files WHERE project=$1 AND path=$2`, project, q.Get("file_path"))
+		return s.codeJSON(ctx, `SELECT COALESCE((SELECT json_build_object('definitions',definitions,'imports',imports,'calls',calls)
+FROM user_code_files WHERE project=$1 AND path=$2), '{"definitions":[],"imports":[],"calls":[]}'::json)::text`, project, q.Get("file_path"))
 	case "/v1/code/search", "/v1/code/hybrid", "/v1/code/context":
 		return s.searchCode(ctx, project, q.Get("query"), limit)
 	case "/v1/code/blast-radius":
@@ -73,16 +79,32 @@ FROM user_code_files WHERE project=$1 AND path=$2`, project, q.Get("file_path"))
 // The same extracted definitions and calls serve callers, blast radius and
 // retrieval expansion. Edges never join symbols across projects, and all hits
 // carry the source file rather than inventing personal memories from code.
-const codeCallEdges = `SELECT DISTINCT caller.project,caller.path AS source,callee.path AS target
-FROM user_code_files caller CROSS JOIN LATERAL jsonb_array_elements(caller.calls) c
-JOIN user_code_files callee ON callee.project=caller.project AND callee.path<>caller.path
-CROSS JOIN LATERAL jsonb_array_elements(callee.definitions) d
-WHERE c->>'callee'=d->>'name'
+// Extract each file's symbols once before joining. Joining files first expands
+// every caller against every definition in its repository on every search.
+// Only edges touching retrieval seeds (or the requested file) are materialized.
+const codeCallEdges = `WITH files AS MATERIALIZED (
+ SELECT project,path,calls,definitions,imports,module_identity FROM user_code_files
+ WHERE project IN (SELECT project FROM anchors)
+), refs AS MATERIALIZED (
+ SELECT project,path,c->>'callee' AS name,'symbol' AS kind FROM files CROSS JOIN LATERAL jsonb_array_elements(calls) c
+ UNION ALL
+ SELECT project,path,imp,'module' FROM files CROSS JOIN LATERAL jsonb_array_elements_text(imports) imp
+), targets AS MATERIALIZED (
+ SELECT project,path,d->>'name' AS name,'symbol' AS kind FROM files CROSS JOIN LATERAL jsonb_array_elements(definitions) d
+ UNION ALL
+ SELECT project,path,module_identity,'module' FROM files WHERE module_identity<>''
+ UNION ALL
+ SELECT project,path,module_identity||'.__init__','module' FROM files WHERE module_identity<>''
+)
+SELECT DISTINCT r.project,r.path AS source,t.path AS target
+FROM anchors a JOIN refs r USING(project,path)
+JOIN targets t ON t.project=r.project AND t.name=r.name AND t.kind=r.kind
+WHERE t.path<>r.path
 UNION
-SELECT caller.project,caller.path,callee.path FROM user_code_files caller
-CROSS JOIN LATERAL jsonb_array_elements_text(caller.imports) imp
-JOIN user_code_files callee ON callee.project=caller.project AND callee.path<>caller.path
-WHERE callee.module_identity<>'' AND (imp=callee.module_identity OR imp=callee.module_identity||'.__init__')`
+SELECT DISTINCT r.project,r.path,t.path
+FROM anchors a JOIN targets t USING(project,path)
+JOIN refs r ON r.project=t.project AND r.name=t.name AND r.kind=t.kind
+WHERE t.path<>r.path`
 
 func (s *postgresDataStore) searchCode(ctx context.Context, project, query string, limit int) (json.RawMessage, error) {
 	vector, serving := "", ""
@@ -105,6 +127,7 @@ func (s *postgresDataStore) searchCode(ctx context.Context, project, query strin
  THEN 1-(embedding <=> NULLIF($5,'')::vector)>0.3 ELSE false END
  ORDER BY rank DESC,project,path LIMIT 32
 ), seeds AS (SELECT * FROM lexical UNION ALL SELECT * FROM dense),
+ anchors AS MATERIALIZED (SELECT DISTINCT project,path FROM seeds WHERE $4),
  edges AS (`+codeCallEdges+`), expanded AS (
  SELECT e.project,CASE WHEN e.source=l.path THEN e.target ELSE e.source END AS path,
  max(l.rank)*0.5 AS rank FROM seeds l JOIN edges e ON e.project=l.project AND (e.source=l.path OR e.target=l.path)
@@ -127,11 +150,67 @@ func (s *postgresDataStore) searchCode(ctx context.Context, project, query strin
 }
 
 func (s *postgresDataStore) blastCode(ctx context.Context, project, file string) (json.RawMessage, error) {
-	return s.codeJSON(ctx, `WITH edges AS (`+codeCallEdges+`)
-SELECT json_build_object('file',$2::text,'project',p.name,'generation',p.generation,'freshness','current','resolved',true,
+	return s.codeJSON(ctx, `WITH anchors AS MATERIALIZED (SELECT $1::text AS project,$2::text AS path), edges AS (`+codeCallEdges+`)
+SELECT COALESCE((SELECT json_build_object('file',$2::text,'project',p.name,'generation',p.generation,'freshness','current','resolved',true,
 'dependency_edges',COALESCE((SELECT json_agg(json_build_object('identity',e.target,'provenance','code_structure','confidence','structural','project',p.name,'generation',p.generation,'freshness','current')) FROM edges e WHERE e.project=p.name AND e.source=$2),'[]'::json),
 'dependent_edges',COALESCE((SELECT json_agg(json_build_object('path',e.source,'provenance','code_structure','confidence','structural','project',p.name,'generation',p.generation,'freshness','current')) FROM edges e WHERE e.project=p.name AND e.target=$2),'[]'::json),
 'dependents',COALESCE((SELECT json_agg(e.source) FROM edges e WHERE e.project=p.name AND e.target=$2),'[]'::json),
 'dependencies',COALESCE((SELECT json_agg(e.target) FROM edges e WHERE e.project=p.name AND e.source=$2),'[]'::json))::text
-FROM user_code_projects p JOIN user_code_files f ON f.project=p.name WHERE p.name=$1 AND f.path=$2`, project, file)
+FROM user_code_projects p JOIN user_code_files f ON f.project=p.name WHERE p.name=$1 AND f.path=$2),
+json_build_object('file',$2::text,'project',$1::text,'error','source file is not in the published index','resolved',false,'dependency_edges','[]'::json,'dependent_edges','[]'::json,'dependents','[]'::json,'dependencies','[]'::json)::text)`, project, file)
+}
+
+// Source recovery reads the published generation, including detached uploads.
+// No supplied path is opened on the server's filesystem.
+func (s *postgresDataStore) codeSpan(ctx context.Context, project string, req CodeIndexRequest) (json.RawMessage, error) {
+	fail := func(message string) (json.RawMessage, error) { return json.Marshal(map[string]any{"error": message}) }
+	if project == "" || !validCodePath(req.FilePath) {
+		return fail("invalid project or source path")
+	}
+	var content string
+	var generation int64
+	err := s.db.QueryRow(ctx, `SELECT f.content,p.generation FROM user_code_files f JOIN user_code_projects p ON p.name=f.project WHERE f.project=$1 AND f.path=$2 AND p.generation>0`, project, req.FilePath).Scan(&content, &generation)
+	if store.IsNoRows(err) {
+		return fail("source file is not in the published index")
+	}
+	if err != nil {
+		return nil, err
+	}
+	start, end, max := req.LineStart, req.LineEnd, req.MaxLines
+	if start < 1 {
+		start = 1
+	}
+	if end < start {
+		end = start
+	}
+	if max <= 0 || max > 400 {
+		max = 400
+	}
+	clamped := end-start >= max
+	if clamped {
+		end = start + max - 1
+	}
+	lines := strings.SplitAfter(content, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	var out strings.Builder
+	emitted := 0
+	truncated := false
+	for i := start - 1; i < len(lines) && i < end; i++ {
+		if out.Len()+len(lines[i]) > 64*1024 {
+			truncated = true
+			break
+		}
+		out.WriteString(lines[i])
+		emitted++
+	}
+	if clamped && end < len(lines) {
+		truncated = true
+	}
+	actualEnd := 0
+	if emitted > 0 {
+		actualEnd = start + emitted - 1
+	}
+	return json.Marshal(map[string]any{"project": project, "file_path": req.FilePath, "line_start": start, "line_end": actualEnd, "line_count": emitted, "truncated": truncated, "content": out.String(), "source_version": fmt.Sprintf("%x", sha256.Sum256([]byte(content))), "generation": generation, "freshness": "published"})
 }

--- a/server-go/modules/workspace/runner_io.go
+++ b/server-go/modules/workspace/runner_io.go
@@ -83,6 +83,7 @@ type rendezvous struct {
 	// makes this unambiguous: there is only ever one stream to pull from.
 	inflight *exchange
 	closed   bool
+	lastPoll time.Time
 	done     chan struct{}
 }
 
@@ -111,6 +112,19 @@ func (r *rendezvous) close() {
 	close(r.done)
 }
 
+// Registration records an authorized tree; only polling proves that a client
+// is serving it. Otherwise a submit pins a shared RPC slot for ten minutes.
+func (r *rendezvous) markServing() {
+	r.mu.Lock()
+	r.lastPoll = time.Now()
+	r.mu.Unlock()
+}
+func (r *rendezvous) hasLiveRunner() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.closed && !r.lastPoll.IsZero() && time.Since(r.lastPoll) < time.Minute
+}
+
 func (r *rendezvous) isClosed() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -126,7 +140,7 @@ func (r *rendezvous) submit(invocation bus.ModuleInvocation, payload []byte) (
 	item := &exchange{payload: payload, chunks: make(chan chunk, ioChunkBuffer)}
 
 	for {
-		if invocation.Cancelled() || r.isClosed() {
+		if invocation.Cancelled() || !r.hasLiveRunner() {
 			return nil, false, false
 		}
 		select {
@@ -186,6 +200,7 @@ func (r *rendezvous) take(invocation bus.ModuleInvocation, item *exchange) ([]by
 // it reports cancelled rather than OK-with-nothing because cancellation
 // precedence is the bus's convention, not this module's to reinterpret.
 func (r *rendezvous) poll(invocation bus.ModuleInvocation) ([]byte, bool) {
+	r.markServing()
 	for {
 		if r.isClosed() {
 			return nil, false
@@ -286,6 +301,9 @@ func handleRunnerIO(invocation bus.ModuleInvocation, request []byte) ([]byte, bu
 
 	switch op {
 	case IOOpSubmit:
+		if !point.hasLiveRunner() {
+			return nil, bus.ModuleStatusCapabilityAbsent
+		}
 		result, more, ok := point.submit(invocation, payload)
 		if !ok {
 			return nil, bus.ModuleStatusCancelled

--- a/server-go/modules/workspace/runner_io_test.go
+++ b/server-go/modules/workspace/runner_io_test.go
@@ -44,6 +44,7 @@ func ioFull(op byte, id string, payload []byte) ([]byte, bool, bus.ModuleStatus)
 func TestRunnerIOCarriesAnOpToTheClientAndItsResultBack(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -107,6 +108,7 @@ func TestRunnerIORefusesATreeNobodyIsServing(t *testing.T) {
 func TestRunnerIOReleasesASubmitterWhenTheClientLeaves(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	done := make(chan bus.ModuleStatus, 1)
 	go func() {
@@ -135,6 +137,7 @@ func TestRunnerIOReleasesASubmitterWhenTheClientLeaves(t *testing.T) {
 func TestRunnerIOElapsedPollReportsCancelledSoTheClientRepolls(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	// DeadlineNS 1 is already past, so the wait ends immediately.
 	_, status := Handle(bus.ModuleInvocation{StageID: StageRunnerIO, DeadlineNS: 1},
@@ -150,6 +153,7 @@ func TestRunnerIOElapsedPollReportsCancelledSoTheClientRepolls(t *testing.T) {
 func TestRunnerIOStreamsAResultInChunks(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	type outcome struct {
 		chunks []string
@@ -220,6 +224,7 @@ func TestRunnerIOStreamsAResultInChunks(t *testing.T) {
 func TestRunnerIOPartialKeepsTheClaimAndFinalReleasesIt(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	go func() { _, _, _ = ioFull(IOOpSubmit, "/srv/repo", []byte("op")) }()
 
@@ -250,6 +255,7 @@ func TestRunnerIOPartialKeepsTheClaimAndFinalReleasesIt(t *testing.T) {
 func TestRunnerIORejectsAnUnclaimedResponse(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 	if _, status := io(IOOpRespond, "/srv/repo", []byte("result")); status != bus.ModuleStatusInvalidRequest {
 		t.Fatalf("unclaimed respond status = %d", status)
 	}
@@ -258,6 +264,7 @@ func TestRunnerIORejectsAnUnclaimedResponse(t *testing.T) {
 func TestRunnerIORejectsInvalidEnvelope(t *testing.T) {
 	reset()
 	call(t, RunnerOpRegister, "/srv/repo")
+	runnerFor("/srv/repo").markServing() // model a client that has already polled
 
 	short := ioRequest(IOOpPoll, "/srv/repo", nil)[:ioHeaderLen-1]
 	if _, status := Handle(bus.ModuleInvocation{StageID: StageRunnerIO}, short); status != bus.ModuleStatusInvalidRequest {
@@ -279,5 +286,22 @@ func TestRunnerIORejectsInvalidEnvelope(t *testing.T) {
 	if _, status := Handle(bus.ModuleInvocation{StageID: StageRunnerIO},
 		ioRequest(IOOpPoll, strings.Repeat("a", runnerIDMax+1), nil)); status != bus.ModuleStatusInvalidRequest {
 		t.Fatalf("oversized-id status = %d", status)
+	}
+}
+
+func TestRegisteredWorkspaceWithoutPollerFailsPromptly(t *testing.T) {
+	reset()
+	call(t, RunnerOpRegister, "/srv/offline")
+	started := time.Now()
+	if _, status := io(IOOpSubmit, "/srv/offline", []byte("rev-parse")); status != bus.ModuleStatusCapabilityAbsent {
+		t.Fatalf("offline runner status: %v", status)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatal("offline runner occupied the RPC pool")
+	}
+	point := runnerFor("/srv/offline")
+	point.lastPoll = time.Now().Add(-2 * time.Minute)
+	if _, status := io(IOOpSubmit, "/srv/offline", []byte("rev-parse")); status != bus.ModuleStatusCapabilityAbsent {
+		t.Fatalf("stale runner status: %v", status)
 	}
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -1440,7 +1440,7 @@ test-transport-artifact:
 	@python3 ../tests/test_transport_artifact.py
 
 memory-retrieval-eval-check:
-	cd ../server-go && AIMEE_MEMORY_EVAL_REQUIRED=1 go test -race -count=1 -v ./modules/memory -run '^(TestRetrievalCorpus|TestPersonalMemoryPrivacyRegression|TestContentGateEmitsCleanVerdict|TestPrivateCodeIndexPublicationAndFusion|TestKBGraphFusionUsesInstancePolicyAndVisibility|TestCodeVectorsRejectStaleContentAndModel)$$'
+	cd ../server-go && AIMEE_MEMORY_EVAL_REQUIRED=1 go test -race -count=1 -v ./modules/memory -run '^(TestRetrievalCorpus|TestPersonalMemoryPrivacyRegression|TestContentGateEmitsCleanVerdict|TestPrivateCode.*|TestKBGraphFusionUsesInstancePolicyAndVisibility|TestCodeVectorsRejectStaleContentAndModel)$$'
 
 # Virtual-context long-session benchmark gate: deterministic compression,
 # stub answerability, and baseline-vs-compacted late-turn accuracy (AC#4).

--- a/src/aimee_sha256.c
+++ b/src/aimee_sha256.c
@@ -6,6 +6,9 @@
  */
 #include "headers/aimee_sha256.h"
 
+/* The low-level context owns no provider state. Audit writers may still finish
+ * during process teardown, after OpenSSL's global provider cleanup has run. */
+#define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/sha.h>
 
 int aimee_sha256_raw(const void *data, size_t len, unsigned char out[32])
@@ -15,7 +18,10 @@ int aimee_sha256_raw(const void *data, size_t len, unsigned char out[32])
    /* A NULL input hashes the empty string, preserving the contract of the
     * workflows-owned wfe_sha256_raw() this replaces. */
    const unsigned char *in = data ? (const unsigned char *)data : (const unsigned char *)"";
-   SHA256(in, data ? len : 0, out);
+   SHA256_CTX ctx;
+   if (SHA256_Init(&ctx) != 1 || SHA256_Update(&ctx, in, data ? len : 0) != 1 ||
+       SHA256_Final(out, &ctx) != 1)
+      return -1;
    return 0;
 }
 

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -64,6 +64,13 @@ static int code_build_manifest(const char *name)
 /* A file is wanted if it is code by extension OR a build manifest by name. */
 static int code_file_wanted(const char *name)
 {
+   const char *slash = strrchr(name, '/');
+   const char *base = slash ? slash + 1 : name;
+   /* Hidden configuration can carry credentials. The private index rejects
+    * it; sending it would abort publication of the entire repository. Keep
+    * the explicit build manifest accepted by both collectors and stores. */
+   if (base[0] == '.' && strcmp(base, ".gitmodules") != 0)
+      return 0;
    return code_ext_ok(name) || code_build_manifest(name);
 }
 

--- a/src/headers/code_span.h
+++ b/src/headers/code_span.h
@@ -32,4 +32,9 @@
 cJSON *code_span_read(const char *project, const char *project_root, const char *file_path,
                       int line_start, int line_end, int max_lines);
 
+/* Private indexes serve published source snapshots without accessing a client path.
+ * Registered at startup; the filesystem/provider path remains the default. */
+typedef cJSON *(*code_span_index_reader_fn)(const char *, const char *, int, int, int);
+void code_span_set_index_reader(code_span_index_reader_fn reader);
+
 #endif /* DEC_CODE_SPAN_H */

--- a/src/modules/guardrails/guardrails.c
+++ b/src/modules/guardrails/guardrails.c
@@ -448,7 +448,7 @@ int is_sensitive_file(const char *path)
    return policy_list_matches_substring(&g_policy.sensitive_patterns, path);
 }
 
-classification_t classify_path(const char *file_path)
+classification_t classify_path_sensitivity(const char *file_path)
 {
    classification_t result;
    memset(&result, 0, sizeof(result));
@@ -487,6 +487,15 @@ classification_t classify_path(const char *file_path)
       snprintf(result.reason, sizeof(result.reason), "database file");
       return result;
    }
+
+   return result;
+}
+
+classification_t classify_path(const char *file_path)
+{
+   classification_t result = classify_path_sensitivity(file_path);
+   if (result.severity >= SEV_RED)
+      return result;
 
    /* Check blast radius via the structural code index (shared resolver — also
     * used by the §7 blast-radius advisory; see guardrails_blast_radius.c). */
@@ -655,7 +664,7 @@ const char *guardrails_check_sensitive_path(const char *path, char *resolved_buf
          return "error: path too long";
    }
 
-   classification_t classification = classify_path(canonical);
+   classification_t classification = classify_path_sensitivity(canonical);
    if (classification.severity >= SEV_RED)
       return "error: access to sensitive path denied";
 

--- a/src/modules/guardrails/guardrails.h
+++ b/src/modules/guardrails/guardrails.h
@@ -130,6 +130,8 @@ int is_sensitive_file(const char *path);
 
 /* Classify a file path by sensitivity and blast radius. */
 classification_t classify_path(const char *file_path);
+/* Sensitivity excludes edit blast radius; read access must not depend on callers. */
+classification_t classify_path_sensitivity(const char *file_path);
 
 /* Pre-tool check. Returns exit code:
  *   0 = allow (msg_buf may contain warnings)

--- a/src/server/code_span.c
+++ b/src/server/code_span.c
@@ -15,6 +15,13 @@
  * of pathologically long lines must not blow the envelope/recovery budget. */
 #define CODE_SPAN_MAX_BYTES (64 * 1024)
 
+static code_span_index_reader_fn index_reader;
+
+void code_span_set_index_reader(code_span_index_reader_fn reader)
+{
+   index_reader = reader;
+}
+
 static cJSON *span_err(const char *msg)
 {
    cJSON *o = cJSON_CreateObject();
@@ -54,6 +61,24 @@ cJSON *code_span_read(const char *project, const char *project_root, const char 
       return span_err("project root is not an absolute path");
    if (has_ctrl_chars(file_path))
       return span_err("file_path contains control characters");
+
+   if (index_reader)
+   {
+      const char *relative = file_path;
+      if (file_path[0] == '/')
+      {
+         if (!path_within_root(file_path, project_root))
+            return span_err("path resolves outside the project workspace");
+         relative = file_path + strlen(project_root);
+         while (*relative == '/')
+            ++relative;
+      }
+      /* Preserve sensitive-file policy; the index supplies bytes, never a
+       * filesystem path or a symlink target. Its reader validates traversal. */
+      if (classify_path_sensitivity(relative).severity >= SEV_RED)
+         return span_err("error: access to sensitive path denied");
+      return index_reader(project, relative, line_start, line_end, max_lines);
+   }
 
    if (max_lines <= 0)
       max_lines = 400;

--- a/src/server/module_stage_adapters.c
+++ b/src/server/module_stage_adapters.c
@@ -116,9 +116,21 @@ cJSON *server_module_memory_data(const cJSON *request)
       free(encoded);
       return NULL;
    }
+   uint64_t budget = MODULE_MEMORY_DATA_DEADLINE_NS;
+   const cJSON *operation = cJSON_GetObjectItemCaseSensitive(request, "operation");
+   if (cJSON_IsString(operation) && strcmp(operation->valuestring, "code-index") == 0)
+   {
+      const cJSON *index = cJSON_GetObjectItemCaseSensitive(request, "code_index");
+      const cJSON *route = cJSON_GetObjectItemCaseSensitive(index, "route");
+      /* Publication builds the search index atomically. A repository scan must
+       * not inherit the five-second budget for an individual memory lookup. */
+      budget = cJSON_IsString(route) && strcmp(route->valuestring, "/v1/code/scan") == 0
+                   ? 120ULL * 1000000000ULL
+                   : 30ULL * 1000000000ULL;
+   }
    int rc = call_module_with_budget(AIMEE_MEMORY_EVENT_DATA, AIMEE_MEMORY_STAGE_DATA, encoded,
                                     (uint32_t)request_len, response, AIMEE_MODULE_MESSAGE_MAX_BODY,
-                                    &response_len, MODULE_MEMORY_DATA_DEADLINE_NS);
+                                    &response_len, budget);
    free(encoded);
    cJSON *decoded = NULL;
    if (rc == 0 && response_len > 0)

--- a/src/server/server_code_index.c
+++ b/src/server/server_code_index.c
@@ -1,6 +1,7 @@
 /* Private code indexing: reuse the shipping collector and language extractors;
  * persist through the existing memory and PostgreSQL modules. */
 #include "server_code_index.h"
+#include "code_span.h"
 #include "module_stage_adapters.h"
 #include "aimee.h"
 #include "index.h"
@@ -80,7 +81,7 @@ static cJSON *call_code(const char *route, const cJSON *body, const cJSON *file)
    cJSON_AddStringToObject(request, "operation", "code-index");
    cJSON *index = cJSON_AddObjectToObject(request, "code_index");
    cJSON_AddStringToObject(index, "route", route);
-   const char *fields[] = {"project", "root_path", "phase", "scan_id"};
+   const char *fields[] = {"project", "root_path", "phase", "scan_id", "file_path"};
    for (unsigned i = 0; i < sizeof(fields) / sizeof(fields[0]); ++i)
    {
       const cJSON *v = cJSON_GetObjectItemCaseSensitive(body, fields[i]);
@@ -90,6 +91,13 @@ static cJSON *call_code(const char *route, const cJSON *body, const cJSON *file)
    const cJSON *count = cJSON_GetObjectItemCaseSensitive(body, "expected_files");
    if (cJSON_IsNumber(count))
       cJSON_AddNumberToObject(index, "expected_files", count->valuedouble);
+   const char *line_fields[] = {"line_start", "line_end", "max_lines"};
+   for (unsigned i = 0; i < sizeof(line_fields) / sizeof(line_fields[0]); ++i)
+   {
+      const cJSON *v = cJSON_GetObjectItemCaseSensitive(body, line_fields[i]);
+      if (cJSON_IsNumber(v))
+         cJSON_AddNumberToObject(index, line_fields[i], v->valuedouble);
+   }
    if (file)
    {
       cJSON *files = cJSON_AddArrayToObject(index, "files");
@@ -100,6 +108,24 @@ static cJSON *call_code(const char *route, const cJSON *body, const cJSON *file)
    cJSON *payload = cJSON_DetachItemFromObjectCaseSensitive(reply, "payload");
    cJSON_Delete(reply);
    return payload;
+}
+
+static cJSON *local_code_span(const char *project, const char *path, int start, int end, int max)
+{
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "project", project);
+   cJSON_AddStringToObject(body, "file_path", path);
+   cJSON_AddNumberToObject(body, "line_start", start);
+   cJSON_AddNumberToObject(body, "line_end", end);
+   cJSON_AddNumberToObject(body, "max_lines", max);
+   cJSON *reply = call_code("/v1/code/span", body, NULL);
+   cJSON_Delete(body);
+   if (!reply)
+   {
+      reply = cJSON_CreateObject();
+      cJSON_AddStringToObject(reply, "error", "published source index unavailable");
+   }
+   return reply;
 }
 
 static char *local_code(const char *route, const void *body_v, int *status)
@@ -247,6 +273,8 @@ static void *scan_main(void *unused)
 void server_code_index_start(void)
 {
    kb_client_set_local_code_provider(local_code);
+   if (kb_client_local_code_enabled())
+      code_span_set_index_reader(local_code_span);
    atomic_store(&scan_stop, 0);
    scan_started = pthread_create(&scan_thread, NULL, scan_main, NULL) == 0;
 }

--- a/src/tests/test_audit_worm_chain.c
+++ b/src/tests/test_audit_worm_chain.c
@@ -166,6 +166,8 @@ static void test_ckpt_mac(void)
    printf("  test_ckpt_mac: ok\n");
 }
 
+#include <openssl/crypto.h>
+
 int main(void)
 {
    test_hex32();
@@ -173,6 +175,12 @@ int main(void)
    test_row_hash_field_sensitivity();
    test_v2_binds_chronology_and_attribution();
    test_ckpt_mac();
+   /* Late audit writes must retain the same hashes after provider teardown. */
+   OPENSSL_cleanup();
+   test_genesis_row_hash();
+   test_v2_binds_chronology_and_attribution();
+   test_ckpt_mac();
+   printf("audit hashes remain valid after crypto cleanup\n");
    printf("all tests passed\n");
    return 0;
 }

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -301,6 +301,37 @@ static void test_build_manifests_collected_git(void)
 
 /* §6 live: the default-branch tree SHA tracks commits, and the pure change-gate
  * decides when a re-index is warranted. */
+static void test_hidden_files_excluded(void)
+{
+   make_root("hidden-files");
+   write_file("source.c", "int visible(void){return 0;}");
+   write_file(".mcp.json", "{\"token\":\"fixture\"}");
+   write_file("nested/.env.production.json", "{\"secret\":true}");
+   write_file(".golangci.yml", "version: 2");
+   write_file(".gitmodules", "[submodule \"x\"]");
+   write_file("nested/.gitmodules", "[submodule \"y\"]");
+   for (int tracked = 0; tracked < 2; ++tracked)
+   {
+      if (tracked)
+      {
+         git("init -q -b main");
+         git("config user.email t@t");
+         git("config user.name t");
+         git("add -A");
+         git("commit -qm fixture");
+      }
+      reset();
+      code_collect_files_cb(g_root, rec_cb, NULL);
+      assert(has("source.c"));
+      assert(has(".gitmodules"));
+      assert(has("nested/.gitmodules"));
+      assert(!has(".mcp.json"));
+      assert(!has("nested/.env.production.json"));
+      assert(!has(".golangci.yml"));
+   }
+   printf("  test_hidden_files_excluded: ok\n");
+}
+
 static void test_default_branch_sha_tracks_commits(void)
 {
    make_root("sha");
@@ -498,6 +529,7 @@ int main(void)
       printf("  (git unavailable; skipping)\nALL PASS\n");
       return 0;
    }
+   test_hidden_files_excluded();
    test_default_branch_is_canonical();
    test_worktree_optin();
    test_clone_resolves_origin_head();

--- a/src/tests/test_code_span.c
+++ b/src/tests/test_code_span.c
@@ -55,6 +55,14 @@ static int jbool_true(cJSON *o, const char *k)
    return cJSON_IsTrue(v);
 }
 
+static cJSON *published_span(const char *project, const char *path, int start, int end, int max)
+{
+   assert(strcmp(project, "detached") == 0);
+   assert(strcmp(path, "source.c") == 0);
+   assert(start == 2 && end == 3);
+   return cJSON_Parse("{\"content\":\"published source\"}");
+}
+
 int main(void)
 {
    make_root();
@@ -173,5 +181,17 @@ int main(void)
    }
 
    printf("All code_span tests passed.\n");
+   code_span_set_index_reader(published_span);
+   cJSON *published = code_span_read("detached", "/unreadable/client", "source.c", 2, 3, 400);
+   assert(published && strcmp(jstr(published, "content"), "published source") == 0);
+   cJSON_Delete(published);
+   published = code_span_read("detached", "/unreadable/client", "/etc/passwd", 2, 3, 400);
+   assert(published && jstr(published, "error"));
+   cJSON_Delete(published);
+   published = code_span_read("detached", "/unreadable/client", ".env", 2, 3, 400);
+   assert(published && jstr(published, "error"));
+   cJSON_Delete(published);
+   code_span_set_index_reader(NULL);
+   PASS("published index reads need no client filesystem and preserve path denials");
    return 0;
 }

--- a/src/tests/test_module_json_call.c
+++ b/src/tests/test_module_json_call.c
@@ -171,6 +171,24 @@ int main(void)
    cJSON_Delete(memory_request);
    printf("  ok    expired or unavailable memory does not fabricate success\n");
 
+   g_result = AIMEE_MODULE_CALL_OK;
+   memory_request = cJSON_CreateObject();
+   cJSON_AddStringToObject(memory_request, "operation", "code-index");
+   cJSON *index = cJSON_AddObjectToObject(memory_request, "code_index");
+   cJSON_AddStringToObject(index, "route", "/v1/code/scan");
+   g_required_budget_ms = 10000;
+   reply = server_module_memory_data(memory_request);
+   assert(reply && g_deadline < aimee_module_call_deadline_ns(121000));
+   cJSON_Delete(reply);
+   cJSON_ReplaceItemInObjectCaseSensitive(index, "route", cJSON_CreateString("/v1/code/hybrid"));
+   reply = server_module_memory_data(memory_request);
+   assert(reply && g_deadline < aimee_module_call_deadline_ns(31000));
+   cJSON_Delete(reply);
+   g_required_budget_ms = 31000;
+   assert(!server_module_memory_data(memory_request));
+   cJSON_Delete(memory_request);
+   printf("  ok    code publication and retrieval have separate bounded budgets\n");
+
    printf("module_json_call: all tests passed\n");
    return 0;
 }

--- a/tests/baselines/refactor/index.json
+++ b/tests/baselines/refactor/index.json
@@ -223,11 +223,11 @@
         },
         {
           "path": "frontend/package-lock.json",
-          "sha256": "1ddf1843077b2514cbbc9f90fe013a0b4a926e74eb4b737a65f510b33b43d87f"
+          "sha256": "59f57fcf533abdd286d43ab09435e6a73832ae1c5812e929029fab434f1117fd"
         },
         {
           "path": "frontend/package.json",
-          "sha256": "cf23035508de05af1ec6663d888b1cd651a70362864649b26a9c14f621800067"
+          "sha256": "5c2c8b93f5587d9c1aa37267ad8b1352d4ddffa475d6b36006c44690b517cf5e"
         },
         {
           "path": "install.ps1",
@@ -567,7 +567,7 @@
         },
         {
           "path": "src/headers/code_span.h",
-          "sha256": "4308f71cd781bec8c677c6481929b90530cd8ed73966087bce3996f1913eab7f"
+          "sha256": "16937cae855af67c0bda923c2618a518d67c2bcbf0df7c2e81d0e28baafc1f96"
         },
         {
           "path": "src/headers/code_treesitter.h",
@@ -1904,7 +1904,7 @@
       ]
     },
     "public-symbols": {
-      "sha256": "d6fe33e7c7b2c9806dec092d93d5d5317c48be0746529ca285b97d100124a23c",
+      "sha256": "8141e8fb95f259008f32e5bee0edcf94d26d60f0d8486873de6bf9ef1f5ac91a",
       "source": "complete normalized contents of public-headers"
     },
     "routes": {


### PR DESCRIPTION
Promote the merged 0.4.4 fixes from testing (`ec4717297e`) to main. This restores first-boot setup, clone progress and recovery, private index publication and queries, published source spans, inactive-runner admission, and deterministic audit hashing during shutdown.

The promotion freezes the reviewed public-surface baseline and bundled application source lock, and records the completed CI evidence. It adds no application changes beyond #2975. The release script confirms **0.4.4**, following v0.4.3.

Validation:
- All 58 checks passed on the feature PR's final application/test tree, including Linux/Windows/macOS builds, full ASan/UBSan and script suites, PostgreSQL/workflow tests, and all four container topologies with LUKS recovery and published-KB upgrade/rollback.
- The local 0.4.4-rc1 image remains healthy on .103: 74 published projects, 23,022 indexed files, and 90 passing post-restart checks across real code and memories. Real PAM GUI login and interrupted clone-response recovery also passed.
- Both frozen snapshots and documentation checks pass. The main-targeting CI run validates the promotion and its module boundaries.

[Validation report](docs/validation/release-0.4.4-2026-09-08.md) includes live evidence, hashes, CI URLs and test limits. Existing accounts, client identities, memories and volumes are retained; no database migration is required. Boundary review covers the private-index C/Go contract, sensitive-path policy and audit durability. The separate release environment controls publication after main promotion.