### PR TITLE
Fix worktree enforcement for non-Git work and honor the off switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ modules supervise the standard modules around the existing C resource and event-
   cheapest model that fits the role. See [Delegates](docs/DELEGATES.md).
 - **Guardrails before execution.** Secret paths, unsafe writes, worktree escapes, and untrusted MCP
   packages are checked first, and delegate sandboxes run with no network and no credentials. See
-  [Security](docs/SECURITY.md).
+  [Security](docs/SECURITY.md). Git worktree isolation can be disabled in instance settings;
+  ordinary non-Git folders do not require a worktree.
 - **One bus, one audit trail.** Every governed action, memory write, guardrail decision and vault
   read crosses one sequenced tap into a WORM ledger. See [Event bus](docs/EVENT_BUS.md).
 - **Any provider.** OpenAI, Anthropic, Gemini, Mistral, Bedrock, and local OpenAI-compatible servers

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -8,7 +8,9 @@ The 0.4.4 candidate repairs first-boot setup, clone progress, private index publ
 retrieval, detached runner admission, and audit hashing during shutdown. See the
 [release validation](validation/release-0.4.4-2026-09-08.md) for tested configurations and remaining
 release gates. Detached source spans read the last published snapshot; workspace registration
-alone does not start a client runner.
+alone does not start a client runner. The worktree repair for this release allows non-Git
+document work and honors `require_session_worktree=false` across startup, hooks, and native
+writes; it requires updated client and server binaries.
 
 ## Runtime
 

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -41,6 +41,13 @@ Connection precedence is:
 
 The client does not hold DB1, DB2, server vault keys, workflow state, or KB credentials.
 
+Git worktree isolation is enabled by default. Set `require_session_worktree` to
+`false` in the instance settings to disable automatic worktree creation, hook path
+routing, and worktree write restrictions. Ordinary non-Git folders are writable
+with isolation enabled. A remote hook carries the client's filesystem scope check
+under its authenticated session identity; the server does not infer the client's
+Git state from its own filesystem. Other write policies still apply.
+
 ## Workspaces and uploads
 
 ```bash

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,11 +1,15 @@
 # What's new
 
-## 0.4.4 repairs setup and private indexing
+## 0.4.4 repairs setup, private indexing, and worktree enforcement
 
 0.4.4 is a patch for existing 0.4.x installations. Keep the instance volumes, account,
 client identities, and memories when upgrading. Release validation is recorded in
 [the 0.4.4 report](validation/release-0.4.4-2026-09-08.md).
 
+- Ordinary non-Git folders no longer require a worktree. The existing
+  `require_session_worktree=false` setting disables automatic worktree creation,
+  hook path routing, and worktree write restrictions. Remote hooks use the authenticated
+  client’s filesystem scope and recover their identity after a server restart.
 - A fresh account opens the setup wizard even when the browser remembers dismissing setup
   on a previous installation.
 - Organization cloning reports each repository as it completes. If a response is lost,

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -99,7 +99,7 @@ The everyday runtime surface. Deploy-time, advanced-tuning, and dev-only keys ar
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
 | `require_aimee_git` | bool | Block a delegate from running `git` or `gh` in a shell (reads included) and redirect git/forge work to aimee's `git_*` tools, which execute on aimee-server where the forge credential stays in-process; delegates are also spawned without git/gh credentials. Note the env strip also drops SSH_AUTH_SOCK (no agent-backed SSH to any host) and neuters the global/system git config (default on). |
 | `require_aimee_memory` | bool | Block agent writes to external file-based agent-memory stores (~/.claude/projects/<slug>/memory/...) and redirect durable memories into aimee's memory system via `aimee memory store` (default on). |
-| `require_session_worktree` | bool | Fail closed on mutating ops outside this session's isolated worktree (session-isolation guard; default on). |
+| `require_session_worktree` | bool | Isolate Git work in a session worktree (default on). False disables automatic creation, routing, and worktree write restrictions. Non-Git folders do not require a worktree. |
 | `subagent_ban_enabled` | bool | Prevent provider-native sub-agent tools when an aimee delegate is available, and install the matching client guardrails (default on). |
 | `synthesis_endpoint` | string | OpenAI-compatible synthesis endpoint. Empty disables synthesis; managed local profiles supply the model-specific sidecar endpoint over mTLS. |
 | `synthesis_model` | string | Model identity requested from the synthesis endpoint. A managed local sidecar fixes the model family selected by its image. |

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -360,7 +360,7 @@ export const FIELD_HELP: Record<string, string> = {
   integrity_dry_run:
     "Run the integrity gate in shadow mode — it logs but never blocks. On by default, so enabling the gate is safe to try first.",
   require_session_worktree:
-    "Refuse file-changing tools unless they run inside an aimee-managed worktree, forcing each session onto its own branch. Off by default.",
+    "Isolate Git work in a session worktree. On by default. Off disables automatic worktree creation, path routing, and worktree write restrictions. Non-Git folders do not need a worktree.",
   fidelity_check_enabled:
     "Run a judge that checks answers against their cited evidence. Off by default; needs evidence logging and context pre-injection on first.",
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -258,8 +258,9 @@ CFG_KEY_DESC = {
     "clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the "
     "prompt + history; the context-economizer (aggressive tier) compresses older results to keep "
     "history bounded.",
-    "require_session_worktree": "Fail closed on mutating ops outside this session's isolated worktree "
-    "(session-isolation guard; default on).",
+    "require_session_worktree": "Isolate Git work in a session worktree (default on). "
+    "False disables automatic creation, routing, and worktree write restrictions. "
+    "Non-Git folders do not require a worktree.",
     "subagent_ban_enabled": "Prevent provider-native sub-agent tools when an aimee delegate is "
     "available, and install the matching client guardrails (default on).",
     "require_aimee_memory": "Block agent writes to external file-based agent-memory stores "

--- a/scripts/test-thin-client-remote-exclusive.py
+++ b/scripts/test-thin-client-remote-exclusive.py
@@ -164,16 +164,18 @@ def run_client(
         (home / ".claude").mkdir(exist_ok=True)
     else:
         env["AIMEE_NO_CLIENT_INTEGRATIONS"] = "1"
-    for key in ("AIMEE_SERVER_URL", "AIMEE_SERVER_TOKEN", "AIMEE_TLS_INSECURE"):
+    for key in ("AIMEE_SERVER_URL", "AIMEE_SERVER_TOKEN", "AIMEE_TLS_INSECURE",
+                "AIMEE_SESSION_ID", "CLAUDE_SESSION_ID", "CODEX_THREAD_ID", "AIMEE_HOOK_CLIENT"):
         env.pop(key, None)
     return subprocess.run(
         [str(binary), "--json", *command],
         env=env,
+        cwd=home,
         text=True,
         capture_output=True,
         input='{"tool_name":"Read","tool_input":{},"cwd":"/tmp"}\n'
         if command[:1] == ["hooks"]
-        else "{}\n"
+        else json.dumps({"session_id": "remote-exclusive-start", "cwd": str(home)}) + "\n"
         if command == ["session-start"]
         else None,
         timeout=20,
@@ -239,8 +241,8 @@ def main() -> int:
                 assert RemoteHandler.count() > before, (command, special.stderr)
                 assert sentinel.contacts_after_settle() == 0, f"{command} contacted local UDS"
 
-            # session-start is now local-only, and that is a contract in its own
-            # right: it must reach NEITHER the remote nor the local socket. A
+            # Non-Git session-start without a harness identity is local-only:
+            # it must reach NEITHER the remote nor the local socket. A
             # regression that reintroduced per-client assembly here would show
             # up as a request to one of the two.
             before = RemoteHandler.count()

--- a/scripts/tests/test_thin_client_proxy.py
+++ b/scripts/tests/test_thin_client_proxy.py
@@ -34,6 +34,34 @@ class Peer(http.server.BaseHTTPRequestHandler):
 
     def do_POST(self):
         body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if self.path in ("/v1/cli/manifest", "/v1/config/get", "/v1/hooks/pre", "/v1/hooks/session_start") and not self.server.reject:
+            request = json.loads(body) if body else {}
+            self.server.control_requests.append((self.path, request))
+            if self.path == "/v1/cli/manifest":
+                response = {"manifest_version": 1, "routes": [
+                    {"op": op, "verb": "POST", "path": "/v1/" + op.replace(".", "/")}
+                    for op in ("config.get", "hooks.pre", "hooks.session_start")]}
+            elif self.path == "/v1/config/get":
+                response = {"value": self.server.require_worktree if request.get("key") == "require_session_worktree" else False}
+            elif self.path == "/v1/hooks/session_start":
+                self.server.hook_starts += 1
+                self.server.hook_token = f"{self.server.hook_starts:064x}"
+                response = {"hook_token": self.server.hook_token, "exit_code": 0}
+            else:
+                trusted = self.server.hook_token is not None and request.get("hook_token") == self.server.hook_token
+                allowed = not self.server.require_worktree or (trusted and request.get("client_non_git_workspace") is True)
+                response = {"exit_code": 0 if allowed else 2,
+                            "hook_identity": "trusted" if trusted else "untrusted",
+                            "message": "" if allowed else "worktree required"}
+            payload = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(payload)
+            self.close_connection = True
+            return
         self.server.requests.put((self.path, dict(self.headers), body))
         if self.path == "/v1/responses" and self.server.codex_response:
             self.send_response(200)
@@ -123,6 +151,10 @@ class ThinClientProxyTest(unittest.TestCase):
         Path(self.env["CODEX_HOME"]).mkdir()
         self.peer = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Peer)
         self.peer.requests = queue.Queue()
+        self.peer.control_requests = []
+        self.peer.require_worktree = True
+        self.peer.hook_token = None
+        self.peer.hook_starts = 0
         self.peer.release = threading.Event()
         self.peer.cancelled = threading.Event()
         self.peer.reject = False
@@ -417,6 +449,61 @@ class ThinClientProxyTest(unittest.TestCase):
         self.assertIn("server rejected the client certificate", result.stdout)
         self.assertNotIn("rejected the stored token", result.stdout)
         self.assertEqual((self.root / "tls/client.crt").read_bytes(), original)
+
+    def run_hook(self, cwd, tool="Write", **tool_input):
+        payload = {"session_id": "document-regression", "cwd": str(cwd),
+                   "tool_name": tool, "tool_input": tool_input or {"file_path": "reports/new/report.md"}}
+        return subprocess.run([str(BINARY), "hooks", "pre"], input=json.dumps(payload),
+                              cwd=cwd, env={**self.env, "AIMEE_HOOK_CLIENT": "codex"},
+                              capture_output=True, text=True, timeout=15)
+
+    def test_document_hook_scope_and_identity_recovery_over_mtls(self):
+        self.start_peer(tls=True)
+        result = self.run_hook(self.root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn('"deny"', result.stdout)
+        self.assertEqual(self.peer.hook_starts, 1)
+        self.assertFalse((self.root / ".aimee/worktrees").exists())
+        checks = [request for path, request in self.peer.control_requests if path == "/v1/hooks/pre"]
+        self.assertEqual(len(checks), 2)
+        self.assertTrue(all(request.get("client_non_git_workspace") is True for request in checks))
+        self.assertEqual(checks[-1]["hook_token"], self.peer.hook_token)
+        # Simulate server restart: the process-local authority forgot this token.
+        self.peer.hook_token = None
+        result = self.run_hook(self.root, "Bash", command=f"mkdir -p {self.root}/extracted")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn('"deny"', result.stdout)
+        self.assertEqual(self.peer.hook_starts, 2)
+        # A non-Git cwd must not attest that an absolute Git target is ordinary work.
+        repo = self.root / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        result = self.run_hook(self.root, file_path=str(repo / "new/report.md"))
+        self.assertIn('"deny"', result.stdout)
+        last = [request for path, request in self.peer.control_requests if path == "/v1/hooks/pre"][-1]
+        self.assertNotIn("client_non_git_workspace", last)
+
+    def test_worktree_disabled_skips_launch_and_session_start_provisioning(self):
+        self.start_peer()
+        self.peer.require_worktree = False
+        repo = self.root / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        result = subprocess.run([str(BINARY), "launch", "--", "/bin/pwd"], cwd=repo,
+                                env=self.env, capture_output=True, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(Path(result.stdout.strip()), repo)
+        result = subprocess.run([str(BINARY), "session-start"], cwd=repo,
+                                input=json.dumps({"session_id": "disabled", "cwd": str(repo)}),
+                                env={**self.env, "AIMEE_HOOK_CLIENT": "codex"},
+                                capture_output=True, text=True, timeout=15)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for tool in ("Write", "Read", "Bash"):
+            result = self.run_hook(repo, tool, **({"command": "touch new.txt"} if tool == "Bash" else {"file_path": "new.txt"}))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn('"deny"', result.stdout)
+            self.assertNotIn("updatedInput", result.stdout)
+        self.assertFalse((repo / ".aimee").exists())
 
     def test_gateway_launch_configures_codex_and_owns_proxy_lifetime(self):
         self.start_peer()

--- a/server-go/internal/engine/shipped_workflows_e2e_test.go
+++ b/server-go/internal/engine/shipped_workflows_e2e_test.go
@@ -135,7 +135,11 @@ func runExactShippedWorkflow(t *testing.T, workflowName, wantState, wantPause st
 	go func() { scheduler.Run(ctx); close(done) }()
 	defer func() { cancel(); <-done }()
 
-	deadline := time.Now().Add(25 * time.Second)
+	// These graphs run real Git worktrees and module/PostgreSQL calls, including
+	// a child workflow and parent continuation for build and build-triggered.
+	// Match the native workflow E2E budget so race-instrumented CI has time to
+	// finish every stage; completion and stage-coverage assertions still apply.
+	deadline := time.Now().Add(2 * time.Minute)
 	var item workflowstore.WorkItem
 	for time.Now().Before(deadline) {
 		item, err = store.WorkItem(t.Context(), id)

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -1,3 +1,4 @@
+#include "worktree_scope.h"
 /* cli_attention_guard.c: see cli_attention_guard.h.
  *
  * Per-session attention log lives at $AIMEE_HOME/.cache/attention/<session>.json
@@ -1001,7 +1002,7 @@ int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
          path[n] = '\0';
          char norm[2048];
          attn_lexical_normalize(path, norm, sizeof(norm));
-         if (!attn_path_in_managed_worktree(norm))
+         if (!attn_path_in_managed_worktree(norm) && !worktree_scope_non_git(cwd, norm))
             return 1;
       }
    }
@@ -1031,7 +1032,8 @@ int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
       path[n] = '\0';
       char norm[2048];
       attn_lexical_normalize(path, norm, sizeof(norm));
-      if (!attn_path_in_managed_worktree(norm) && !attn_path_is_harness_state(norm))
+      if (!attn_path_in_managed_worktree(norm) && !attn_path_is_harness_state(norm) &&
+          !worktree_scope_non_git(cwd, norm))
          return 1;
    }
 
@@ -1068,7 +1070,7 @@ int attn_bash_escapes_worktree(const char *bash_cmd, const char *cwd)
                char norm[2048];
                attn_lexical_normalize(path, norm, sizeof(norm));
                if (strncmp(norm, "/dev/null", 9) != 0 && !attn_path_in_managed_worktree(norm) &&
-                   !attn_path_is_harness_state(norm))
+                   !attn_path_is_harness_state(norm) && !worktree_scope_non_git(cwd, norm))
                   return 1;
                a += n;
                continue;
@@ -1578,8 +1580,50 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
    char norm[2048];
    attn_session_isolation_target(file_path, cwd, norm, sizeof(norm));
    if (attn_path_in_managed_worktree(norm) || attn_path_is_harness_state(norm) ||
-       attn_path_is_session_scratch(norm, session_id))
+       attn_path_is_session_scratch(norm, session_id) || worktree_scope_non_git(cwd, norm))
       return 0;
+   return 1;
+}
+
+int attn_tool_in_non_git_workspace(const char *cwd, const char *tool, const cJSON *input)
+{
+   static const char *const cwd_keys[] = {"workdir", "cwd", "working_dir", "working_directory",
+                                          NULL};
+   for (int i = 0; cwd_keys[i]; i++)
+   {
+      const char *value =
+          cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(input, cwd_keys[i]));
+      if (value && value[0])
+      {
+         cwd = value;
+         break;
+      }
+   }
+   if (!worktree_scope_non_git(cwd, NULL))
+      return 0;
+   static const char *const path_keys[] = {"file_path",     "filePath",  "path",
+                                           "notebook_path", "directory", NULL};
+   for (int i = 0; path_keys[i]; i++)
+   {
+      const char *path =
+          cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(input, path_keys[i]));
+      if (path && path[0])
+      {
+         char target[2048];
+         attn_session_isolation_target(path, cwd, target, sizeof(target));
+         if (!worktree_scope_non_git(cwd, target))
+            return 0;
+      }
+   }
+   if (attn_tool_is_shell(tool))
+   {
+      const char *command =
+          cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(input, "command"));
+      if (!command)
+         command = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(input, "cmd"));
+      if (attn_bash_escapes_worktree(command, cwd))
+         return 0;
+   }
    return 1;
 }
 

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -1,4 +1,3 @@
-#include "worktree_scope.h"
 /* cli_attention_guard.c: see cli_attention_guard.h.
  *
  * Per-session attention log lives at $AIMEE_HOME/.cache/attention/<session>.json
@@ -16,6 +15,7 @@
  * (require_session_worktree: false), never something the guarded agent can do.
  */
 #include "cli_attention_guard.h"
+#include "worktree_scope.h"
 #include "cli_session_start.h" /* read_stdin */
 #include "client_config.h"
 #include "client_session_worktree.h"

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1205,6 +1205,35 @@ static int handle_hooks(int argc, char **argv, int json_output)
    }
 
    cJSON *resp = cli_v1_dispatch(req, 5000);
+   /* Hook identities are process-local on the server. A restart (or a resumed
+    * client that missed SessionStart) must not turn ordinary document work back
+    * into a worktree error. Renew once through the authenticated lifecycle route
+    * and retry the same preflight; never trust or forward a caller-supplied token. */
+   const char *identity =
+       cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(resp, "hook_identity"));
+   if (resp && identity && strcmp(identity, "untrusted") == 0 &&
+       cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "client_non_git_workspace")) && sid &&
+       sid[0] && hook_client && hook_client[0])
+   {
+      cJSON *start = cJSON_CreateObject();
+      cJSON_AddStringToObject(start, "method", "hooks.session_start");
+      cJSON_AddStringToObject(start, "session_id", sid);
+      cJSON_AddStringToObject(start, "harness_client", hook_client);
+      cJSON_AddStringToObject(start, "hook_input", "{}");
+      cJSON_AddBoolToObject(start, "nonblocking", 1);
+      cJSON *renewed = cli_v1_dispatch(start, 5000);
+      cJSON_Delete(start);
+      const char *token =
+          cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(renewed, "hook_token"));
+      if (token && hook_session_token_store(aimee_home(), sid, hook_client, token) == 0)
+      {
+         cJSON_DeleteItemFromObjectCaseSensitive(req, "hook_token");
+         cJSON_AddStringToObject(req, "hook_token", token);
+         cJSON_Delete(resp);
+         resp = cli_v1_dispatch(req, 5000);
+      }
+      cJSON_Delete(renewed);
+   }
    cJSON_Delete(req);
    free(stdin_data);
 

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1164,6 +1164,11 @@ static int handle_hooks(int argc, char **argv, int json_output)
    cJSON_AddStringToObject(req, "tool_name", tool_name);
    cJSON_AddStringToObject(req, "tool_input", tool_input);
    cJSON_AddStringToObject(req, "cwd", cwd);
+   if (strcmp(phase, "pre") == 0 &&
+       attn_tool_in_non_git_workspace(hook_cwd, tool_name,
+                                      local_updated ? local_updated : hook_input))
+      cJSON_AddBoolToObject(req, "client_non_git_workspace", 1);
+
    if (sid && sid[0])
       cJSON_AddStringToObject(req, "session_id", sid);
 

--- a/src/client_session_worktree.c
+++ b/src/client_session_worktree.c
@@ -6,6 +6,7 @@
  * Every git invocation here is shell-free (fork/execvp): session ids and repo
  * paths reach argv directly, so there is nothing to quote or inject. */
 #include "client_session_worktree.h"
+#include "client_config.h"
 #include "session_worktree_key.h"
 #include <errno.h>
 #include <signal.h>
@@ -810,6 +811,8 @@ int client_session_worktree_ensure_at(const char *sid, const char *cwd, char *ou
    if (!out || !cap)
       return -1;
    out[0] = '\0';
+   if (!client_config_bool("require_session_worktree", 1))
+      return -1; /* Explicit operator opt-out: no provisioning or cwd change. */
 
    char source[4096], top[4096];
    int already_owned = 0;
@@ -923,6 +926,9 @@ int client_session_worktree_route_path(const char *sid, const char *cwd, const c
 {
    if (!out || !cap)
       return -2;
+   if (!client_config_bool("require_session_worktree", 1))
+      return 1; /* Routing is disabled, including existing session mappings. */
+
    out[0] = '\0';
    char target[8192];
    if (csw_normalize(cwd, input, target, sizeof target) != 0)
@@ -1010,6 +1016,9 @@ int client_session_worktree_route_command(const char *sid, const char *cwd, cons
 {
    if (!command || !out || !cap)
       return -2;
+   if (!client_config_bool("require_session_worktree", 1))
+      return 1; /* Routing is disabled, including existing session mappings. */
+
    if (csw_is_foreign_worktree(command, sid))
       return -3;
    char source[4096], top[4096];
@@ -1157,6 +1166,9 @@ int client_session_worktree_route_patch(const char *sid, const char *cwd, const 
 {
    if (!patch || !out || !cap)
       return -2;
+   if (!client_config_bool("require_session_worktree", 1))
+      return 1; /* Routing is disabled, including existing session mappings. */
+
    static const char *const leaders[] = {
        "*** Add File: ", "*** Update File: ", "*** Delete File: ", "*** Move to: ", NULL};
    size_t used = 0;

--- a/src/client_session_worktree.c
+++ b/src/client_session_worktree.c
@@ -811,14 +811,18 @@ int client_session_worktree_ensure_at(const char *sid, const char *cwd, char *ou
    if (!out || !cap)
       return -1;
    out[0] = '\0';
-   if (!client_config_bool("require_session_worktree", 1))
-      return -1; /* Explicit operator opt-out: no provisioning or cwd change. */
 
    char source[4096], top[4096];
    int already_owned = 0;
    if (!sid || !sid[0] || !cwd || !cwd[0] ||
-       csw_repo_context(cwd, sid, source, sizeof source, top, sizeof top, &already_owned) != 0 ||
-       already_owned)
+       csw_repo_context(cwd, sid, source, sizeof source, top, sizeof top, &already_owned) != 0)
+      return csw_ensure_at_unlocked(sid, cwd, out, cap);
+
+   /* No repository means no isolation policy to consult. Keep document-only
+    * startup local; a Git session still honors the operator's live opt-out. */
+   if (!client_config_bool("require_session_worktree", 1))
+      return -1;
+   if (already_owned)
       return csw_ensure_at_unlocked(sid, cwd, out, cap);
 
    char common_dir[4096], lock_path[4200];

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -380,7 +380,7 @@ void cmd_hooks(app_ctx_t *ctx, int argc, char **argv)
             if (cJSON_IsString(fp))
                wt_fpath = fp->valuestring;
          }
-         int wt_block = is_write_tool(tool_name) && cwd[0] &&
+         int wt_block = config_require_session_worktree() && is_write_tool(tool_name) && cwd[0] &&
                         aimee_edit_target_in_main_clone(wt_fpath, cwd) &&
                         !aimee_main_clone_edits_allowed(cwd);
          cJSON_Delete(wt_ti);

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -72,6 +72,9 @@ int attn_weight_for(attn_op_t op);
  * `session_id` (the hook's session id, may be NULL) admits this session's own
  * harness scratch dir — "<tmp>/claude-<uid>/<slug>/<session-id>/..." — which is
  * harness-owned temp space rather than repo content. */
+/* Positive filesystem evidence for a hook forwarded to a remote server. */
+int attn_tool_in_non_git_workspace(const char *cwd, const char *tool, const cJSON *input);
+
 int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd,
                                    const char *session_id);
 

--- a/src/headers/worktree_scope.h
+++ b/src/headers/worktree_scope.h
@@ -33,8 +33,8 @@ static inline int worktree_scope_path_non_git(const char *path)
       if (errno != ENOENT && errno != ENOTDIR)
          return 0;
       char *slash = strrchr(probe, '/');
-      if (!slash)
-         return 0;
+      if (!slash || !slash[1])
+         return 0; /* An unavailable root (for example a disconnected drive). */
       if (slash == probe || (slash == probe + 2 && probe[1] == ':'))
          slash[1] = '\0';
       else

--- a/src/headers/worktree_scope.h
+++ b/src/headers/worktree_scope.h
@@ -1,0 +1,86 @@
+/* Git isolation applies to repositories, not ordinary document directories.
+ * Keep this filesystem-only predicate shared by the thin client and server. */
+#ifndef AIMEE_WORKTREE_SCOPE_H
+#define AIMEE_WORKTREE_SCOPE_H
+
+#include "platform.h"
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* Only return true for a positively identified non-Git path. Missing file
+ * descendants are normal for Write; inspect their nearest existing ancestor.
+ * Resolve that ancestor before walking so symlinks into repositories count.
+ * A .git file (linked worktree/submodule) counts just like a .git directory.
+ * Unknown paths, permissions failures and oversized paths keep enforcement. */
+static inline int worktree_scope_path_non_git(const char *path)
+{
+   char probe[PATH_MAX], resolved[PATH_MAX], marker[PATH_MAX];
+   struct stat st;
+   if (!path || !path[0] || strlen(path) >= sizeof(probe))
+      return 0;
+   snprintf(probe, sizeof(probe), "%s", path);
+#ifdef AIMEE_WINDOWS
+   for (char *p = probe; *p; p++)
+      if (*p == '\\')
+         *p = '/';
+#endif
+   while (stat(probe, &st) != 0)
+   {
+      if (errno != ENOENT && errno != ENOTDIR)
+         return 0;
+      char *slash = strrchr(probe, '/');
+      if (!slash)
+         return 0;
+      if (slash == probe)
+         slash[1] = '\0';
+      else
+         *slash = '\0';
+   }
+   if (!realpath(probe, resolved))
+      return 0;
+#ifdef AIMEE_WINDOWS
+   for (char *p = resolved; *p; p++)
+      if (*p == '\\')
+         *p = '/';
+#endif
+   if (!S_ISDIR(st.st_mode))
+   {
+      char *slash = strrchr(resolved, '/');
+      if (!slash)
+         return 0;
+      if (slash == resolved)
+         slash[1] = '\0';
+      else
+         *slash = '\0';
+   }
+   for (;;)
+   {
+      int n = snprintf(marker, sizeof(marker), "%s/.git", resolved);
+      if (n < 0 || (size_t)n >= sizeof(marker))
+         return 0;
+      if (stat(marker, &st) == 0 || errno != ENOENT)
+         return 0;
+      char *slash = strrchr(resolved, '/');
+      if (!slash)
+         return 0;
+      if (!slash[1])
+         return 1;
+      if (slash == resolved)
+         slash[1] = '\0';
+      else
+         *slash = '\0';
+   }
+}
+
+static inline int worktree_scope_non_git(const char *cwd, const char *target)
+{
+   struct stat st;
+   return cwd && cwd[0] && stat(cwd, &st) == 0 && S_ISDIR(st.st_mode) &&
+          worktree_scope_path_non_git(cwd) &&
+          (!target || !target[0] || worktree_scope_path_non_git(target));
+}
+#endif

--- a/src/headers/worktree_scope.h
+++ b/src/headers/worktree_scope.h
@@ -35,7 +35,7 @@ static inline int worktree_scope_path_non_git(const char *path)
       char *slash = strrchr(probe, '/');
       if (!slash)
          return 0;
-      if (slash == probe)
+      if (slash == probe || (slash == probe + 2 && probe[1] == ':'))
          slash[1] = '\0';
       else
          *slash = '\0';
@@ -52,7 +52,7 @@ static inline int worktree_scope_path_non_git(const char *path)
       char *slash = strrchr(resolved, '/');
       if (!slash)
          return 0;
-      if (slash == resolved)
+      if (slash == resolved || (slash == resolved + 2 && resolved[1] == ':'))
          slash[1] = '\0';
       else
          *slash = '\0';
@@ -69,7 +69,7 @@ static inline int worktree_scope_path_non_git(const char *path)
          return 0;
       if (!slash[1])
          return 1;
-      if (slash == resolved)
+      if (slash == resolved || (slash == resolved + 2 && resolved[1] == ':'))
          slash[1] = '\0';
       else
          *slash = '\0';

--- a/src/modules/guardrails/guardrails.h
+++ b/src/modules/guardrails/guardrails.h
@@ -139,6 +139,12 @@ classification_t classify_path_sensitivity(const char *file_path);
  *   2 = block (msg_buf contains error message) */
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len);
+/* Hook adapter only: the authenticated client has checked its own filesystem.
+ * Native/server tools must use pre_tool_check and the server's scope check. */
+int pre_tool_check_client_workspace(const char *tool_name, const char *input_json,
+                                    session_state_t *state, const char *guardrail_mode,
+                                    const char *cwd, char *msg_buf, size_t msg_len,
+                                    int client_non_git_workspace);
 
 /* Register a config-reload reapplier that clears the cached audit_action_enabled
  * / audit_worm_enabled gates so a live config.set / SIGHUP takes effect without a
@@ -149,8 +155,8 @@ void guardrails_action_audit_register_reload(void);
  * guardrails_action_audit.c) that calls this and emits the per-action audit
  * row. Same return contract as pre_tool_check. */
 int pre_tool_check_inner(const char *tool_name, const char *input_json, session_state_t *state,
-                         const char *guardrail_mode, const char *cwd, char *msg_buf,
-                         size_t msg_len);
+                         const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len,
+                         int client_non_git_workspace);
 
 /* Normalize provider/internal tool names into guardrail-facing categories.
  * Provider-native sub-agent spawns (Task/Agent/spawn_agent/RemoteTrigger) map to

--- a/src/modules/guardrails/guardrails_action_audit.c
+++ b/src/modules/guardrails/guardrails_action_audit.c
@@ -148,11 +148,20 @@ static int emit_action_audit(const char *tool_name, const char *input_json,
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
 {
+   return pre_tool_check_client_workspace(tool_name, input_json, state, guardrail_mode, cwd,
+                                          msg_buf, msg_len, 0);
+}
+
+int pre_tool_check_client_workspace(const char *tool_name, const char *input_json,
+                                    session_state_t *state, const char *guardrail_mode,
+                                    const char *cwd, char *msg_buf, size_t msg_len,
+                                    int client_non_git_workspace)
+{
    /* Clear the last audit event before the verdict so a block site's key from a
     * prior call cannot leak as this call's reason_code. */
    audit_last_event_reset();
-   int rc =
-       pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
+   int rc = pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf,
+                                 msg_len, client_non_git_workspace);
    if (emit_action_audit(tool_name, input_json, guardrail_mode, state, rc, msg_buf) != 0 && rc != 2)
    {
       if (msg_buf && msg_len > 0)

--- a/src/modules/guardrails/guardrails_orchestrator.c
+++ b/src/modules/guardrails/guardrails_orchestrator.c
@@ -1,3 +1,4 @@
+#include "worktree_scope.h"
 /* guardrails_orchestrator.c: the `pre_tool_check` entry point and its
  * orchestrator-self-discipline helpers (write-command classification,
  * bash-guard messaging, per-session counters).
@@ -849,12 +850,6 @@ static int git_checkout_on_non_default_branch(const char *dir)
    return ok;
 }
 
-static int cwd_is_git_checkout(const char *cwd)
-{
-   char git_root[MAX_PATH_LEN];
-   return cwd && cwd[0] && git_repo_root(cwd, git_root, sizeof(git_root)) == 0 && git_root[0];
-}
-
 static int git_checkout_is_external_feature_worktree(const char *cwd)
 {
    char git_root[MAX_PATH_LEN];
@@ -1193,7 +1188,7 @@ static int is_write_intent(const char *tool_name, cJSON *root)
 
 static int pre_tool_check_impl(const char *tool_name, const char *input_json,
                                session_state_t *state, const char *guardrail_mode, const char *cwd,
-                               char *msg_buf, size_t msg_len)
+                               char *msg_buf, size_t msg_len, int client_non_git_workspace)
 {
    if (!tool_name || !input_json || !state)
       return 0;
@@ -1285,18 +1280,6 @@ static int pre_tool_check_impl(const char *tool_name, const char *input_json,
       }
    }
 
-   if (!container_delegate && (script_tool || is_write_intent(tool_name, root)) &&
-       !cwd_is_git_checkout(effective_cwd) && !session_cwd_is_worktree(effective_cwd) &&
-       !command_targets_worktree && !target_is_worktree &&
-       !cwd_is_detached_workspace(effective_cwd))
-   {
-      snprintf(msg_buf, msg_len,
-               "BLOCKED: write blocked because this session is not running in a worktree. "
-               "Enter the session worktree before writing.");
-      cJSON_Delete(root);
-      return 2;
-   }
-
    /* Verify gate: block push/PR (enforce:true); --show-toplevel keeps worktrees independent. */
    if (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd) &&
        (bash_has_git_push_requiring_gate(cmd->valuestring) ||
@@ -1364,7 +1347,8 @@ static int pre_tool_check_impl(const char *tool_name, const char *input_json,
     * run independently of this block, so they still apply. */
    const workspace_provider_t *gr_ws_active = workspace_provider_active();
    int gr_detached_active = gr_ws_active && gr_ws_active->kind == WS_PROVIDER_DETACHED;
-   if (!gr_detached_active &&
+   const int require_worktree = config_require_session_worktree() && !client_non_git_workspace;
+   if (require_worktree && !gr_detached_active &&
        (is_path_tool(tool_name) || (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd))))
    {
       /* Determine target path */
@@ -1523,10 +1507,19 @@ static int pre_tool_check_impl(const char *tool_name, const char *input_json,
       }
    }
 
+   char scope_target[MAX_PATH_LEN];
+   snprintf(scope_target, sizeof(scope_target), "%s", effective_cwd ? effective_cwd : "");
+   if (is_path_tool(tool_name) && cJSON_IsString(fp))
+      normalize_path(fp->valuestring, effective_cwd, scope_target, sizeof(scope_target));
+   else if (is_shell_tool(tool_name) && cJSON_IsString(cmd))
+      bash_git_target_dir(cmd->valuestring, effective_cwd, scope_target, sizeof(scope_target));
+
    /* Hard block for write intents the redirect above cannot handle (e.g.
     * script tools) when the session is not running in any worktree. A detached
     * workspace is exempt: its tree lives on the serving client, not here. */
-   if (!container_delegate && (script_tool || is_write_intent(tool_name, root)) &&
+   if (require_worktree && !container_delegate &&
+       !worktree_scope_non_git(effective_cwd, scope_target) &&
+       (script_tool || is_write_intent(tool_name, root)) &&
        !session_cwd_is_worktree(effective_cwd) && !command_targets_worktree &&
        !target_is_worktree && !cwd_is_detached_workspace(effective_cwd))
    {
@@ -2031,7 +2024,8 @@ static char *guardrails_workspace_exec(void *ctx, const char *cmd, int *exit_cod
 }
 
 int pre_tool_check_inner(const char *tool_name, const char *input_json, session_state_t *state,
-                         const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
+                         const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len,
+                         int client_non_git_workspace)
 {
    /* Worktree/branch/verify helpers predate workspace providers and use run_cmd.
     * Keep every probe on the same filesystem as the tool being checked, for
@@ -2044,8 +2038,8 @@ int pre_tool_check_inner(const char *tool_name, const char *input_json, session_
    if (detached)
       previous = run_cmd_exchange_executor(
           (run_cmd_executor_t){guardrails_workspace_exec, (void *)provider});
-   int rc =
-       pre_tool_check_impl(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
+   int rc = pre_tool_check_impl(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len,
+                                client_non_git_workspace);
    if (detached)
       run_cmd_exchange_executor(previous);
    return rc;

--- a/src/modules/guardrails/guardrails_orchestrator.c
+++ b/src/modules/guardrails/guardrails_orchestrator.c
@@ -1,4 +1,3 @@
-#include "worktree_scope.h"
 /* guardrails_orchestrator.c: the `pre_tool_check` entry point and its
  * orchestrator-self-discipline helpers (write-command classification,
  * bash-guard messaging, per-session counters).
@@ -9,6 +8,7 @@
 #define _GNU_SOURCE
 #endif
 #include "aimee.h"
+#include "worktree_scope.h"
 #include "cJSON.h"
 #include "computer_use.h"
 #include "guardrails_internal.h"

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -1,4 +1,3 @@
-#include "worktree_scope.h"
 /* agent_tools.c: tool execution, checkpoints, and tool definition JSON builders.
  *
  * BOUNDARY (core modularization): this is the server-side session-state slice of
@@ -9,6 +8,7 @@
  * halves communicate only through the public agent_tools.h. Do NOT add tool
  * dispatch or tool implementations here; they belong in src/modules/tools/. */
 #include "aimee.h"
+#include "worktree_scope.h"
 #include "util.h"
 #include <aimee/tools/agent_tools.h>
 #include "agent_exec.h"

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -1,3 +1,4 @@
+#include "worktree_scope.h"
 /* agent_tools.c: tool execution, checkpoints, and tool definition JSON builders.
  *
  * BOUNDARY (core modularization): this is the server-side session-state slice of
@@ -245,6 +246,8 @@ int agent_tools_session_isolation_blocks(const char *path, const char *cwd)
     * preferences. */
    char norm[MAX_PATH_LEN];
    normalize_path(path, cwd, norm, sizeof(norm));
+   if (worktree_scope_non_git(cwd, norm))
+      return 0;
    size_t root_len = agent_tools_managed_root_len(norm);
    if (root_len && cwd && cwd[0])
    {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -938,15 +938,20 @@ static int handle_hooks_pre(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    }
    char saved_cwd[MAX_PATH_LEN];
    snprintf(saved_cwd, sizeof(saved_cwd), "%s", run_cmd_get_cwd() ? run_cmd_get_cwd() : "");
+   /* Only an authenticated lifecycle hook may attest to client-local scope.
+    * The claim never reaches native tool execution or disables other guards. */
+   int client_non_git =
+       hook_identity == 1 &&
+       cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "client_non_git_workspace"));
    int bound = workspace_turn_bind_active(target_cwd);
    const workspace_provider_t *provider = workspace_provider_active();
    int detached = bound && provider->kind == WS_PROVIDER_DETACHED;
    if (detached)
       run_cmd_set_cwd(target_cwd);
-   else
+   else if (!client_non_git)
       hooks_ensure_cwd_worktree(&state, sid, cwd);
-   int rc = pre_tool_check(tool_name, tool_input, &state, config_guardrail_mode(), cwd, msg,
-                           sizeof(msg));
+   int rc = pre_tool_check_client_workspace(tool_name, tool_input, &state, config_guardrail_mode(),
+                                            cwd, msg, sizeof(msg), client_non_git);
    run_cmd_set_cwd(saved_cwd[0] ? saved_cwd : NULL);
    workspace_turn_unbind_active();
    cJSON_Delete(input);

--- a/src/server/server_hooks.c
+++ b/src/server/server_hooks.c
@@ -174,6 +174,9 @@ int server_memory_intercept(const char *tool, const char *tool_input, const char
 
 int hooks_ensure_cwd_worktree(session_state_t *state, const char *sid, const char *cwd)
 {
+   if (!config_require_session_worktree())
+      return 0;
+
    if (!state || !sid || !sid[0] || strcmp(sid, "unknown") == 0 || !cwd || !cwd[0])
       return 0;
 

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -3508,6 +3508,21 @@ static void test_session_isolation_guard(void)
    /* Traversal OUT of a wfe worktree still blocks. */
    assert(agent_tools_session_isolation_blocks(
               "/var/lib/aimee/wfe-worktrees/wi_ab12.s3/../../escape.c", NULL) == 1);
+   /* Ordinary document folders, including missing descendants, are writable. */
+   assert(agent_tools_session_isolation_blocks("reports/new/report.md", home) == 0);
+   char repository[640], git_marker[700], target[700];
+   snprintf(repository, sizeof(repository), "%s/repo", home);
+   assert(platform_mkdir_p(repository, 0700) == 0);
+   snprintf(git_marker, sizeof(git_marker), "%s/.git", repository);
+   assert(platform_mkdir_p(git_marker, 0700) == 0);
+   snprintf(target, sizeof(target), "%s/reports/new/report.md", repository);
+   assert(agent_tools_session_isolation_blocks(target, home) == 1);
+   assert(config_set_require_session_worktree(0) == 0);
+   assert(agent_tools_session_isolation_blocks(target, repository) == 0);
+   assert(config_set_require_session_worktree(1) == 0);
+   assert(agent_tools_session_isolation_blocks(target, repository) == 1);
+   assert(rmdir(git_marker) == 0);
+   assert(rmdir(repository) == 0);
    /* NULL path is a no-op (returns 0). */
    assert(agent_tools_session_isolation_blocks(NULL, NULL) == 0);
 

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -658,6 +658,56 @@ static int capture_stderr(char *out, size_t outsz)
    return rc;
 }
 
+static void test_non_git_document_work(void)
+{
+   char dir[256], hook[2048], path[512];
+   snprintf(dir, sizeof(dir), "%s/aimee-doc-attn-XXXXXX", platform_tmpdir());
+   assert(mkdtemp(dir));
+   write_config(NULL);
+   snprintf(hook, sizeof(hook),
+            "{\"session_id\":\"documents\",\"cwd\":\"%s\",\"tool_name\":\"Write\","
+            "\"tool_input\":{\"file_path\":\"reports/new/report.md\"}}",
+            dir);
+   g_stdin_json = hook;
+   assert(handle_attention_guard() == 0);
+   cJSON *input = cJSON_Parse("{\"file_path\":\"reports/new/report.md\"}");
+   assert(attn_tool_in_non_git_workspace(dir, "Write", input) == 1);
+   cJSON_Delete(input);
+
+   snprintf(hook, sizeof(hook),
+            "{\"session_id\":\"documents\",\"cwd\":\"%s\",\"tool_name\":\"Bash\","
+            "\"tool_input\":{\"command\":\"mkdir -p %s/extracted\"}}",
+            dir, dir);
+   assert(handle_attention_guard() == 0);
+   /* A document session cannot use its cwd to excuse writes into a repository. */
+   snprintf(path, sizeof(path), "%s/repo", dir);
+   assert(mkdir(path, 0700) == 0);
+   snprintf(path, sizeof(path), "%s/repo/.git", dir);
+   assert(mkdir(path, 0700) == 0);
+   snprintf(path, sizeof(path), "%s/repo/new/file.md", dir);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, path, dir, "documents") == 1);
+   input = cJSON_CreateObject();
+   cJSON_AddStringToObject(input, "file_path", path);
+   assert(attn_tool_in_non_git_workspace(dir, "Write", input) == 0);
+   cJSON_Delete(input);
+   char link[512];
+   snprintf(link, sizeof(link), "%s/linked", dir);
+   snprintf(path, sizeof(path), "%s/repo", dir);
+   assert(symlink(path, link) == 0);
+   snprintf(path, sizeof(path), "%s/linked/new/file.md", dir);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, path, dir, "documents") == 1);
+   assert(unlink(link) == 0);
+
+   snprintf(hook, sizeof(hook), "mkdir -p %s/repo/new", dir);
+   assert(attn_bash_escapes_worktree(hook, dir) == 1);
+   snprintf(path, sizeof(path), "%s/repo/.git", dir);
+   assert(rmdir(path) == 0);
+   snprintf(path, sizeof(path), "%s/repo", dir);
+   assert(rmdir(path) == 0);
+   assert(rmdir(dir) == 0);
+   g_stdin_json = NULL;
+}
+
 static void test_isolation_enforcement(void)
 {
    snprintf(g_home, sizeof(g_home), "%s/aimee_iso_test_%d", platform_tmpdir(), (int)getpid());
@@ -779,6 +829,7 @@ int main(void)
    test_guard_enforcement();
    test_required_discovery_activation();
    test_session_isolation_decision();
+   test_non_git_document_work();
    test_isolation_enforcement();
    test_camel_case_client_path_routing();
    test_external_memory_decision();

--- a/src/tests/test_client_session_worktree.c
+++ b/src/tests/test_client_session_worktree.c
@@ -8,6 +8,7 @@
  * invisible to a mocked git.
  */
 #include "client_session_worktree.h"
+#include "client_config.h"
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -368,6 +369,31 @@ static void test_ensure_requires_a_session_id_and_a_repo(void)
 
    assert(chdir(cwd_before) == 0);
    printf("  ensure: no session id / no repo -> not applicable: ok\n");
+}
+
+static cJSON *worktree_disabled_config(const char *key)
+{
+   return strcmp(key, "require_session_worktree") == 0 ? cJSON_CreateFalse() : NULL;
+}
+
+static void test_worktree_opt_out(void)
+{
+   char repo[512], out[8192], marker[640];
+   make_repo("worktree-disabled", "main", repo, sizeof repo);
+   client_config_set_provider(worktree_disabled_config);
+   assert(client_session_worktree_ensure_at("disabled", repo, out, sizeof out) == -1);
+   assert(out[0] == '\0');
+   assert(client_session_worktree_route_path("disabled", repo, "new.txt", out, sizeof out) == 1);
+   assert(client_session_worktree_route_command("disabled", repo, "touch new.txt", out,
+                                                sizeof out) == 1);
+   assert(client_session_worktree_route_patch(
+              "disabled", repo, "*** Begin Patch\n*** Add File: new.txt\n+text\n*** End Patch\n",
+              out, sizeof out) == 1);
+   snprintf(marker, sizeof marker, "%s/.aimee", repo);
+   assert(access(marker, F_OK) != 0);
+   /* A live setting change restores provisioning for the same repository. */
+   client_config_set_provider(NULL);
+   assert(client_session_worktree_ensure_at("disabled", repo, out, sizeof out) == 0);
 }
 
 static void test_external_path_does_not_provision_a_worktree(void)
@@ -748,6 +774,7 @@ int main(void)
    test_explicit_feature_base_incorporates_latest_default();
    test_concurrent_session_starts_get_distinct_worktrees();
    test_ensure_requires_a_session_id_and_a_repo();
+   test_worktree_opt_out();
    test_external_path_does_not_provision_a_worktree();
    test_routes_reads_writes_shell_and_patch_per_session();
    test_release_recycles_only_clean_session_worktrees();

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#include <utime.h>
 #include "aimee.h"
 #include <aimee/audit/obs_bus.h> /* obs_bus_flush — gsem_record records guardrail events async now */
 #include "db1_client/db1.h"
@@ -347,9 +348,15 @@ static void test_policy_file_reloads_on_change(void)
    assert(classify_path("alpha.secret").severity == SEV_BLOCK);
    assert(classify_path("beta.secret").severity == SEV_GREEN);
 
-   sleep(1);
+   struct stat before;
+   assert(stat(policy_path, &before) == 0);
    write_file_text(policy_path,
                    "{ \"sensitive_exact\": [\"beta.secret\"], \"write_commands\": [\"sync \"] }\n");
+
+   /* The loader compares whole-second mtimes. sleep(1) can be interrupted by
+    * a fixture child's SIGCHLD and leave both writes in the same clock tick. */
+   struct utimbuf changed = {.actime = before.st_atime, .modtime = before.st_mtime + 2};
+   assert(utime(policy_path, &changed) == 0);
 
    assert(classify_path("alpha.secret").severity == SEV_GREEN);
    assert(classify_path("beta.secret").severity == SEV_BLOCK);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -1772,7 +1772,7 @@ static void test_hook_call_count_increments(void)
    guardrails_close_test_sqlite();
 }
 
-static void test_no_worktree_blocks_writes(void)
+static void test_unknown_workspace_blocks_writes(void)
 {
    guardrails_open_test_sqlite();
    session_state_t state;
@@ -1784,26 +1784,26 @@ static void test_no_worktree_blocks_writes(void)
    int rc = pre_tool_check("Edit",
                            "{\"file_path\":\"/tmp/test.c\","
                            "\"old_string\":\"old\",\"new_string\":\"new\"}",
-                           &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+                           &state, MODE_APPROVE, "/missing-client-workspace", msg, sizeof(msg));
    assert(rc == 2);
    assert(strstr(msg, "not running in a worktree") != NULL);
 
    msg[0] = '\0';
    rc = pre_tool_check("Bash", "{\"command\":\"echo x > /tmp/test.c\"}", &state, MODE_APPROVE,
-                       "/tmp", msg, sizeof(msg));
+                       "/missing-client-workspace", msg, sizeof(msg));
    assert(rc == 2);
    assert(strstr(msg, "not running in a worktree") != NULL);
 
    msg[0] = '\0';
    rc =
        pre_tool_check("execute_script", "{\"language\":\"bash\",\"body\":\"echo x > /tmp/test.c\"}",
-                      &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+                      &state, MODE_APPROVE, "/missing-client-workspace", msg, sizeof(msg));
    assert(rc == 2);
    assert(strstr(msg, "not running in a worktree") != NULL);
 
    msg[0] = '\0';
-   rc = pre_tool_check("Bash", "{\"command\":\"git status\"}", &state, MODE_APPROVE, "/tmp", msg,
-                       sizeof(msg));
+   rc = pre_tool_check("Bash", "{\"command\":\"git status\"}", &state, MODE_APPROVE,
+                       "/missing-client-workspace", msg, sizeof(msg));
    assert(rc == 0);
 
    guardrails_close_test_sqlite();
@@ -1827,7 +1827,7 @@ static void test_container_delegate_exempt_from_worktree_guard(void)
    workspace_turn_set_container_bound_for_test(0);
    int rc = pre_tool_check(
        "Edit", "{\"file_path\":\"/tmp/test.c\",\"old_string\":\"a\",\"new_string\":\"b\"}", &state,
-       MODE_APPROVE, "/tmp", msg, sizeof(msg));
+       MODE_APPROVE, "/missing-client-workspace", msg, sizeof(msg));
    assert(rc == 2 && strstr(msg, "not running in a worktree") != NULL);
 
    /* Container-bound delegate: the same write must NOT be blocked by the worktree guard. */
@@ -1835,14 +1835,14 @@ static void test_container_delegate_exempt_from_worktree_guard(void)
    msg[0] = '\0';
    rc = pre_tool_check("Edit",
                        "{\"file_path\":\"/tmp/test.c\",\"old_string\":\"a\",\"new_string\":\"b\"}",
-                       &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+                       &state, MODE_APPROVE, "/missing-client-workspace", msg, sizeof(msg));
    assert(strstr(msg, "not running in a worktree") == NULL);
 
    /* execute_script (the script_tool path, second block site) is also exempt. */
    msg[0] = '\0';
    rc =
        pre_tool_check("execute_script", "{\"language\":\"bash\",\"body\":\"echo x > /tmp/test.c\"}",
-                      &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+                      &state, MODE_APPROVE, "/missing-client-workspace", msg, sizeof(msg));
    assert(strstr(msg, "not running in a worktree") == NULL);
    (void)rc;
 
@@ -1965,6 +1965,52 @@ static void test_external_default_checkout_blocks_writes(void)
 
    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
    system(cmd);
+}
+
+static void test_non_git_work_and_worktree_opt_out(void)
+{
+   char dir[256], command[1024], msg[2048], input[1024];
+   snprintf(dir, sizeof(dir), "%s/aimee-doc-work-XXXXXX", platform_tmpdir());
+   assert(mkdtemp(dir));
+   guardrails_open_test_sqlite();
+   session_state_t state = {0};
+   strcpy(state.session_mode, MODE_IMPLEMENT);
+   strcpy(state.guardrail_mode, MODE_APPROVE);
+   assert(config_set_require_session_worktree(1) == 0);
+   /* Document work has no repository to isolate, including new directories. */
+   assert(pre_tool_check("Write", "{\"file_path\":\"reports/new/report.md\"}", &state, MODE_APPROVE,
+                         dir, msg, sizeof(msg)) != 2);
+   assert(pre_tool_check("Bash",
+                         "{\"command\":\"mkdir -p extracted && tar -xf archive.tar -C extracted\"}",
+                         &state, MODE_APPROVE, dir, msg, sizeof(msg)) == 0);
+   assert(pre_tool_check("execute_script", "{}", &state, MODE_APPROVE, dir, msg, sizeof(msg)) == 0);
+   snprintf(command, sizeof(command), "git -C '%s' init -q", dir);
+   assert(system(command) == 0);
+   /* The explicit opt-out must disable hard blocks AND read/write rerouting. */
+   assert(config_set_require_session_worktree(0) == 0);
+   const char *names[] = {"Write", "Read", "Bash", "execute_script"};
+   const char *inputs[] = {"{\"file_path\":\"reports/new/report.md\"}",
+                           "{\"file_path\":\"report.md\"}", "{\"command\":\"mkdir -p extracted\"}",
+                           "{}"};
+   for (int i = 0; i < 4; i++)
+      assert(pre_tool_check(names[i], inputs[i], &state, MODE_APPROVE, dir, msg, sizeof(msg)) == 0);
+   snprintf(input, sizeof(input), "%s/.aimee", dir);
+   assert(access(input, F_OK) != 0);
+   /* Authenticated client evidence also works when its folder is not mounted
+    * on the server; it cannot leak into the next native tool check. */
+   assert(config_set_require_session_worktree(1) == 0);
+   assert(pre_tool_check_client_workspace("Write", inputs[0], &state, MODE_APPROVE,
+                                          "/client-only/documents", msg, sizeof(msg), 1) == 0);
+   assert(pre_tool_check("Write", inputs[0], &state, MODE_APPROVE, "/client-only/documents", msg,
+                         sizeof(msg)) == 2);
+   assert(config_set_require_session_worktree(0) == 0);
+   /* Disabling worktrees does not disable plan-mode protection. */
+   strcpy(state.session_mode, MODE_PLAN);
+   assert(pre_tool_check("Write", inputs[0], &state, MODE_APPROVE, dir, msg, sizeof(msg)) == 2);
+   assert(config_set_require_session_worktree(1) == 0);
+   guardrails_close_test_sqlite();
+   snprintf(command, sizeof(command), "rm -rf '%s'", dir);
+   assert(system(command) == 0);
 }
 
 static void test_shell_in_main_checkout_forced_to_worktree(void)
@@ -4046,12 +4092,13 @@ int main(void)
    test_known_subagent_tools_blocked();
    test_unknown_subagent_surface_blocked();
    test_hook_call_count_increments();
-   test_no_worktree_blocks_writes();
+   test_unknown_workspace_blocks_writes();
    test_container_delegate_exempt_from_worktree_guard();
    test_shell_command_targeting_worktree_allows_write();
    test_write_file_targeting_worktree_allows_stale_cwd();
    test_external_feature_checkout_allows_writes();
    test_external_default_checkout_blocks_writes();
+   test_non_git_work_and_worktree_opt_out();
    test_shell_in_main_checkout_forced_to_worktree();
    test_path_tool_redirect_is_cwd_independent();
    test_git_commands_allowed_by_default();

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1599,6 +1599,16 @@ int pre_tool_check(const char *tool_name, const char *tool_input, session_state_
    return g_hook_guard_result;
 }
 
+static int g_client_non_git_workspace;
+int pre_tool_check_client_workspace(const char *tool_name, const char *tool_input,
+                                    session_state_t *state, const char *guardrail_mode,
+                                    const char *cwd, char *msg, size_t msg_len,
+                                    int client_non_git_workspace)
+{
+   g_client_non_git_workspace = client_non_git_workspace;
+   return pre_tool_check(tool_name, tool_input, state, guardrail_mode, cwd, msg, msg_len);
+}
+
 void post_tool_update(const char *tool_name, const char *tool_input, session_state_t *state)
 {
    (void)tool_name;
@@ -2308,11 +2318,13 @@ static void test_hook_identity_session_binding(void)
    snprintf(pre, sizeof(pre),
             "{\"method\":\"hooks.pre\",\"session_id\":\"bound-session\","
             "\"harness_client\":\"claude\",\"hook_token\":\"%s\","
-            "\"tool_name\":\"Read\",\"tool_input\":{},\"cwd\":\"/tmp\"}",
+            "\"client_non_git_workspace\":true,\"tool_name\":\"Read\",\"tool_input\":{},\"cwd\":\"/"
+            "tmp\"}",
             saved);
    json = dispatch_json(ctx, conn, pre, strlen(pre));
    assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(json, "hook_identity")),
                  "trusted") == 0);
+   assert(g_client_non_git_workspace == 1);
    cJSON_Delete(json);
 
    /* The same secret cannot claim a different harness or session. */
@@ -2320,11 +2332,13 @@ static void test_hook_identity_session_binding(void)
    snprintf(mismatch, sizeof(mismatch),
             "{\"method\":\"hooks.pre\",\"session_id\":\"other-session\","
             "\"harness_client\":\"claude\",\"hook_token\":\"%s\","
-            "\"tool_name\":\"Read\",\"tool_input\":{},\"cwd\":\"/tmp\"}",
+            "\"client_non_git_workspace\":true,\"tool_name\":\"Read\",\"tool_input\":{},\"cwd\":\"/"
+            "tmp\"}",
             saved);
    json = dispatch_json(ctx, conn, mismatch, strlen(mismatch));
    assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(json, "hook_identity")),
                  "untrusted") == 0);
+   assert(g_client_non_git_workspace == 0);
    cJSON_Delete(json);
 
    hook_session_token_registry_reset();


### PR DESCRIPTION
Writing or extracting documents in an ordinary non-Git folder was blocked by worktree guards. Setting `require_session_worktree=false` also left server checks and startup provisioning enabled.

This change scopes isolation to Git work and honors the existing switch across client startup, path/command routing, server hooks, and native writes. Remote hooks carry the client's filesystem scope under the session/client/principal identity binding, with one token-renewal retry after a server restart. Unknown scopes and known Git targets still follow isolation rules; plan-mode, memory, verification, and other policies remain independent. Non-Git startup does not fetch an isolation setting it does not need.

Targets `testing` for inclusion in the next main release (0.4.4). Both the thin client and server must be upgraded for the remote-hook fix. Release notes and settings help are updated. No database migration, new setting, or release-baseline update is included.

Validation:
- `make -C src -j8 verify-ci GIT_VERSION=v0.4.4-rc1 AIMEE_VERIFY_TEST_JOBS=2` passed: build/linkage, lint, 637 scheduled native test binaries, Go modules and cross-language conformance, build integrity, integration tests, and generated docs.
- Integration harness: 94 checks passed; 71 checks requiring unconfigured services explicitly skipped. Docker/PostgreSQL coverage runs separately in CI.
- Built-client HTTP/mTLS suite: 28 tests passed, including disabled launch/SessionStart, non-Git document writes, Git-target rejection, and token recovery.
- Frontend TypeScript and production build passed.
- The policy-reload test now advances its file timestamp explicitly instead of relying on an interruptible sleep. The rebuilt guardrails suite passed after that test-only change.

- The shipped-workflow E2E deadline now matches the native workflow test’s two-minute budget. Full workflow store, API, and engine suites passed locally against disposable PostgreSQL 17 with `go test -race -count=1`; all five shipped workflows completed.

Review focus: client/server filesystem ownership, authenticated hook scope, and worktree confinement. GitHub Actions is running on the final commit.
